### PR TITLE
[Translation] Improve Chinese translation entries  

### DIFF
--- a/i18n/zh_CN.yml
+++ b/i18n/zh_CN.yml
@@ -101,7 +101,7 @@ HBCB4550F177A: "#pragma warning 期望 'push'、'pop'、'default'、'disable'、
 # '#pragma warning expected a warning number'
 HB9A465F10016: '#pragma warning 期望一个警告编号'
 # '#pragma warning(push, level) requires a level between 0 and 4'
-H99A37FD4A6D8: '#pragma warning(push, level) 需要级别在 0 到 4之间'
+H99A37FD4A6D8: '#pragma warning(push, level) 需要级别在 0 到 4 之间'
 # '#warning is a %select{C23|C++23}0 extension'
 H0F157EC51CD6: '#warning 是 %select{C23|C++23}0 的扩展'
 # '#warning is incompatible with C standards before C23'
@@ -193,15 +193,15 @@ HFCD2CCA9A22B: '%0 属性不能从%select{块|Objective-C函数|此上下文}1�
 # '%0 attribute cannot be used with pointers to members'
 H828AE7C76F14: '%0 属性不能用于成员指针'
 # "%0 attribute cannot specify more than one 'self:' parameter"
-HC2B60D257432: "%0 属性不能指定超过一个'self:'参数"
+HC2B60D257432: "%0 属性不能指定超过一个 'self:' 参数"
 # '%0 attribute does not appear on the first declaration'
 HE84901B6BFC0: '%0 属性未出现在首次声明中'
 # '%0 attribute expression never produces a constant expression'
 H6DB854C2324C: '%0 属性表达式无法生成常量表达式'
 # "%0 attribute for 'subscript' getter cannot have a 'newValue:' parameter"
-HEBB5613EEF15: "%0 属性的 'subscript' 获取器不能包含'newValue:'参数"
+HEBB5613EEF15: "%0 属性的 'subscript' 获取器不能包含 'newValue:' 参数"
 # "%0 attribute for 'subscript' must %select{be a getter or setter|have at least one parameter|have a 'self:' parameter}1"
-H445CA4D5B31B: "%0 属性的 'subscript' 必须%select{是getter或setter|至少有一个参数|具有'self:'参数}1"
+H445CA4D5B31B: "%0 属性的 'subscript' 必须%select{是getter或setter|至少有一个参数|具有 'self:' 参数}1"
 # "%0 attribute for 'subscript' setter cannot have multiple 'newValue:' parameters"
 H2C95053B8BED: "%0 'subscript' setter 的属性不能有多个 'newValue:' 参数"
 # "%0 attribute for 'subscript' setter must have a 'newValue:' parameter"
@@ -225,7 +225,7 @@ H208A7E24C5FA: '在非定义声明上，%0 属性被忽略'
 # '%0 attribute ignored on inline function'
 H96102C6ED34D: '在内联函数上，%0 属性被忽略'
 # '%0 attribute ignored on local class%select{| member}1'
-HFF01D57072C2: '在局部类%select{| 成员}1 上，%0 属性被忽略'
+HFF01D57072C2: '在局部类 %select{| 成员}1 上，%0 属性被忽略'
 # '%0 attribute ignored when parsing type'
 HD37333D19CA5: '解析类型时，%0 属性被忽略'
 # '%0 attribute is deprecated and ignored in %1'
@@ -261,17 +261,17 @@ HC4348E6FE2CB: '%0 属性不可与可变参数函数一起使用'
 # '%0 attribute minimum and maximum arguments are equal'
 HCEAC369F8447: '%0 属性的最小和最大参数值相等'
 # "%0 attribute must be applied to a %select{function|method}1 annotated with non-'none' attribute 'swift_async'"
-H1EED532B31A7: '%0 属性必须应用于带有非"none" "swift_async"属性的%select{函数|方法}1'
+H1EED532B31A7: '%0 属性必须应用于带有非 "none" "swift_async" 属性的%select{函数|方法}1'
 # '%0 attribute must be greater than 0'
 H2544E0569FB3: '%0 属性必须大于 0'
 # '%0 attribute on entry function does not match the target profile'
 H789CC95F4AD2: '%0 属性在入口函数中与目标配置文件不匹配'
 # '%0 attribute only applies to %select{Objective-C object|pointer|pointer-to-CF-pointer|pointer/reference-to-OSObject-pointer}1 parameters'
-H5089073C0897: '%0 属性仅适用于%select{Objective-C 对象|指针|指向 CF 指针的指针|指向 OSObject 指针的指针/引用}1 参数'
+H5089073C0897: '%0 属性仅适用于 %select{Objective-C 对象|指针|指向 CF 指针的指针|指向 OSObject 指针的指针/引用}1 参数'
 # '%0 attribute only applies to %select{Objective-C object|pointer|pointer-to-CF-pointer}1 parameters'
-HF1529765C253: '%0 属性仅适用于%select{Objective-C 对象|指针|指向 CF 指针的指针}1 参数'
+HF1529765C253: '%0 属性仅适用于 %select{Objective-C 对象|指针|指向 CF 指针的指针}1 参数'
 # '%0 attribute only applies to %select{functions|methods|properties}1 that return %select{an Objective-C object|a pointer|a non-retainable pointer}2'
-H0AEFAD59CD2C: '%0 属性仅适用于返回%select{Objective-C 对象|指针|不可保留指针}2的%select{函数|方法|属性}1'
+H0AEFAD59CD2C: '%0 属性仅适用于返回 %select{Objective-C 对象|指针|不可保留指针}2的%select{函数|方法|属性}1'
 # '%0 attribute only applies to %select{pointer|integer}1 arguments'
 H3971FB6B9374: '%0 属性仅适用于%select{指针|整数}1参数'
 # '%0 attribute only applies to a pointer or reference (%1 is invalid)'
@@ -281,7 +281,7 @@ H83B4DE3C5663: '%0 属性仅适用于返回值为指针的情况'
 # '%0 attribute only applies to return values that are pointers or references'
 HA603B89762A9: '%0 属性仅适用于返回值为指针或引用的情况'
 # '%0 attribute only applies to%select{| constant}1 pointer arguments'
-H1E90BC4B3746: '%0 属性仅适用于%select{|常量}1指针参数'
+H1E90BC4B3746: '%0 属性仅适用于 %select{|常量}1指针参数'
 # '%0 attribute parameter %1 is negative and will be ignored'
 HB94334A9F06D: '%0 属性的参数 %1 为负数，将被忽略'
 # '%0 attribute parameter %1 is out of bounds'
@@ -293,21 +293,21 @@ H4FBE5E81E84C: '%0 属性的参数类型不匹配：函数 %2 的参数 %1 类�
 # '%0 attribute parameters do not match the previous declaration'
 HBB1E6D667EEA: '%0 属性的参数与之前的声明不匹配'
 # '%0 attribute references function %1, which %plural{0:takes no arguments|1:takes one argument|:takes exactly %2 arguments}2'
-HC6916839EF90: '%0 属性引用函数 %1，该函数%plural{0:没有参数|1:有一个参数|:恰好有 %2 个参数}2'
+HC6916839EF90: '%0 属性引用函数 %1，该函数 %plural{0:没有参数|1:有一个参数|:恰好有 %2 个参数}2'
 # '%0 attribute references parameter %1, but the function %2 has only %3 parameters'
 H95C6EBBF3D05: '%0 属性引用参数 %1，但函数 %2 只有 %3 个参数'
 # '%0 attribute requires %select{int or bool|an integer constant|a string|an identifier}1'
-H4D660FD4970F: '%0 属性需要%select{int或bool类型|一个整型常量|一个字符串|一个标识符}1'
+H4D660FD4970F: '%0 属性需要 %select{int或bool类型|一个整型常量|一个字符串|一个标识符}1'
 # '%0 attribute requires a %select{positive|non-negative}1 integral compile time constant expression'
 H88B2A4A1C6F1: '%0 属性需要一个%select{正数|非负数}1 类型的整型编译时常量表达式'
 # '%0 attribute requires an integer argument which is a constant power of two between %1 and %2 inclusive; provided argument was %3'
 HBE3281153430: '%0 属性需要一个介于 %1 和 %2 之间的 2 的常量幂整数参数；提供的参数是 %3'
 # "%0 attribute requires arguments whose type is annotated with 'capability' attribute; type here is %1"
-H6A637254187D: '%0 属性需要参数类型带有"capability"属性；此处的类型是 %1'
+H6A637254187D: '%0 属性需要参数类型带有 "capability" 属性；此处的类型是 %1'
 # '%0 attribute requires integer constant between %1 and %2 inclusive'
 HEAC447E72E0E: '%0 属性需要介于 %1 和 %2 之间的整型常量'
 # '%0 attribute requires parameter %1 to be %select{int or bool|an integer constant|a string|an identifier|a constant expression|a builtin function}2'
-H410FC41452B2: '%0 属性要求参数 %1 为%select{int或bool类型|一个整型常量|一个字符串|一个标识符|一个常量表达式|一个内建函数}2'
+H410FC41452B2: '%0 属性要求参数 %1 为 %select{int或bool类型|一个整型常量|一个字符串|一个标识符|一个常量表达式|一个内建函数}2'
 # '%0 attribute requires that both caller and callee functions have a prototype'
 H16EEA1808E57: '%0 属性要求调用函数和被调用函数都具有原型声明'
 # '%0 attribute requires that the return value is the result of a function call'
@@ -321,7 +321,7 @@ HD834E8E626F3: '%0 属性使用 "%1" 约定时只能应用于返回%select{整�
 # "%0 attribute with '%1' convention must have an integral-typed parameter in completion handler at index %2, type here is %3"
 HA510BC647385: '%0 属性使用 "%1" 约定时，完成处理程序在索引 %2 处必须具有整型参数，此处的类型为 %3'
 # "%0 attribute with 'nonnull_error' convention can only be applied to a %select{function|method}1 with a completion handler with an error parameter"
-HB02ECE112485: '%0 属性使用"nonnull_error"约定时只能应用于具有带有错误参数的完成处理程序的%select{函数|方法}1'
+HB02ECE112485: '%0 属性使用 "nonnull_error" 约定时只能应用于具有带有错误参数的完成处理程序的%select{函数|方法}1'
 # '%0 attribute without capability arguments can only be applied to non-static methods of a class'
 H1A6503974C19: '%0 属性在没有能力参数时只能应用于类的非静态方法'
 # "%0 attribute without capability arguments refers to 'this', but %1 isn't annotated with 'capability' or 'scoped_lockable' attribute"
@@ -373,7 +373,7 @@ H9015777D8EDA: '%0 不能在枚举中定义'
 # '%0 cannot be defined in the result type of a function'
 HBCF321DF1229: '%0 不能在函数的返回类型中定义'
 # '%0 cannot be specialized%select{|: %2}1'
-H2F24480223D6: '%0 不能被特化%select{|: %2}1'
+H2F24480223D6: '%0 不能被特化 %select{|: %2}1'
 # '%0 cannot be the name of a parameter'
 H86909FCB5AFA: '%0 不能作为参数名'
 # '%0 cannot be the name of a variable or data member'
@@ -513,7 +513,7 @@ HC570BF566E38: '%0 不是全局变量、静态局部变量或静态数据成员'
 # '%0 is not a global variable, static local variable or static data member; did you mean %1'
 H32A3026BA924: '%0 不是全局变量、静态局部变量或静态数据成员；您是指 %1 吗？'
 # '%0 is not a recognized builtin%select{|; consider including <intrin.h> to access non-builtin intrinsics}1'
-HB8FF0E17F733: '%0 不是已识别的内建函数%select{|；请包含 <intrin.h> 以访问非内建本机函数}1'
+HB8FF0E17F733: '%0 不是已识别的内建函数 %select{|；请包含 <intrin.h> 以访问非内建本机函数}1'
 # '%0 is not a structural type because it has a %select{non-static data member|base class}1 of non-structural type %2'
 HF393BE38CC50: '%0 不是结构性类型，因为它具有非结构性类型 %2 的 %select{非静态数据成员|基类}1'
 # '%0 is not a structural type because it has a %select{non-static data member|base class}1 that is not public'
@@ -543,7 +543,7 @@ H35BFFB66B4EF: '%0 不是文字类型，因为它具有用户提供的析构函�
 # '%0 is not literal because it has base class %1 of non-literal type'
 H41CFD9851FA8: '%0 不是文字类型，因为它具有基类 %1 属于非文字类型'
 # '%0 is not literal because it has data member %1 of %select{non-literal|volatile}3 type %2'
-H39754ECC239F: '%0 不是文字类型，因为它具有%select{非文字型|volatile}3类型 %2 的成员 %1'
+H39754ECC239F: '%0 不是文字类型，因为它具有%select{非文字型|volatile}3 类型 %2 的成员 %1'
 # '%0 is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors'
 HD7160BA9A570: '%0 不是文字类型，因为它不是聚合类型且除了拷贝或移动构造函数外没有constexpr构造函数'
 # '%0 is not literal because its destructor is not constexpr'
@@ -559,9 +559,9 @@ H580226EF44DA: '%0 不能与-fembed-bitcode选项同时使用'
 # '%0 is not virtual and cannot be declared pure'
 HFCE20933CC31: '%0 不是虚函数，不能声明为纯虚函数'
 # '%0 is only available %select{|in %4 environment }3on %1 %2 or newer'
-H1926B8ADA9BD: '%0 仅在%select{|%4 环境 }3%1 %2 或更高版本中可用'
+H1926B8ADA9BD: '%0 仅在 %select{|%4 环境 }3%1 %2 或更高版本中可用'
 # '%0 is only supported when \'-mrvv-vector-bits=<bits>\' is specified with a value of "zvl" or a power 2 in the range [64,65536]'
-H714177E08C3D: '%0 仅在指定‘-mrvv-vector-bits=<bits>’参数为"zvl"或 64 到 65536之间的 2 的幂时支持'
+H714177E08C3D: '%0 仅在指定‘-mrvv-vector-bits=<bits>’参数为 "zvl" 或 64 到 65536 之间的 2 的幂时支持'
 # "%0 is only supported when '-msve-vector-bits=<bits>' is specified with a value of 128, 256, 512, 1024 or 2048"
 H5256E220BB0F: '在指定‘-msve-vector-bits=<bits>’参数值为 128、256、512、1024或 2048 时支持 %0'
 # "%0 is required to declare the member 'unhandled_exception()'"
@@ -605,7 +605,7 @@ H3F1AA6022CE0: '%0 可能不打算支持类模板实参推导'
 # '%0 may not respond to %1'
 HE863B7C4E09E: '%0 可能无法响应 %1'
 # '%0 must be explicitly converted to %1; use %select{%objcclass2|%objcinstance2}3 method for this conversion'
-H7B5D141884DB: '%0 必须显式转换为 %1；使用%select{%objcclass2|%objcinstance2}3方法进行此转换'
+H7B5D141884DB: '%0 必须显式转换为 %1；使用 %select{%objcclass2|%objcinstance2}3 方法进行此转换'
 # '%0 must be name of an Objective-C class to be able to convert %1 to %2'
 HF9706A398326: '%0 必须是Objective-C类的名称，以便将 %1 转换为 %2'
 # '%0 must be specified on definition if it is specified on any declaration'
@@ -615,7 +615,7 @@ HAA08D126AF16: '%0 必须在预处理指令中使用'
 # '%0 must have at least one parameter'
 H2488FE597801: '%0 必须至少有一个参数'
 # "%0 must not appear in both clauses 'to' and 'link'"
-HC3403F617C92: "%0 不得同时出现在' to '和' link '子句中"
+HC3403F617C92: "%0 不得同时出现在 ' to ' 和 ' link ' 子句中"
 # '%0 must return type %1'
 H561F31EBFB23: '%0 必须返回类型 %1'
 # '%0 needs target feature %1'
@@ -657,7 +657,7 @@ H33A930D763B0: '%0 需要超过 1 个模板参数；请显式提供剩余参数�
 # '%0 returns a reference'
 H81B0F21DCC91: '%0 返回引用'
 # '%0 should be declared prior to the call site%select{| or in %2| or in an associated namespace of one of its arguments}1'
-H80A1DB32BBA2: '%0 应在调用位置之前声明%select{|或在 %2 中|或在其实参关联命名空间之一中}1'
+H80A1DB32BBA2: '%0 应在调用位置之前声明 %select{|或在 %2 中|或在其实参关联命名空间之一中}1'
 # "%0 should not return a null pointer unless it is declared 'throw()'%select{| or 'noexcept'}1"
 HD6330A6C968B: "%0 除非被声明为 'throw()'%select{|或 'noexcept'}1，否则不应返回空指针"
 # '%0 size too large'
@@ -763,7 +763,7 @@ H39CEC8B6DBEB: "%q0 在不同模块中有不同的定义；%select{模块 '%2' �
 # "%q0 has different definitions in different modules; %select{definition in module '%2'|defined here}1 first difference is %select{return type is %4|%ordinal4 parameter with name %5|%ordinal4 parameter with type %5%select{| decayed from %7}6|%ordinal4 parameter with%select{out|}5 a default argument|%ordinal4 parameter with a default argument|function body}3"
 H68AA8A549FAA: "%q0 在不同模块中有不同的定义；%select{模块 '%2' 的定义|此处定义}1 首个差异是 %select{返回类型为 %4|%ordinal4 参数名为 %5|%ordinal4 参数类型为 %5%select{| 衰减为 %7}6|%ordinal4 参数%select{外|}5 有默认参数|%ordinal4 参数有默认参数|函数体}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{%4 base %plural{1:class|:classes}4|%4 virtual base %plural{1:class|:classes}4|%ordinal4 base class with type %5|%ordinal4 %select{non-virtual|virtual}5 base class %6|%ordinal4 base class %5 with %select{public|protected|private|no}6 access specifier}3"
-HC4303FABC437: "%q0 在不同模块中有不同的定义；第一个差异是 %select{在模块 '%2' 的定义|在此处定义}1 发现 %select{有 %4 个基类%plural{1:类|:类}4|有 %4 个虚基类%plural{1:类|:类}4|%ordinal4 基类类型为 %5|%ordinal4 %select{非虚|虚}5 基类 %6|%ordinal4 基类 %5 的访问说明符为 %select{public|protected|private|无}6}3"
+HC4303FABC437: "%q0 在不同模块中有不同的定义；第一个差异是 %select{在模块 '%2' 的定义|在此处定义}1 发现 %select{有 %4 个基类 %plural{1:类|:类}4|有 %4 个虚基类 %plural{1:类|:类}4|%ordinal4 基类类型为 %5|%ordinal4 %select{非虚|虚}5 基类 %6|%ordinal4 基类 %5 的访问说明符为 %select{public|protected|private|无}6}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{%4 referenced %plural{1:protocol|:protocols}4|%ordinal4 referenced protocol with name %5}3"
 HC9695A16C965: "%q0 在不同模块中有不同的定义；第一个差异是 %select{在模块 '%2' 中的定义|在此处定义}1 发现 %select{引用了 %4 %plural{1:协议|:协议}4|%ordinal4 参考的协议名称为 %5}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{%select{method %5|constructor|destructor}4 that has %6 parameter%s6|%select{method %5|constructor|destructor}4 with %ordinal6 parameter of type %7%select{| decayed from %9}8|%select{method %5|constructor|destructor}4 with %ordinal6 parameter named %7}3"
@@ -775,15 +775,15 @@ H3C6A067820A4: "%q0 在不同模块中有不同的定义；第一个差异是 %s
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{end of class|public access specifier|private access specifier|protected access specifier|static assert|field|method|type alias|typedef|data member|friend declaration|function template|method|instance variable|property}3"
 HC7FCD2470FA2: "%q0 在不同模块中有不同的定义；第一个差异是 %select{模块 '%2' 中的定义|在此处定义}1 发现 %select{类结尾|public访问说明符|private访问说明符|protected访问说明符|静态断言|字段|方法|类型别名|typedef|数据成员|朋友声明|函数模板|方法|实例变量|属性}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{field %4|field %4 with type %5|%select{non-|}5bit-field %4|bit-field %4 with one width expression|%select{non-|}5mutable field %4|field %4 with %select{no|an}5 initializer|field %4 with an initializer}3"
-H60D85DC0E685: "%q0 在不同模块中有不同的定义；第一个差异是 %select{模块 '%2' 中的定义|在此处定义}1 发现 %select{字段 %4|字段 %4 的类型 %5|%select{非-|}5位字段 %4|位字段 %4 具有单个宽度表达式|%select{非-|}5可变字段 %4|字段 %4 具有%select{无|}5初始值设定项|字段 %4 具有初始值设定项}3"
+H60D85DC0E685: "%q0 在不同模块中有不同的定义；第一个差异是 %select{模块 '%2' 中的定义|在此处定义}1 发现 %select{字段 %4|字段 %4 的类型 %5|%select{非-|}5 位字段 %4|位字段 %4 具有单个宽度表达式|%select{非-|}5 可变字段 %4|字段 %4 具有%select{无|}5 初始值设定项|字段 %4 具有初始值设定项}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{method %4 with return type %5|%select{class|instance}5 method %4|%select{no|'required'|'optional'}4 method control|method %4 with %select{no designated initializer|designated initializer}5|%select{regular|direct}5 method %4|method %4}3"
 H5AECB1226BDE: "%q0 在不同模块中有不同的定义；第一个差异是 %select{模块 '%2' 中的定义|在此处定义}1 发现 %select{返回类型为 %5 的方法 %4|%select{类|实例}5 方法 %4|%select{无|'required'|'optional'}4 方法控制|方法 %4 具有%select{无指定初始化器|指定初始化器}5|%select{常规|直接}5 方法 %4|方法 %4}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{property %4|property %4 with type %5|%select{no|'required'|'optional'}4 property control|property %4 with %select{default |}6'%select{none|readonly|getter|assign|readwrite|retain|copy|nonatomic|setter|atomic|weak|strong|unsafe_unretained|nullability|null_resettable|class|direct}5' attribute}3"
 H47E62251068F: "%q0 在不同模块中有不同的定义；第一个差异是 %select{模块 '%2' 中的定义|在此处定义}1 发现 %select{属性 %4|属性 %4 的类型 %5|%select{无|'required'|'optional'}4 属性控制|属性 %4 具有%select{默认 |}6'%select{none|readonly|getter|assign|readwrite|retain|copy|nonatomic|setter|atomic|weak|strong|unsafe_unretained|nullability|null_resettable|class|direct}5' 属性}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{static assert with condition|static assert with message|static assert with %select{|no }4message|%select{method %5|constructor|destructor}4|%select{method %5|constructor|destructor}4 is %select{not deleted|deleted}6|%select{method %5|constructor|destructor}4 is %select{not defaulted|defaulted}6|%select{method %5|constructor|destructor}4 is %select{|pure }6%select{not virtual|virtual}7|%select{method %5|constructor|destructor}4 is %select{not static|static}6|%select{method %5|constructor|destructor}4 is %select{not volatile|volatile}6|%select{method %5|constructor|destructor}4 is %select{not const|const}6|%select{method %5|constructor|destructor}4 is %select{not inline|inline}6|%select{method %5|constructor|destructor}4 with %ordinal6 parameter with%select{out|}7 a default argument|%select{method %5|constructor|destructor}4 with %ordinal6 parameter with a default argument|%select{method %5|constructor|destructor}4 with %select{no |}6template arguments|%select{method %5|constructor|destructor}4 with %6 template argument%s6|%select{method %5|constructor|destructor}4 with %6 for %ordinal7 template argument|%select{method %5|constructor|destructor}4 with %select{no body|body}6|%select{method %5|constructor|destructor}4 with body|friend %select{class|function}4|friend %4|friend function %4|function template %4 with %5 template parameter%s5|function template %4 with %ordinal5 template parameter being a %select{type|non-type|template}6 template parameter|function template %4 with %ordinal5 template parameter %select{with no name|named %7}6|function template %4 with %ordinal5 template parameter with %select{no |}6default argument|function template %4 with %ordinal5 template parameter with default argument %6|function template %4 with %ordinal5 template parameter with one type|function template %4 with %ordinal5 template parameter %select{not |}6being a template parameter pack|}3"
-HCEB41952ED68: "%q0 在不同模块中具有不同的定义；第一个差异是 %select{模块 '%2' 中的定义|在此处定义}1 发现 %select{带有条件的静态断言|带有消息的静态断言|%select{|无 }4消息的静态断言|%select{方法 %5|构造函数|析构函数}4|%select{方法 %5|构造函数|析构函数}4 是 %select{未删除|已删除}6|%select{方法 %5|构造函数|析构函数}4 是 %select{未默认|已默认}6|%select{方法 %5|构造函数|析构函数}4 是 %select{|纯 }6%select{非虚|虚}7|%select{方法 %5|构造函数|析构函数}4 是 %select{非静态|静态}6|%select{方法 %5|构造函数|析构函数}4 是 %select{非volatile|volatile}6|%select{方法 %5|构造函数|析构函数}4 是 %select{非const|const}6|%select{方法 %5|构造函数|析构函数}4 是 %select{非内联|内联}6|%select{方法 %5|构造函数|析构函数}4 具有第 %ordinal6 参数带有%select{出|}7 默认参数|%select{方法 %5|构造函数|析构函数}4 具有第 %ordinal6 参数带有默认参数|%select{方法 %5|构造函数|析构函数}4 具有%select{无 |}6模板参数|%select{方法 %5|构造函数|析构函数}4 具有 %6 模板参数%s6|%select{方法 %5|构造函数|析构函数}4 具有 %6 作为第 %ordinal7 模板参数|%select{方法 %5|构造函数|析构函数}4 具有%select{无|有}6函数体|%select{方法 %5|构造函数|析构函数}4 具有函数体|友元 %select{类|函数}4|友元 %4|友元函数 %4|函数模板 %4 具有 %5 模板参数%s5|函数模板 %4 具有第 %ordinal5 模板参数是 %select{类型|非类型|模板}6 模板参数|函数模板 %4 具有第 %ordinal5 模板参数%select{无名称|名称为 %7}6|函数模板 %4 具有第 %ordinal5 模板参数%select{无|}6默认参数|函数模板 %4 具有第 %ordinal5 模板参数默认参数 %6|函数模板 %4 具有第 %ordinal5 模板参数具有一个类型|函数模板 %4 具有第 %ordinal5 模板参数%select{不|}6是模板参数包|}3"
+HCEB41952ED68: "%q0 在不同模块中具有不同的定义；第一个差异是 %select{模块 '%2' 中的定义|在此处定义}1 发现 %select{带有条件的静态断言|带有消息的静态断言|%select{|无 }4消息的静态断言|%select{方法 %5|构造函数|析构函数}4|%select{方法 %5|构造函数|析构函数}4 是 %select{未删除|已删除}6|%select{方法 %5|构造函数|析构函数}4 是 %select{未默认|已默认}6|%select{方法 %5|构造函数|析构函数}4 是 %select{|纯 }6%select{非虚|虚}7|%select{方法 %5|构造函数|析构函数}4 是 %select{非静态|静态}6|%select{方法 %5|构造函数|析构函数}4 是 %select{非volatile|volatile}6|%select{方法 %5|构造函数|析构函数}4 是 %select{非const|const}6|%select{方法 %5|构造函数|析构函数}4 是 %select{非内联|内联}6|%select{方法 %5|构造函数|析构函数}4 具有第 %ordinal6 参数带有%select{出|}7 默认参数|%select{方法 %5|构造函数|析构函数}4 具有第 %ordinal6 参数带有默认参数|%select{方法 %5|构造函数|析构函数}4 具有%select{无 |}6 模板参数|%select{方法 %5|构造函数|析构函数}4 具有 %6 模板参数%s6|%select{方法 %5|构造函数|析构函数}4 具有 %6 作为第 %ordinal7 模板参数|%select{方法 %5|构造函数|析构函数}4 具有%select{无|有}6函数体|%select{方法 %5|构造函数|析构函数}4 具有函数体|友元 %select{类|函数}4|友元 %4|友元函数 %4|函数模板 %4 具有 %5 模板参数%s5|函数模板 %4 具有第 %ordinal5 模板参数是 %select{类型|非类型|模板}6 模板参数|函数模板 %4 具有第 %ordinal5 模板参数%select{无名称|名称为 %7}6|函数模板 %4 具有第 %ordinal5 模板参数%select{无|}6 默认参数|函数模板 %4 具有第 %ordinal5 模板参数默认参数 %6|函数模板 %4 具有第 %ordinal5 模板参数具有一个类型|函数模板 %4 具有第 %ordinal5 模板参数%select{不|}6 是模板参数包|}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{unnamed template parameter|template parameter %5|template parameter with %select{no |}4default argument|template parameter with default argument}3"
-HA9E92FE31082: "%q0 在不同模块中有不同的定义；第一个差异是 %select{模块 '%2' 中的定义|在此处定义}1 发现 %select{未命名的模板参数|模板参数 %5|模板参数%select{无 |}4默认参数|模板参数具有默认参数}3"
+HA9E92FE31082: "%q0 在不同模块中有不同的定义；第一个差异是 %select{模块 '%2' 中的定义|在此处定义}1 发现 %select{未命名的模板参数|模板参数 %5|模板参数%select{无 |}4 默认参数|模板参数具有默认参数}3"
 # '%q0 hides overloaded virtual %select{function|functions}1'
 H2FDDD909C4BF: '%q0 隐藏重载虚 %select{函数|函数}1'
 # '%q0 is not a member of class %1'
@@ -871,9 +871,9 @@ H47225B26A402: "%select{预编译头|模块|AST}0 文件 '%1' 来自不同分支
 # "%select{PCH|module|AST}0 file '%1' contains compiler errors"
 H70FD1E0F0771: "%select{预编译头|模块|AST}0 文件 '%1' 包含编译错误"
 # "%select{PCH|module|AST}0 file '%1' is out of date and needs to be rebuilt%select{|: %3}2"
-H1F11095B483F: "%select{预编译头|模块|AST}0 文件 '%1' 已过期需要重新生成%select{|： %3}2"
+H1F11095B483F: "%select{预编译头|模块|AST}0 文件 '%1' 已过期需要重新生成 %select{|： %3}2"
 # "%select{PCH|module|AST}0 file '%1' not found%select{|: %3}2"
-HA37A363A734E: "%select{预编译头|模块|AST}0 文件 '%1' 未找到%select{|： %3}2"
+HA37A363A734E: "%select{预编译头|模块|AST}0 文件 '%1' 未找到 %select{|： %3}2"
 # "%select{PCH|module|AST}0 file '%1' uses a newer format that cannot be read"
 H80665252BAE8: "%select{预编译头|模块|AST}0 文件 '%1' 使用无法读取的新格式"
 # "%select{PCH|module|AST}0 file '%1' uses an older format that is no longer supported"
@@ -905,7 +905,7 @@ HF5A022BDF3DB: '%select{对齐值|大小}0 的字段 %1 (%2 位) 与透明联合
 # '%select{alignment|size}0 of first field is %1 bits'
 H996CEE2D3252: '%select{对齐值|大小}0 的第一个字段是 %1 位'
 # '%select{all|second and third}0 arguments to %1 must be of scalar or vector type with matching scalar element type%diff{: $ vs $|}2,3'
-HE09C48EB126A: '%select{所有|第二个和第三个}0 参数到 %1 必须为标量或向量类型且具有匹配的标量元素类型%diff{: $ vs $|}2,3'
+HE09C48EB126A: '%select{所有|第二个和第三个}0 参数到 %1 必须为标量或向量类型且具有匹配的标量元素类型 %diff{: $ vs $|}2,3'
 # '%select{an attribute specifier sequence|%0}1 in this position is a C++23 extension'
 H561F9F6DB91B: '%select{属性说明符序列|%0}1 在此位置是 C++23 扩展'
 # '%select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23'
@@ -943,7 +943,7 @@ HB2E74DC62C72: '%select{不同枚举类型的算术运算|不同枚举类型的�
 # '%select{assignment to readonly property|no setter method %1 for assignment to property}0'
 H7FB56A6FE5D6: '%select{将只读属性赋值|属性赋值没有设置器方法 %1}0'
 # '%select{base class|inherited virtual base class}0 %1 has %select{private|protected}3 %select{default |copy |move |*ERROR* |*ERROR* |*ERROR*|}2constructor'
-H3EE5604475F7: '%select{基类|继承的虚基类}0 %1 具有%select{私有|受保护}3 %select{默认 |拷贝 |移动 |*ERROR* |*ERROR* |*ERROR*|}2构造函数'
+H3EE5604475F7: '%select{基类|继承的虚基类}0 %1 具有%select{私有|受保护}3 %select{默认 |拷贝 |移动 |*ERROR* |*ERROR* |*ERROR*|}2 构造函数'
 # '%select{bit-field %1|anonymous bit-field}0 is too wide (%2 bits)'
 H4CB82469419C: '%select{位段 %1|匿名位段}0 过宽（%2 位）'
 # "%select{block pointer|pointer|reference}0 to function type %select{%2 |}1cannot have '%3' qualifier"
@@ -951,11 +951,11 @@ H0BABB964A63A: "%select{块指针|指针|引用}0 到函数类型 %select{%2 |}1
 # '%select{call to non-static member function|use of non-static data member}0 %2 of %1 from nested type %3'
 H4DA493B4F5FF: '%select{调用非静态成员函数|使用非静态数据成员}0 %2 的 %1 来自嵌套类型 %3'
 # '%select{cannot assign to return value because function %1 returns a const value|cannot assign to variable %1 with const-qualified type %2|cannot assign to %select{non-|}1static data member %2 with const-qualified type %3|cannot assign to non-static data member within const member function %1|cannot assign to %select{variable %2|non-static data member %2|lvalue}1 with %select{|nested }3const-qualified data member %4|read-only variable is not assignable}0'
-H957C121C1C4E: '%select{不能将返回值赋值因为函数 %1 返回 const 值|不能将 const 限定类型 %2 的变量 %1 赋值|不能将 const 限定类型 %3 的%select{非-|}1静态数据成员 %2 赋值|不能在 const 成员函数 %1 内对非静态数据成员赋值|不能对%select{变量 %2|非静态数据成员 %2|左值}1 赋值，因为其%select{|嵌套 }3const 限定数据成员 %4|只读变量不可赋值}0'
+H957C121C1C4E: '%select{不能将返回值赋值因为函数 %1 返回 const 值|不能将 const 限定类型 %2 的变量 %1 赋值|不能将 const 限定类型 %3 的%select{非-|}1 静态数据成员 %2 赋值|不能在 const 成员函数 %1 内对非静态数据成员赋值|不能对%select{变量 %2|非静态数据成员 %2|左值}1 赋值，因为其 %select{|嵌套 }3const 限定数据成员 %4|只读变量不可赋值}0'
 # "%select{case value|enumerator value|non-type template argument|non-type parameter of template template parameter|array size|explicit specifier argument|noexcept specifier argument|call to 'size()'|call to 'data()'}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1"
-HECF4733C9DA0: "%select{情况值|枚举值|非类型模板实参|模板模板参数的非类型参数|数组大小|显式说明符实参|noexcept 说明符实参|调用'size()'|调用'data()'}0 %select{不能从类型 %2 窄化到 %3|计算为 %2，无法窄化为类型 %3}1"
+HECF4733C9DA0: "%select{情况值|枚举值|非类型模板实参|模板模板参数的非类型参数|数组大小|显式说明符实参|noexcept 说明符实参|调用 'size()'|调用 'data()'}0 %select{不能从类型 %2 窄化到 %3|计算为 %2，无法窄化为类型 %3}1"
 # "%select{case value|enumerator value|non-type template argument|non-type parameter of template template parameter|array size|explicit specifier argument|noexcept specifier argument|call to 'size()'|call to 'data()'}0 is not a constant expression"
-HFB41B693F137: "%select{情况值|枚举值|非类型模板实参|模板模板参数的非类型参数|数组大小|显式说明符实参|noexcept 说明符实参|调用'size()'|调用'data()'}0 不是常量表达式"
+HFB41B693F137: "%select{情况值|枚举值|非类型模板实参|模板模板参数的非类型参数|数组大小|显式说明符实参|noexcept 说明符实参|调用 'size()'|调用 'data()'}0 不是常量表达式"
 # '%select{cast|implicit conversion}0 of %select{Objective-C|block|C}1 pointer type %2 to %select{Objective-C|block|C}3 pointer type %4 requires a bridged cast'
 H312933E2115D: '%select{转换|隐式转换}0 %select{Objective-C|块|C}1 指针类型 %2 到 %select{Objective-C|块|C}3 指针类型 %4 需要桥接转换'
 # '%select{category %1|class extension}0 cannot conform to protocol %2 because of direct members declared in interface %3'
@@ -985,7 +985,7 @@ HF51A27778394: '%select{类|实例}0 方法 %1 在一个翻译单元中是可变
 # '%select{class|protocol|category|class extension|implementation|category implementation}0 started here'
 HB972B56B97CE: '%select{类|协议|分类|类扩展|实现|分类实现}0 在此处开始'
 # '%select{class|struct|interface|union|enum|enum class|enum struct}0 cannot be marked %select{<ERROR>|constexpr|consteval|constinit}1'
-H6CC4F10FF6EF: '%select{类|结构体|接口|联合体|枚举|枚举类|枚举结构体}0 无法被标记为%select{<ERROR>|constexpr|consteval|constinit}1'
+H6CC4F10FF6EF: '%select{类|结构体|接口|联合体|枚举|枚举类|枚举结构体}0 无法被标记为 %select{<ERROR>|constexpr|consteval|constinit}1'
 # '%select{class|type alias}0 template declared here'
 HC92E96CB1535: '%select{类|类型别名}0 模板在此处声明'
 # '%select{class|variable}0 template partial specialization contains %select{a template parameter|template parameters}1 that cannot be deduced; this partial specialization will never be used'
@@ -1067,17 +1067,17 @@ H2588FE2C83FF: '%select{默认化|删除化}0函数定义是C++11扩展'
 # '%select{defaulted|deleted}0 function definitions are incompatible with C++98'
 HE7CB963644EA: '%select{默认化|删除化}0函数定义与C++98不兼容'
 # "%select{definition|#undef}0 of configuration macro '%1' has no effect on the import of '%2'; pass '%select{-D%1=...|-U%1}0' on the command line to configure the module"
-H20DEB068BA86: "%select{定义|#undef}0的配置宏 '%1' 对导入 '%2' 无影响；请通过命令行Pass'%select{-D%1=...|-U%1}0'配置模块"
+H20DEB068BA86: "%select{定义|#undef}0 的配置宏 '%1' 对导入 '%2' 无影响；请通过命令行Pass'%select{-D%1=...|-U%1}0' 配置模块"
 # '%select{delete|destructor}0 called on %1 that is abstract but has non-virtual destructor'
-HD3B2B405330A: '对具有非虚析构函数的抽象 %1 调用%select{delete|析构函数}0'
+HD3B2B405330A: '对具有非虚析构函数的抽象 %1 调用 %select{delete|析构函数}0'
 # '%select{delete|destructor}0 called on non-final %1 that has virtual functions but non-virtual destructor'
-HD186820BFF8C: '对非final且包含虚函数但非虚析构函数的 %1 调用%select{delete|析构函数}0'
+HD186820BFF8C: '对非final且包含虚函数但非虚析构函数的 %1 调用 %select{delete|析构函数}0'
 # '%select{delimited|named}0 escape sequences are a %select{C++23|C2y|Clang}1 extension'
 HDBE05BE4D14B: '%select{限定|命名}0转义序列是 %select{C++23|C2y|Clang}1 扩展'
 # '%select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23'
 HFB62920439FF: '%select{限定|命名}0转义序列与C++23之前的C++标准不兼容'
 # '%select{destination for|source of|first operand of|second operand of}0 this %1 call is a pointer to %select{|class containing a }2dynamic class %3; vtable pointer will be %select{overwritten|copied|moved|compared}4'
-H63A8D05F544B: '此 %1 调用的%select{目标|源|第一个操作数|第二个操作数}0是指向%select{|包含动态类的类}2%3 的指针；vtable指针将被%select{覆盖|复制|移动|比较}4'
+H63A8D05F544B: '此 %1 调用的%select{目标|源|第一个操作数|第二个操作数}0是指向 %select{|包含动态类的类}2%3 的指针；vtable指针将被%select{覆盖|复制|移动|比较}4'
 # '%select{destination for|source of|first operand of|second operand of}0 this %1 call is a pointer to record %2 that is not trivial to %select{primitive-default-initialize|primitive-copy}3'
 HB6A0DAA8C1C8: '%select{此 %1 调用的|源|第一个操作数的|第二个操作数的}0 目标是指向非 %select{原始默认初始化|原始复制}3 类型 %2 的指针'
 # '%select{destination for|source of}0 this %1 call is a pointer to ownership-qualified type %2'
@@ -1085,7 +1085,7 @@ HEE4DB03498AC: '此 %1 调用的%select{目标|源}0是指向所有权限定类�
 # '%select{destructor|deallocator}0 has a %select{non-throwing|implicit non-throwing}1 exception specification'
 H78E56ACB6245: '%select{析构函数|解分配器}0具有%select{不抛出异常的|隐式不抛出异常的}1异常规范'
 # '%select{dictionary|array}1 subscript base type %0 is not an Objective-C object'
-HE2828D54BB1B: '%select{字典|数组}1 下标基类型 %0 不是 Objective-C 对象'
+HE2828D54BB1B: '%select{字典|array}1 下标基类型 %0 不是 Objective-C 对象'
 # '%select{equality|inequality|relational|three-way}0 comparison result unused'
 H69C6598EFBD9: '%select{相等|不等|关系|三向}0 比较结果未被使用'
 # '%select{expected an expression statement|expected built-in assignment operator|expected expression of scalar type|expected lvalue expression}0'
@@ -1099,7 +1099,7 @@ H2BEDF1CDD9ED: "%select{期望复合语句|期望恰好一个表达式语句|期
 # '%select{explicit|friend}0 specialization cannot have a trailing requires clause unless it declares a function template'
 H4B8C1F1CA2BB: '%select{显式|友元}0 特殊化除非声明函数模板，否则不能有尾随 requires 子句'
 # '%select{expression|base type|declaration type|data member type|bit-field size|static assertion|fixed underlying type|enumerator value|using declaration|friend declaration|qualifier|initializer|default argument|non-type template parameter type|exception type|explicit specialization|partial specialization|__if_exists name|__if_not_exists name|lambda|block|type constraint|requirement|requires clause}0 contains%plural{0: an|:}1 unexpanded parameter pack%plural{0:|1: %2|2:s %2 and %3|:s %2, %3, ...}1'
-HE9A8E0B2E8F5: '%select{表达式|基类型|声明类型|数据成员类型|位段大小|静态断言|固定底层类型|枚举值|使用声明|友元声明|限定符|初始化器|默认参数|非类型模板参数类型|异常类型|显式特殊化|部分特殊化|__if_exists 名称|__if_not_exists 名称|lambda|block|类型约束|需求|requires 子句}0 包含%plural{0: 一个|:}1 未展开的参数包%plural{0:|1: %2|2:s %2 和 %3|:s %2, %3, ...}1'
+HE9A8E0B2E8F5: '%select{表达式|基类型|声明类型|数据成员类型|位段大小|静态断言|固定底层类型|枚举值|使用声明|友元声明|限定符|初始化器|默认参数|非类型模板参数类型|异常类型|显式特殊化|部分特殊化|__if_exists 名称|__if_not_exists 名称|lambda|block|类型约束|需求|requires 子句}0 包含 %plural{0: 一个|:}1 未展开的参数包 %plural{0:|1: %2|2:s %2 和 %3|:s %2, %3, ...}1'
 # '%select{extension|category}0 of non-parameterized class %1 cannot have type parameters'
 H6F4F8CBFDF9B: '%select{扩展|分类}0 非参数化类 %1 不能有类型参数'
 # '%select{fewer|more}0 specifiers in format string than expected'
@@ -1121,7 +1121,7 @@ HBF77ADC8F095: '%select{第一个|第二个}0 操作数被隐式转换为类型 
 # '%select{forward class declaration|class definition|category|extension}0 has too %select{few|many}1 type parameters (expected %2, have %3)'
 HF027D432E158: '%select{前向类声明|类定义|类别|扩展}0 的类型参数数量%select{太少|太多}1（期望 %2，实际 %3）'
 # '%select{function %1 which returns const-qualified type %2 declared here|variable %1 declared const here|%select{non-|}1static data member %2 declared const here|member function %q1 is declared const here|%select{|nested }1data member %2 declared const here}0'
-HA9209A7005BD: '%select{返回const限定类型 %2 的函数 %1 在此声明|在此声明为const的变量 %1|非%select{静态|匿名}1数据成员 %2 在此声明为const|在此声明为const的成员函数%q1|%select{嵌套|}1数据成员 %2 在此声明为const}0'
+HA9209A7005BD: '%select{返回const限定类型 %2 的函数 %1 在此声明|在此声明为const的变量 %1|非%select{静态|匿名}1数据成员 %2 在此声明为const|在此声明为const的成员函数%q1|%select{嵌套|}1 数据成员 %2 在此声明为const}0'
 # '%select{function parameter|typedef}0 cannot be %select{<ERROR>|constexpr|consteval|constinit}1'
 H86C3A8B0C257: '%select{函数参数|typedef}0 不能是 %select{<ERROR>|constexpr|consteval|constinit}1'
 # '%select{function template|class template|variable template|type alias template|template template parameter}0 %1 declared here'
@@ -1171,7 +1171,7 @@ H2BE56E173B04: '%select{隐式转换|强制类型转换}0 将 %select{%2|非 Obj
 # '%select{implicit conversion|cast}0 of weak-unavailable object of type %1 to a __weak object of type %2'
 H5E0A61E4DC2C: '%select{隐式转换|显式转换}0 类型为 %1 的 weak-unavailable 对象到类型为 %2 的 __weak 对象'
 # '%select{implicitly |}2captured%select{| by reference}3%select{%select{ due to use|}2 here| via initialization of lambda capture %0}1'
-H0BA3D7D599E5: '%select{隐式 |}2捕获%select{|通过引用}3%select{%select{ 因为此处的使用|}2 |通过 lambda 捕获 %0 的初始化}1'
+H0BA3D7D599E5: '%select{隐式 |}2 捕获 %select{|通过引用}3%select{%select{ 因为此处的使用|}2 |通过 lambda 捕获 %0 的初始化}1'
 # '%select{implicit|explicit}0 instantiation first required here'
 HB12903FE55DA: '%select{隐式|显式}0 实例化首次在此处需要'
 # '%select{implicit|explicit}0 instantiation of template %1 within its own definition'
@@ -1225,7 +1225,7 @@ H1777D1633EE8: '%select{非 const|volatile}0 左值引用 %diff{到类型 $ 不�
 # '%select{non-const|volatile}0 lvalue reference to type %1 cannot bind to an initializer list temporary'
 H3CF62E12AA3E: '%select{非 const|volatile}0 类型 %1 的左值引用不能绑定到初始化列表临时值'
 # '%select{non-const|volatile}0 reference cannot bind to bit-field%select{| %1}2'
-H8AF09902E67B: '%select{非 const|volatile}0 引用不能绑定到位段%select{| %1}2'
+H8AF09902E67B: '%select{非 const|volatile}0 引用不能绑定到位段 %select{| %1}2'
 # '%select{non-const|volatile}0 reference cannot bind to matrix element'
 HA82833F246FF: '%select{非 const|volatile}0 引用不能绑定到矩阵元素'
 # '%select{non-const|volatile}0 reference cannot bind to vector element'
@@ -1239,7 +1239,7 @@ HFB817CBCD184: "%select{非成员函数|静态成员函数|显式对象成员函
 # '%select{non-member|member}0 %select{<ERROR>|equality|three-way|equality|relational}1 comparison operator must have %select{2|1}0 parameters'
 HB5C9D99264DA: '%select{非成员|成员}0 %select{<ERROR>|相等|三向|相等|关系}1 比较运算符必须有 %select{2|1}0 个参数'
 # '%select{non-member|static member|non-static member}0 function cannot perform a tail call to %select{non-member|static member|non-static member|pointer-to-member}1 function%select{| %3}2'
-HE869F55E570F: '%select{非成员|静态成员|非静态成员}0 函数不能尾调用 %select{非成员|静态成员|非静态成员|成员指针}1 函数%select{| %3}2'
+HE869F55E570F: '%select{非成员|静态成员|非静态成员}0 函数不能尾调用 %select{非成员|静态成员|非静态成员|成员指针}1 函数 %select{| %3}2'
 # "%select{non-pointer|function pointer|void pointer}0 argument to '__builtin_launder' is not allowed"
 H5F5CB4F84C85: "%select{非指针|函数指针|void 指针}0 参数传递给 '__builtin_launder' 不允许"
 # "%select{non-struct type|non-class type|non-union type|non-enum type|typedef|type alias|template|alias template|template template argument}1 %0 cannot be referenced with the '%select{struct|interface|union|class|enum}2' specifier"
@@ -1251,11 +1251,11 @@ HEC6E2A0FBA29: "传递给 '__builtin_is_within_lifetime' 的%select{非-|函数 
 # "%select{no|too many}0 integer expression arguments provided to OpenACC 'num_gangs' %select{|clause: '%1' directive expects maximum of %2, %3 were provided}0"
 HDF54FE517944: "为OpenACC 'num_gangs' %select{|子句 '%1' 指令最多接受 %2，但提供了 %3 个}0提供了 %select{no|too many}0 整型表达式参数"
 # "%select{orphaned 'omp section' directives are prohibited, it|'omp section' directive}0 must be closely nested to a sections region%select{|, not a %1 region}0"
-HF07F4A64D372: "%select{孤儿的 'omp section' 指令被禁止，它|'omp section' 指令}0必须紧密嵌套到一个 sections 区域%select{|，而不是一个 %1 区域}0"
+HF07F4A64D372: "%select{孤儿的 'omp section' 指令被禁止，它|'omp section' 指令}0必须紧密嵌套到一个 sections 区域 %select{|，而不是一个 %1 区域}0"
 # "%select{overridden|current}0 method is explicitly declared 'instancetype'%select{| and is expected to return an instance of its class type}0"
 HB89C11914779: "%select{覆盖|当前}0方法显式声明为 'instancetype'%select{|并期望返回其类类型的实例}0"
 # "%select{overridden|current}0 method is part of the '%select{|alloc|copy|init|mutableCopy|new|autorelease|dealloc|finalize|release|retain|retainCount|self}1' method family%select{| and is expected to return an instance of its class type}0"
-HB76B1E081BAA: "%select{覆盖|当前}0方法属于 '%select{|alloc|copy|init|mutableCopy|new|autorelease|dealloc|finalize|release|retain|retainCount|self}1' 方法族%select{|并期望返回其类类型的实例}0"
+HB76B1E081BAA: "%select{覆盖|当前}0方法属于 '%select{|alloc|copy|init|mutableCopy|new|autorelease|dealloc|finalize|release|retain|retainCount|self}1' 方法族 %select{|并期望返回其类类型的实例}0"
 # '%select{parameters|function return value}0 cannot have __fp16 type; did you forget * ?'
 H3BDED28AD784: '%select{参数|函数返回值}0不能具有 __fp16 类型；是否漏掉了 * ？'
 # '%select{parameter|non-static data member}3 %0 %select{|of %1 }3shadows member inherited from type %2'
@@ -1287,17 +1287,17 @@ H0FF342784C44: '%select{指针|引用}1 到非 const 类型 %0 未显式指定�
 # '%select{precompiled header|module}0 uses __DATE__ or __TIME__'
 H2637E05CCFD6: '%select{预编译头|模块}0使用了__DATE__或__TIME__'
 # '%select{program scope|static local|extern}0 variable must reside in %1 address space'
-H8250A4383E97: '%select{程序作用域|静态局部|extern}0变量必须位于 %1 地址空间中'
+H8250A4383E97: '%select{程序作用域|静态局部|extern}0 变量必须位于 %1 地址空间中'
 # '%select{property|instance variable}0 access cannot be qualified with %1'
 H8153C2BE3904: '%select{属性|实例变量}0的访问不能使用 %1 修饰符'
 # "%select{public|private|project}1 umbrella header file not found in input: '%0'"
 HFB4B45B92460: "%select{公共|私有|项目}1 伞状头文件未在输入中找到: '%0'"
 # "%select{qualifier in |static |}0array size %select{||'[*] '}0is a C99 feature"
-H5561702CDE0D: "%select{限定符在 |静态 |}0数组大小%select{||'[*] '}0是C99特性"
+H5561702CDE0D: "%select{限定符在 |静态 |}0 数组大小 %select{||'[*] '}0 是C99特性"
 # "%select{qualifier in |static |}0array size %select{||'[*] '}0is a C99 feature, not permitted in C++"
-HD9EDD0C87400: "%select{限定符在 |静态 |}0数组大小%select{||'[*] '}0是C99特性，不被C++允许"
+HD9EDD0C87400: "%select{限定符在 |静态 |}0 数组大小 %select{||'[*] '}0 是C99特性，不被C++允许"
 # '%select{read of|read of|assignment to|increment of|decrement of|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>}0 volatile %select{temporary|object %2|member %2}1 is not allowed in a constant expression'
-H88BF34501395: '%select{读取|读取|对...的赋值|递增|递减|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>}0 volatile %select{临时对象|对象 %2|成员 %2}1在常量表达式中不允许'
+H88BF34501395: '%select{读取|读取|对...的赋值|递增|递减|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>}0 volatile %select{临时对象|对象 %2|成员 %2}1 在常量表达式中不允许'
 # '%select{read of|read of|assignment to|increment of|decrement of|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>}0 volatile-qualified type %1 is not allowed in a constant expression'
 HFA8AACB1DC9D: '%select{读取|读取|对...的赋值|递增|递减|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>}0 %1 的volatile限定类型在常量表达式中不允许'
 # '%select{read of|read of|assignment to|increment of|decrement of|member call on|dynamic_cast of|typeid applied to|construction of subobject of|destruction of|read of}0 %select{object outside its lifetime|uninitialized object}1 is not allowed in a constant expression'
@@ -1305,7 +1305,7 @@ H030F1EA383B2: '%select{读取|读取|对...的赋值|递增|递减|成员调用
 # '%select{read of|read of|assignment to|increment of|decrement of|member call on|dynamic_cast of|typeid applied to|construction of subobject of|destruction of|read of}0 member %1 of union with %select{active member %3|no active member}2 is not allowed in a constant expression'
 HAA36C87281CE: '%select{读取|读取|对...的赋值|递增|递减|成员调用|dynamic_cast|typeid应用|子对象构造|析构|读取}0 union成员 %1 在%select{有活动成员 %3|无活动成员}2时不允许出现在常量表达式中'
 # '%select{read of|read of|assignment to|increment of|decrement of|member call on|dynamic_cast of|typeid applied to|construction of|destruction of|read of}0 %select{temporary|variable}1 whose %plural{8:storage duration|:lifetime}0 has ended'
-H1E2EE7FC7CDC: '%select{读取|读取|对...的赋值|递增|递减|成员调用|dynamic_cast|typeid应用|构造|析构|读取}0 %select{临时对象|变量}1其%plural{8:存储持续期|:生命周期}0已结束'
+H1E2EE7FC7CDC: '%select{读取|读取|对...的赋值|递增|递减|成员调用|dynamic_cast|typeid应用|构造|析构|读取}0 %select{临时对象|变量}1其 %plural{8:存储持续期|:生命周期}0已结束'
 # '%select{read of|read of|assignment to|increment of|decrement of|member call on|dynamic_cast of|typeid applied to|construction of|destruction of|read of}0 dereferenced null pointer is not allowed in a constant expression'
 H22FE9FDFDD6D: '%select{读取|读取|对...的赋值|递增|递减|成员调用|dynamic_cast|typeid应用|构造|析构|读取}0 解引用空指针在常量表达式中不允许'
 # '%select{read of|read of|assignment to|increment of|decrement of|member call on|dynamic_cast of|typeid applied to|construction of|destruction of|read of}0 dereferenced one-past-the-end pointer is not allowed in a constant expression'
@@ -1325,19 +1325,19 @@ H20B2C79559EA: '%select{读取|写入}1所指向的 %0 需要持有%select{任�
 # '%select{reading|writing}1 variable %0 requires holding %select{any mutex|any mutex exclusively}1'
 HAB41C50F5547: '%select{读取|写入}1变量 %0 需要持有%select{任意互斥锁|独占互斥锁}1'
 # "%select{reading|writing}3 the value pointed to by %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
-HA3CF53D5D321: "%select{读取|写入}3 %1 所指向的值需要保持 %0 %select{'%2'|'独占的 %2'}3"
+HA3CF53D5D321: "%select{读取|写入}3 %1 所指向的值需要保持 %0 %select{'%2'|' 独占的 %2'}3"
 # "%select{reading|writing}3 variable %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
-HBF61FE4FFCA3: "%select{读取|写入}3 变量 %1 需要保持 %0 %select{'%2'|'独占的 %2'}3"
+HBF61FE4FFCA3: "%select{读取|写入}3 变量 %1 需要保持 %0 %select{'%2'|' 独占的 %2'}3"
 # "%select{reference|backing array for 'std::initializer_list'}2 %select{|subobject of }1member %0 %select{binds to|is}2 a temporary object whose lifetime is shorter than the lifetime of the constructed object"
-H31A36503387B: "%select{引用|'std::initializer_list'的后备数组}2 %select{|成员 %0 的子对象}1 %select{绑定到|是}2 一个临时对象，其生命周期比构造对象的生命周期短"
+H31A36503387B: "%select{引用|'std::initializer_list' 的后备数组}2 %select{|成员 %0 的子对象}1 %select{绑定到|是}2 一个临时对象，其生命周期比构造对象的生命周期短"
 # "%select{reference|backing array for 'std::initializer_list'}2 %select{|subobject of }1member %0 %select{binds to|is}2 a temporary object whose lifetime would be shorter than the lifetime of the constructed object"
-H54C5751F42B3: "%select{引用|'std::initializer_list'的后备数组}2 %select{|成员 %0 的子对象}1 %select{绑定到|是}2 一个临时对象，其生命周期将比构造对象的生命周期短"
+H54C5751F42B3: "%select{引用|'std::initializer_list' 的后备数组}2 %select{|成员 %0 的子对象}1 %select{绑定到|是}2 一个临时对象，其生命周期将比构造对象的生命周期短"
 # '%select{reference|pointer}0 member declared here'
 H8AC5A0A64CFD: '%select{引用|指针}0 成员在此声明'
 # '%select{reinterpret_cast|C-style cast}0 from %1 to %2 changes address space of nested pointers'
-HDAB148B74E30: '从 %1 到 %2 的%select{reinterpret_cast|C风格转换}0更改了嵌套指针的地址空间'
+HDAB148B74E30: '从 %1 到 %2 的 %select{reinterpret_cast|C风格转换}0更改了嵌套指针的地址空间'
 # '%select{reinterpret_cast|dynamic_cast|%select{this conversion|cast that performs the conversions of a reinterpret_cast}1|cast from %1}0 is not allowed in a constant expression%select{| in C++ standards before C++20||}0'
-H1688ED0E5178: '%select{reinterpret_cast|dynamic_cast|%select{此转换|执行reinterpret_cast转换的转换}1|来自 %1 的转换}0 在常量表达式中不允许%select{|在C++20之前的C++标准中||}0'
+H1688ED0E5178: '%select{reinterpret_cast|dynamic_cast|%select{此转换|执行reinterpret_cast转换的转换}1|来自 %1 的转换}0 在常量表达式中不允许 %select{|在C++20之前的C++标准中||}0'
 # '%select{remainder|division}0 by zero is undefined'
 HDDF6DBF3AFB2: '%select{余数|除法}0 除以零是未定义的'
 # '%select{returning|passing}0 a VL-dependent argument %select{from|to}0 a function with a different streaming-mode is undefined behaviour when the streaming and non-streaming vector lengths are different at runtime'
@@ -1361,9 +1361,9 @@ H866585566251: '%select{有符号|无符号}0 _BitInt 必须具有至少 %select
 # '%select{signed|unsigned}0 _BitInt of bit sizes greater than %1 not supported'
 HB66515AEE2F3: '%select{有符号|无符号}0 _BitInt 的位大小超过 %1 不受支持'
 # "%select{source|destination}2 of '%select{%select{memcpy|wmemcpy}1|%select{memmove|wmemmove}1}0' is %3"
-H752C91AB4DE4: "'%select{%select{memcpy|wmemcpy}1|%select{memmove|wmemmove}1}0'的%select{源|目标}2 是 %3"
+H752C91AB4DE4: "'%select{%select{memcpy|wmemcpy}1|%select{memmove|wmemmove}1}0' 的%select{源|目标}2 是 %3"
 # "%select{statement after '#pragma omp %1' must be a for loop|expected %2 for loops after '#pragma omp %1'%select{|, but found only %4}3}0"
-H5AE78EDFB051: '%select{#pragma omp %1 后的语句必须是一个for循环|期望在#pragma omp %1 后有 %2 个for循环%select{|，但仅找到 %4}3}0'
+H5AE78EDFB051: '%select{#pragma omp %1 后的语句必须是一个for循环|期望在#pragma omp %1 后有 %2 个for循环 %select{|，但仅找到 %4}3}0'
 # '%select{statement|directive}0 outside teams construct here'
 HCEC20E30EFC9: '%select{语句|指令}0 在 teams 结构外部此处'
 # "%select{static data member is predetermined as shared|variable with static storage duration is predetermined as shared|loop iteration variable is predetermined as private|loop iteration variable is predetermined as linear|loop iteration variable is predetermined as lastprivate|constant variable is predetermined as shared|global variable is predetermined as shared|non-shared variable in a task construct is predetermined as firstprivate|variable with automatic storage duration is predetermined as private}0%select{|; perhaps you forget to enclose 'omp %2' directive into a parallel or another task region?}1"
@@ -1385,13 +1385,13 @@ HBECD0A183C46: '%select{结构|联合}0 无命名成员是 GNU 扩展'
 # '%select{subtraction|addition}0 of address-of-label expressions is not supported with ptrauth indirect gotos'
 H131327EB0D0D: '%select{标签地址差|标签地址和}0 不支持带有 ptrauth 间接 goto'
 # '%select{template type|non-type template|template template}0 parameter%select{| pack}1 conflicts with previous %select{template type|non-type template|template template}0 parameter%select{ pack|}1'
-HACD51B91D6D5: '%select{模板类型|非类型模板|模板模板}0 参数%select{| 包}1 与之前的 %select{模板类型|非类型模板|模板模板}0 参数%select{ 包|}1 冲突'
+HACD51B91D6D5: '%select{模板类型|非类型模板|模板模板}0 参数 %select{| 包}1 与之前的 %select{模板类型|非类型模板|模板模板}0 参数%select{ 包|}1 冲突'
 # '%select{template type|non-type template|template template}0 parameter%select{| pack}1 does not match %select{template type|non-type template|template template}0 parameter%select{ pack|}1 in template argument'
-H42D8D01F5E06: '%select{模板类型|非类型模板|模板模板}0 参数%select{| 包}1 与模板实参中的 %select{模板类型|非类型模板|模板模板}0 参数%select{ 包|}1 不匹配'
+H42D8D01F5E06: '%select{模板类型|非类型模板|模板模板}0 参数 %select{| 包}1 与模板实参中的 %select{模板类型|非类型模板|模板模板}0 参数%select{ 包|}1 不匹配'
 # '%select{template|partial|member}0 specialization cannot be declared __module_private__'
 H0A90D5264D30: '%select{模板|部分|成员}0 专项化不能被声明为 __module_private__'
 # '%select{temporary %select{whose address is used as value of|%select{|implicitly }2bound to}4 %select{%select{|reference }4member of local variable|local %select{variable|reference}4}1|array backing %select{initializer list subobject of local variable|local initializer list}1}0 %select{%3 |}2will be destroyed at the end of the full-expression'
-H1685FEE7827D: '临时%select{其地址被用作%select{|隐式}2绑定到%select{%select{|引用}4本地变量的成员|本地%select{变量|引用}4}1|数组后端%select{本地变量的初始化列表子对象|本地初始化列表}1}0 %select{%3 |}2%select{将被销毁在完整表达式结束时|}3'
+H1685FEE7827D: '临时%select{其地址被用作 %select{|隐式}2绑定到 %select{%select{|引用}4本地变量的成员|本地%select{变量|引用}4}1|数组后端%select{本地变量的初始化列表子对象|本地初始化列表}1}0 %select{%3 |}2%select{将被销毁在完整表达式结束时|}3'
 # "%select{the message|the expression}0 in %select{a static assertion|this asm operand}0 must be a string literal or an object with 'data()' and 'size()' member functions"
 H320EEB9B1530: '%select{消息|表达式}0 在 %select{静态断言|这个asm操作数}0 必须由常量表达式生成'
 # '%select{the message|the expression}0 in %select{a static assertion|this asm operand}0 must be produced by a constant expression'
@@ -1403,7 +1403,7 @@ H1136016D414E: '%select{消息|表达式}0 在 %select{此静态断言|此asm操
 # '%select{too few|too many}0 template arguments for %select{class template|function template|variable template|alias template|template template parameter|concept|template}1 %2'
 HA3BFC0466346: '%select{模板实参不足|模板实参过多}0 对于 %select{类模板|函数模板|变量模板|别名模板|模板模板参数|概念|模板}1 %2'
 # '%select{too few|too many}0 template parameters in template %select{|template parameter }1redeclaration'
-H2FC8E4427754: '%select{模板参数不足|模板参数过多}0 在模板%select{| 模板参数 }1重声明中'
+H2FC8E4427754: '%select{模板参数不足|模板参数过多}0 在模板 %select{| 模板参数 }1重声明中'
 # '%select{too few|too many}0 template parameters in template template argument'
 HEDDF73011D6C: '%select{模板参数太少|模板参数太多}0 在模板模板参数中'
 # '%select{too many|too few}0 elements in vector %select{initialization|operand}3 (expected %1 elements, have %2)'
@@ -1431,7 +1431,7 @@ HF8F02B43BB62: '%select{值|类型}0 依赖表达式被传递给调试命令'
 # '%select{variable|static data member}0 instantiated with function type %1'
 HE6193A7D74C4: '%select{变量|静态数据成员}0 实例化为函数类型 %1'
 # '%select{via initialization of|binding reference}0 variable %select{%2 |}1here'
-HB0440A5001E5: '%select{通过初始化|绑定引用}0 变量%select{%2 |}1此处'
+HB0440A5001E5: '%select{通过初始化|绑定引用}0 变量 %select{%2 |}1 此处'
 # "%select{virtual method|function pointer}0 cannot be inferred '%1'"
 H57712FD11644: "%select{虚方法|函数指针}0 无法推断 '%1'"
 # '%select{void function|void method|constructor|destructor}1 %0 must not return a value'
@@ -1457,7 +1457,7 @@ H1D02391D3A58: '%select{|直接 }0%select{方法|属性}1 声明与之前的 %se
 # '%select{|empty }0%select{struct|union}1 has size 0 in C, %select{size 1|non-zero size}2 in C++'
 HEA8D8C4B49F9: '%select{|空 }0%select{结构体|联合体}1 在C中有大小 0，在C++中%select{大小为 1|非零大小}2'
 # "%select{|implicit }0use of 'this' pointer is only allowed within the evaluation of a call to a 'constexpr' member function"
-HE1347141F3D2: '%select{|隐式 }0使用"this"指针仅允许在constexpr成员函数调用的求值过程中使用'
+HE1347141F3D2: '%select{|隐式 }0使用 "this" 指针仅允许在constexpr成员函数调用的求值过程中使用'
 # '%select{|implicitly }1declared %select{private|protected}0 here'
 H8D12655CD9C3: '%select{|隐式 }1声明为 %select{私有|保护}0 这里'
 # "%select{|incremented }0enumerator value which exceeds the range of 'int' is a C23 extension (%1 is too %select{small|large}2)"
@@ -1489,7 +1489,7 @@ H3E89611A15B6: '%select{|对 }0大小缺失的类型 %1 的引用在异常规格
 # '%select{|second }0%1 token is here'
 H00E98F1D44F7: '%select{|第二个 }0%1 标记在此处'
 # '%select{|static_cast|reinterpret_cast|dynamic_cast|C-style cast|functional-style cast|}0 from %1 to %2 uses deleted function%select{|: %4}3'
-HD806C936F5D9: '%select{|static_cast|reinterpret_cast|dynamic_cast|C风格转换|函数式转换|}0从 %1 到 %2 的转换使用了已删除的函数%select{|: %4}3'
+HD806C936F5D9: '%select{|static_cast|reinterpret_cast|dynamic_cast|C风格转换|函数式转换|}0 从 %1 到 %2 的转换使用了已删除的函数 %select{|: %4}3'
 # '%select{|success |failure }0memory order argument to atomic operation is invalid'
 HFAC869D2863E: '%select{|成功 |失败 }0原子操作的内存顺序参数无效'
 # "%select{|umbrella }0header '%1' not found"
@@ -1497,33 +1497,33 @@ H3FDB64D57A92: "%select{|umbrella }0头文件 '%1' 未找到"
 # '%select{|unsafe_unretained|strong|weak}1 property %0 may not also be declared %select{|__unsafe_unretained|__strong|__weak|__autoreleasing}2'
 HC9D6BEED9F9F: '%select{|unsafe_unretained|strong|weak}1 属性 %0 可能也不能被声明为 %select{|__unsafe_unretained|__strong|__weak|__autoreleasing}2'
 # '%select{||reinterpret_cast||C-style cast||}0 from scalar %1 to vector %2 of different size'
-HFF11D1B4EA50: '%select{||reinterpret_cast||C风格转换||}0从标量 %1 到不同大小的向量 %2'
+HFF11D1B4EA50: '%select{||reinterpret_cast||C风格转换||}0 从标量 %1 到不同大小的向量 %2'
 # '%select{||reinterpret_cast||C-style cast||}0 from vector %1 to scalar %2 of different size'
-H4BC2B3E593E1: '%select{||reinterpret_cast||C风格转换||}0从向量 %1 到不同大小的标量 %2'
+H4BC2B3E593E1: '%select{||reinterpret_cast||C风格转换||}0 从向量 %1 到不同大小的标量 %2'
 # '%select{||reinterpret_cast||C-style cast||}0 from vector %1 to vector %2 of different size'
-H855233AE0D42: '%select{||reinterpret_cast||C风格转换||}0从向量 %1 到不同大小的向量 %2'
+H855233AE0D42: '%select{||reinterpret_cast||C风格转换||}0 从向量 %1 到不同大小的向量 %2'
 # "%select{|||||virtual function called on|dynamic_cast applied to|typeid applied to|construction of|destruction of}0 object '%1' whose dynamic type is not constant"
 H292A692F3948: "%select{|||||虚函数调用|dynamic_cast 应用于|typeid 应用于|构造|析构}0 对象 '%1' 其动态类型不是常量"
 # "'##' cannot appear at end of __VA_OPT__ argument"
-H2B78B6D67ACA: "'##'不能出现在__VA_OPT__参数末尾"
+H2B78B6D67ACA: "'##' 不能出现在__VA_OPT__参数末尾"
 # "'##' cannot appear at end of macro expansion"
-H0D880CABAC3F: "'##'不能出现在宏展开末尾"
+H0D880CABAC3F: "'##' 不能出现在宏展开末尾"
 # "'##' cannot appear at start of __VA_OPT__ argument"
-H2F2411264E60: "'##'不能出现在__VA_OPT__参数开头"
+H2F2411264E60: "'##' 不能出现在__VA_OPT__参数开头"
 # "'##' cannot appear at start of macro expansion"
-H49669D0F3359: "'##'不能出现在宏展开开头"
+H49669D0F3359: "'##' 不能出现在宏展开开头"
 # "'#include <filename>' attaches the declarations to the named module '%0', which is not usually intended; consider moving that directive before the module declaration"
-HE8759FB5FF70: "'#include <filename>'将声明附加到名为 %0 的模块，这通常不是预期行为；建议将该指令移动到模块声明之前"
+HE8759FB5FF70: "'#include <filename>' 将声明附加到名为 %0 的模块，这通常不是预期行为；建议将该指令移动到模块声明之前"
 # "'#pragma %0' can only appear at file scope"
-HCE0F9341D433: "'#pragma %0'只能出现在文件作用域"
+HCE0F9341D433: "'#pragma %0' 只能出现在文件作用域"
 # "'#pragma %0' can only appear at file scope or at the start of a compound statement"
-HD3947EF6D864: "'#pragma %0'只能出现在文件作用域或复合语句开头"
+HD3947EF6D864: "'#pragma %0' 只能出现在文件作用域或复合语句开头"
 # "'#pragma %0' is not supported on this target - ignored"
-H10F342B08150: "'#pragma %0'在此目标上不支持 - 已忽略"
+H10F342B08150: "'#pragma %0' 在此目标上不支持 - 已忽略"
 # "'#pragma STDC FENV_ACCESS ON' is illegal when precise is disabled"
-H17CE846EF8B0: "'#pragma STDC FENV_ACCESS ON'在precise被禁用时非法"
+H17CE846EF8B0: "'#pragma STDC FENV_ACCESS ON' 在precise被禁用时非法"
 # "'#pragma alloc_text' is applicable only to functions"
-H29BA150C71BF: "'#pragma alloc_text'仅适用于函数"
+H29BA150C71BF: "'#pragma alloc_text' 仅适用于函数"
 # "'#pragma alloc_text' is applicable only to functions with C linkage"
 H8053A181B977: "'#pragma alloc_text' 仅适用于具有C链接的函数"
 # "'#pragma clang arc_cf_code_audited' was not ended within this file"
@@ -1585,9 +1585,9 @@ H140C3ABC4AE4: "忽略 '%0' 操作，已指定之前的 '%1' 操作"
 # "'%0' and '%1' clause are mutually exclusive and may not appear on the same directive"
 H124967FEEE58: "'%0' 和 '%1' 子句是互斥的，不能出现在同一指令中"
 # "'%0' argument on '%1' clause is not permitted on a%select{|n orphaned}2 '%3' construct%select{| associated with a '%5' compute construct}4"
-H43AC213E21A0: "不允许在%select{|孤立的}2 '%3' 构造体%select{|与 '%5' 计算构造体关联}4中对 '%1' 子句使用 '%0' 参数"
+H43AC213E21A0: "不允许在 %select{|孤立的}2 '%3' 构造体 %select{|与 '%5' 计算构造体关联}4中对 '%1' 子句使用 '%0' 参数"
 # "'%0' argument to '%1' clause not allowed on a '%2' construct%select{| associated with a '%4' construct}3 that has a '%5' clause"
-H08457CF75CEB: "不允许在%select{|与 '%4' 构造体关联}3的 '%2' 构造体中对带有 '%5' 子句的 '%0' 参数使用 '%1' 子句"
+H08457CF75CEB: "不允许在 %select{|与 '%4' 构造体关联}3的 '%2' 构造体中对带有 '%5' 子句的 '%0' 参数使用 '%1' 子句"
 # "'%0' as a module map name is deprecated, rename it to %select{module.modulemap|module.private.modulemap}1%select{| in the 'Modules' directory of the framework}2"
 H871445ACDF0B: "'%0' 作为模块映射名称已弃用，应重命名为 %select{module.modulemap|module.private.modulemap}1%select{|并在框架的 'Modules' 目录中}2"
 # "'%0' attribute cannot be specified on a definition"
@@ -1615,7 +1615,7 @@ H0985DFE3C8AA: "'%0' 类型转换在不使用 ARC 时没有效果"
 # "'%0' clause is specified here"
 H573F42F97FF4: "'%0' 子句在此处指定"
 # "'%0' clause not allowed on a 'kernels loop' construct that has a '%1' clause with a%select{n| 'num'}2 argument"
-HA63B4E6AC69A: "'%0' 子句不允许用于带有参数为%select{n| 'num'}2的 '%1' 子句的'kernels loop'结构"
+HA63B4E6AC69A: "'%0' 子句不允许用于带有参数为 %select{n| 'num'}2 的 '%1' 子句的 'kernels loop' 结构"
 # "'%0' clause requires 'dispatch' context selector"
 H94FAB67C930A: "'%0' 子句需要 'dispatch' 上下文选择器"
 # "'%0' clause specifies a loop count greater than the number of available loops"
@@ -1717,7 +1717,7 @@ H6BFADFD542E9: "'%0' 仅允许用于变量声明"
 # "'%0' is only available in %1"
 H468F8034CF09: "'%0' 仅在 %1 中可用"
 # "'%0' is used without '-mstack-protector-guard-offset', and there is no default"
-H8812B24333D0: "'%0' 未与'-mstack-protector-guard-offset'选项一起使用，且没有默认值"
+H8812B24333D0: "'%0' 未与 '-mstack-protector-guard-offset' 选项一起使用，且没有默认值"
 # "'%0' keyword is a C++11 extension"
 H23175F3671E1: "'%0' 关键字是C++11的扩展"
 # "'%0' keyword is incompatible with C++98"
@@ -1735,9 +1735,9 @@ H2B43B16BADDB: "'%0' 仅适用于中等和大型代码模型"
 # "'%0' option requires target HLSL Version >= 2018%select{| and shader model >= 6.2}1, but HLSL Version is '%2'%select{| and shader model is '%3'}1"
 H73FD169C1664: "'%0' 选项要求目标HLSL版本 >= 2018%select{|且着色器模型 >= 6.2}1，但HLSL版本是 '%2'%select{|且着色器模型是 '%3'}1"
 # "'%0' parameter can only be used with swiftcall%select{ or swiftasynccall|}1 calling convention%select{|s}1"
-H7F6C0A7A9011: "'%0' 参数只能与swiftcall%select{或swiftasynccall|}1调用约定%select{|s}1一起使用"
+H7F6C0A7A9011: "'%0' 参数只能与swiftcall%select{或swiftasynccall|}1 调用约定 %select{|s}1 一起使用"
 # "'%0' parameter must have pointer%select{| to unqualified pointer}1 type; type here is %2"
-HA49C073BB7A8: "'%0' 参数必须具有指针%select{|到无限定符指针}1类型；此处的类型是 %2"
+HA49C073BB7A8: "'%0' 参数必须具有指针 %select{|到无限定符指针}1类型；此处的类型是 %2"
 # "'%0' previously encountered here"
 HC082D10D967F: "'%0' 之前在这里遇到过"
 # "'%0' qualifier is not allowed on a constructor"
@@ -1773,7 +1773,7 @@ HB1E296AE95BC: "'%0' 语句不能在OpenMP for循环中使用"
 # "'%0' statement cannot be used in OpenMP simd region"
 H1C587C7353B1: "'%0' 语句不能在OpenMP simd区域中使用"
 # "'%0' type not found; include <omp.h>"
-H4CF50F4E769F: "未找到 '%0' 类型；请包含<omp.h>"
+H4CF50F4E769F: "未找到 '%0' 类型；请包含 <omp.h>"
 # "'%0' type qualifier%s1 on return type %plural{1:has|:have}1 no effect"
 H065A9C128711: "'%0' 类型限定符%s1 在返回类型 %plural{1:没有|:没有}1 效果"
 # "'%0' type specifier is incompatible with C++98"
@@ -1803,7 +1803,7 @@ HEA339F2E046F: "'%0'：无法与此工具一起使用AST文件"
 # "'%0': unable to use module files with this tool"
 H25C074B573CF: "'%0'：无法与此工具一起使用模块文件"
 # "'%0(%select{source|sink:vec}1)' clause%select{|s}1 cannot be mixed with '%0(%select{sink:vec|source}1)' clause%select{s|}1"
-H081C849E3FF9: "'%0(%select{source|sink:vec}1)' 子句%select{|s}1 不能与 '%0(%select{sink:vec|source}1)' 子句%select{s|}1 混用"
+H081C849E3FF9: "'%0(%select{source|sink:vec}1)' 子句 %select{|s}1 不能与 '%0(%select{sink:vec|source}1)' 子句 %select{s|}1 混用"
 # "'%1' attribute on property %0 does not match the property inherited from %2"
 H0392738DA622: "'%1' 属性与属性 %0 从 %2 继承的属性不匹配"
 # "'%1' cannot be used in %select{a constructor|a destructor|the 'main' function|a constexpr function|a function with a deduced return type|a varargs function|a consteval function}0"
@@ -1851,7 +1851,7 @@ H69D52A4DAF87: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null
 # "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}1' field %0 isn't within the same struct as the annotated %select{pointer|flexible array}2"
 HBD3F5637D173: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}1' 字段 %0 不在与标注的 %select{pointer|flexible array}2 同一个结构体中"
 # "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}4' %select{cannot|should not}3 be applied to %select{a pointer with pointee|an array with element}0 of unknown size because %1 is %select{an incomplete type|a sizeless type|a function type|a struct type with a flexible array member%select{|. This will be an error in a future compiler version}3}2"
-HEFA740A9E276: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}4' %select{不能|不应}3 应用于 %select{指向未知大小的指针|元素为未知大小的数组}0，因为 %1 是 %select{不完整类型|无尺寸类型|函数类型|带有柔性数组成员的结构体类型%select{|。这将在未来的编译器版本中变为错误}3}2"
+HEFA740A9E276: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}4' %select{不能|不应}3 应用于 %select{指向未知大小的指针|元素为未知大小的数组}0，因为 %1 是 %select{不完整类型|无尺寸类型|函数类型|带有柔性数组成员的结构体类型 %select{|。这将在未来的编译器版本中变为错误}3}2"
 # "'%select{if|switch}0' initialization statements are a C++17 extension"
 HBFF569602D2E: "'%select{if|switch}0' 初始化语句是 C++17 扩展"
 # "'%select{make_unsigned|make_signed}0' is only compatible with non-%select{bool|_BitInt(1)}1 integers and enum types, but was given %2%select{| whose underlying type is %4}3"
@@ -2029,7 +2029,7 @@ H99449471B7D4: "不可与变长参数函数同时使用 'append_args'"
 # "'assign' property of object type may become a dangling reference; consider using 'unsafe_unretained'"
 H7256F2B86929: "'assign' 对象类型属性可能导致悬垂引用；建议使用 'unsafe_unretained'"
 # "'atomic capture' with a compound statement only supports two statements"
-H0E46970C2D96: "'atomic capture'配合复合语句仅支持两个语句"
+H0E46970C2D96: "'atomic capture' 配合复合语句仅支持两个语句"
 # "'auto' as a functional-style cast is incompatible with C++ standards before C++23"
 HD4DCD08E6C51: "作为函数式类型转换的 'auto' 与C++23之前的标准不兼容"
 # "'auto' deduced as 'id' in declaration of %0"
@@ -2115,15 +2115,15 @@ HCA2FB0047F16: "'cpu_dispatch' 函数用不同CPU重新声明"
 # "'decltype' type specifier is incompatible with C++98"
 H06E59DDEED89: "'decltype' 类型说明符与C++98不兼容"
 # "'decltype(auto)' can only be used as a return type in a function declaration"
-H5356DF2FE6D3: "'decltype(auto)'只能用作函数声明的返回类型"
+H5356DF2FE6D3: "'decltype(auto)' 只能用作函数声明的返回类型"
 # "'decltype(auto)' cannot be combined with other type specifiers"
-H139F443827AC: "'decltype(auto)'不能与其他类型说明符组合使用"
+H139F443827AC: "'decltype(auto)' 不能与其他类型说明符组合使用"
 # "'decltype(auto)' not allowed here"
-HA795F2923798: "'decltype(auto)'在此处不允许"
+HA795F2923798: "'decltype(auto)' 在此处不允许"
 # "'decltype(auto)' type specifier is a C++14 extension"
-H7E1DB4CB833F: "'decltype(auto)'类型说明符是C++14扩展"
+H7E1DB4CB833F: "'decltype(auto)' 类型说明符是C++14扩展"
 # "'decltype(auto)' type specifier is incompatible with C++ standards before C++14"
-HA38CAC8829B9: "'decltype(auto)'类型说明符与C++14之前的C++标准不兼容"
+HA38CAC8829B9: "'decltype(auto)' 类型说明符与C++14之前的C++标准不兼容"
 # "'default' statement not in switch statement"
 H1133498536DD: "'default' 语句不在switch语句中"
 # "'defined' cannot appear within this context"
@@ -2177,7 +2177,7 @@ H021467CD0886: "'gnu_inline' 属性在 C++ 中若未带 'extern' 则被视为外
 # "'hybrid_patchable' is ignored on functions without external linkage"
 H0ADF7398ED3A: "'hybrid_patchable' 在没有外部链接性的函数上被忽略"
 # "'inline' can only appear on functions%select{| and non-local variables}0"
-H89E78E1738F9: "'inline' 只能出现在函数%select{|和非局部变量}0 上"
+H89E78E1738F9: "'inline' 只能出现在函数 %select{|和非局部变量}0 上"
 # "'inscan' modifier can be used only in 'omp for', 'omp simd', 'omp for simd', 'omp parallel for', or 'omp parallel for simd' directive"
 HD994FA838907: "'inscan' 修饰符只能在 'omp for'、'omp simd'、'omp for simd'、'omp parallel for' 或 'omp parallel for simd' 指令中使用"
 # "'internal_linkage' attribute on a non-static local variable is ignored"
@@ -2263,13 +2263,13 @@ HB68377C1CB34: "'new' 不能分配可变长度类型 %0 的对象"
 # "'new' cannot allocate objects of type %0 in address space '%1'"
 H8F2EE8209986: "'new' 不能在 '%1' 地址空间中分配类型 %0 的对象"
 # "'new' expression with placement arguments refers to non-placement 'operator delete'"
-H9A938FDFCB36: "带有placement参数的 'new' 表达式指向非placement的'operator delete'"
+H9A938FDFCB36: "带有placement参数的 'new' 表达式指向非placement的 'operator delete'"
 # "'nocf_check' attribute ignored; use -fcf-protection to enable the attribute"
 HCD98AFA044EC: "'nocf_check' 属性被忽略；请使用-fcf-protection选项启用该属性"
 # "'noderef' can only be used on an array or pointer type"
 H265BDBEEC1EC: "'noderef' 只能用于数组或指针类型"
 # "'noexcept' can only be used in a compound requirement (with '{' '}' around the expression)"
-H88CA64B4E3F6: "'noexcept' 只能用于复合需求（需用'{' '}'包裹表达式）"
+H88CA64B4E3F6: "'noexcept' 只能用于复合需求（需用 '{' '}' 包裹表达式）"
 # "'nonmonotonic' modifier can only be specified with 'dynamic' or 'guided' schedule kind"
 H60F2BCD19874: "'nonmonotonic' 修饰符只能与 'dynamic' 或 'guided' 调度类型一起使用"
 # "'nonnull' attribute applied to function with no pointer arguments"
@@ -2311,7 +2311,7 @@ HC1D7E6DA4A9D: "在这里声明的 'operator->' 会产生类型为 %0 的对象"
 # "'ordered' clause with a parameter cannot be specified in '#pragma omp %0' directive"
 HE291A06801DB: "带有参数的 'ordered' 子句不能在 '#pragma omp %0' 指令中指定"
 # "'ordered' clause%select{| with specified parameter}0"
-H337028DA61A4: "'ordered' 子句%select{| 带指定参数}0"
+H337028DA61A4: "'ordered' 子句 %select{| 带指定参数}0"
 # "'ordered' directive %select{without any clauses|with 'threads' clause}0 cannot be closely nested inside ordered region with specified parameter"
 HB16FD1003ED0: "'ordered' 指令%select{无任何子句|带有 'threads' 子句}0 不能紧密嵌套在带有指定参数的有序区域内部"
 # "'ordered' directive with '%0' clause cannot be closely nested inside ordered region without specified parameter"
@@ -2329,7 +2329,7 @@ H8DB05E11AD0A: "在旧版 GCC 和 Clang 中，'packed' 属性会忽略单字节�
 # "'reduction' clause cannot be used with 'nogroup' clause"
 H186A32581806: "'reduction' 子句不能与 'nogroup' 子句一起使用"
 # "'reduction' clause not allowed with '#pragma omp loop bind(teams)'"
-H4981CB6A6643: "不允许在'#pragma omp loop bind(teams)'中使用 'reduction' 子句"
+H4981CB6A6643: "不允许在 '#pragma omp loop bind(teams)' 中使用 'reduction' 子句"
 # "'reduction' clause with 'inscan' modifier is used here"
 HE04EBCC11985: "带有 'inscan' 修饰符的 'reduction' 子句在此处使用"
 # "'reduction' clause with 'task' modifier allowed only on non-simd parallel or worksharing constructs"
@@ -2375,7 +2375,7 @@ H01C26A9D5D7B: "'size_t' 后缀的字面量与C++23之前的C++标准不兼容"
 # "'static' can only be specified inside the class definition"
 HC2C3574A2AC5: "'static' 只能在类定义内部指定"
 # "'static' function %0 declared in header file should be declared 'static inline'"
-HAC6B8325923D: "在头文件中声明的 'static' 函数 %0 应声明为'static inline'"
+HAC6B8325923D: "在头文件中声明的 'static' 函数 %0 应声明为 'static inline'"
 # "'static' may not be used with an unspecified variable length array size"
 H8C886B8B17D3: "'static' 不能与未指定的可变长度数组大小一起使用"
 # "'static' may not be used without an array size"
@@ -2393,11 +2393,11 @@ H89070CD2F991: "无消息的 'static_assert' 是C++17扩展"
 # "'static_assert' with no message is incompatible with C++ standards before C++17"
 HFE8F37E6AE5C: "无消息的 'static_assert' 与C++17之前的C++标准不兼容"
 # "'std::allocator<...>::deallocate' used to delete a null pointer"
-HF2B279909DBC: "'std::allocator<...>::deallocate'被用来删除空指针"
+HF2B279909DBC: "'std::allocator<...>::deallocate' 被用来删除空指针"
 # "'std::source_location::__impl' must be standard-layout and have only two 'const char *' fields '_M_file_name' and '_M_function_name', and two integral fields '_M_line' and '_M_column'"
-HCA27D3915F0B: "'std::source_location::__impl'必须是标准布局类型，并且只有两个'const char *'类型的字段 '_M_file_name' 和 '_M_function_name'，以及两个整数类型的字段 '_M_line' 和 '_M_column'"
+HCA27D3915F0B: "'std::source_location::__impl' 必须是标准布局类型，并且只有两个 'const char *' 类型的字段 '_M_file_name' 和 '_M_function_name'，以及两个整数类型的字段 '_M_line' 和 '_M_column'"
 # "'std::source_location::__impl' was not found; it must be defined before '__builtin_source_location' is called"
-HD0F806FB73A8: "'std::source_location::__impl'未找到；它必须在调用 '__builtin_source_location' 之前被定义"
+HD0F806FB73A8: "'std::source_location::__impl' 未找到；它必须在调用 '__builtin_source_location' 之前被定义"
 # "'super' is only valid in a method body"
 HB06D73D4C0E7: "'super' 仅在方法体内有效"
 # "'swift_async' completion handler parameter must have block type returning 'void', type here is %0"
@@ -2421,7 +2421,7 @@ H14251E8B39CA: "'sycl_kernel_entry_point' 属性仅适用于具有非推导 'voi
 # "'sycl_kernel_entry_point' kernel name argument conflicts with a previous declaration"
 HFAE6DB6B8BBB: "'sycl_kernel_entry_point' 内核名称参数与之前的声明冲突"
 # "'sycl_kernel_entry_point' kernel name argument does not match prior declaration%diff{: $ vs $|}0,1"
-H6714A3237372: "'sycl_kernel_entry_point' 内核名称参数与之前的声明不匹配%diff{: $ vs $|}0,1"
+H6714A3237372: "'sycl_kernel_entry_point' 内核名称参数与之前的声明不匹配 %diff{: $ vs $|}0,1"
 # "'target_clones' attribute does not match previous declaration"
 HBD2CF88C376B: "'target_clones' 属性与之前的声明不匹配"
 # "'target_clones' multiversioning requires a default target"
@@ -2443,11 +2443,11 @@ HB5D291C13072: "成员函数 %0 的 'this' 参数类型为 %1，但函数未标�
 # "'this' argument to member function %0 is an %select{lvalue|rvalue}1, but function has %select{non-const lvalue|rvalue}2 ref-qualifier"
 H0AF4BFFD004C: "成员函数 %0 的 'this' 参数是 %select{lvalue|rvalue}1 类型，但函数具有 %select{非 const lvalue|rvalue}2 引用限定符"
 # "'this' cannot be %select{implicitly |}0captured in this context"
-H0697D44E3441: "'this' 在此上下文中不能%select{隐式|}0被捕获"
+H0697D44E3441: "'this' 在此上下文中不能%select{隐式|}0 被捕获"
 # "'this' cannot be captured by reference"
 H13B6762030CD: "'this' 不能通过引用来捕获"
 # "'this' cannot be%select{| implicitly}0 used in a static member function declaration"
-H4C9AC15A6831: "静态成员函数声明中%select{|隐式}0不能使用 'this'"
+H4C9AC15A6831: "静态成员函数声明中 %select{|隐式}0不能使用 'this'"
 # "'this' pointer cannot be null in well-defined C++ code; comparison may be assumed to always evaluate to %select{true|false}0"
 HC979F6DEC864: "'this' 指针在符合 C++ 标准的代码中不能为 null；该比较可能被假定始终评估为 %select{true|false}0"
 # "'this' pointer cannot be null in well-defined C++ code; pointer may be assumed to always convert to true"
@@ -2503,9 +2503,9 @@ H3B7FE1A42F0E: "作为参数的 'void' 不能带有类型限定符"
 # "'void' must be the first and only parameter if specified"
 H7DDAB71DFE28: "如果指定了 'void'，它必须是唯一的且第一个参数"
 # "'||' of a value and its negation always evaluates to true"
-H067D990351EF: "一个值与其否定的'||'运算结果始终为真"
+H067D990351EF: "一个值与其否定的 '||' 运算结果始终为真"
 # "'~' in destructor name should be after nested name specifier"
-H85ED3FE9838A: "析构函数名称中的'~'应位于嵌套名称限定符之后"
+H85ED3FE9838A: "析构函数名称中的 '~' 应位于嵌套名称限定符之后"
 # "(Deprecated) Controls whether '-Winvalid-gnu-asm-cast' defaults to an error or a warning"
 HBE7A04BC29B9: "(已弃用) 控制 '-Winvalid-gnu-asm-cast' 默认为错误还是警告"
 # "(For new pass manager) 'per-pass': one report for each pass; 'per-pass-run': one report for each pass invocation"
@@ -2875,11 +2875,11 @@ H07C815591653: '测试用的pass管线的文本描述'
 # "A textual description of the pass pipeline, same as what's passed to `opt -passes`."
 HAD654D568007: '与`opt -passes`传递的内容相同的pass管线的文本描述'
 # 'A textual description of the pass pipeline. To have analysis passes available before a certain pass, add "require<foo-analysis>".'
-H799364B80DF3: 'pass管线的文本描述。要在某个pass之前提供分析pass，请添加"require<foo-analysis>"。'
+H799364B80DF3: 'pass管线的文本描述。要在某个pass之前提供分析pass，请添加 "require<foo-analysis>"。'
 # "A textual description of the pass pipeline. To have analysis passes available before a certain pass, add 'require<foo-analysis>'."
-HB92573A0FB9B: "pass管线的文本描述。要在某个pass之前提供分析pass，请添加'require<foo-analysis>'。"
+HB92573A0FB9B: "pass管线的文本描述。要在某个pass之前提供分析pass，请添加 'require<foo-analysis>'。"
 # "A textual description of the pass pipeline. To have analysis passes available before a certain pass, add 'require<foo-analysis>'. '-passes' overrides the pass pipeline (but not all effects) from specifying '--opt-level=O?' (O2 is the default) to clang-linker-wrapper.  Be sure to include the corresponding 'default<O?>' in '-passes'."
-H4608F37A5D56: 'pass管线的文本描述。要在某个pass之前提供分析pass，请添加\'require<foo-analysis>\'。"-passes"会覆盖clang-linker-wrapper中通过指定"--opt-level=O?"（默认O2）设置的pass管线（但并非所有效果）。请确保在"-passes"中包含对应的"default<O?>"。'
+H4608F37A5D56: 'pass管线的文本描述。要在某个pass之前提供分析pass，请添加\'require<foo-analysis>\'。"-passes" 会覆盖clang-linker-wrapper中通过指定 "--opt-level=O?"（默认O2）设置的pass管线（但并非所有效果）。请确保在 "-passes" 中包含对应的 "default<O?>"。'
 # 'A threshold controls whether an indirect call will be specialized'
 HE03B79F00E10: '一个阈值控制间接调用是否会被特化'
 # 'A threshold of live range size which may cause high compile time cost in global splitting.'
@@ -3027,7 +3027,7 @@ H5B6E5D0BD096: '浮点运算交换分析'
 # 'API notes replacement type %0 has a different size from original type %1'
 HB87A25B6CDE7: 'API注释中的替换类型 %0 与原始类型 %1 的大小不同'
 # 'ARC %select{unused|__unsafe_unretained|__strong|__weak|__autoreleasing}0 lifetime qualifier on return type is ignored'
-H4E4E8ED8984D: 'ARC忽略返回类型上的%select{未使用的|__unsafe_unretained|__strong|__weak|__autoreleasing}0生命周期限定符'
+H4E4E8ED8984D: 'ARC忽略返回类型上的%select{未使用的|__unsafe_unretained|__strong|__weak|__autoreleasing}0 生命周期限定符'
 # 'ARC DAG->DAG Pattern Instruction Selection'
 H40C54AF1B605: 'ARC DAG->DAG 模式指令选择'
 # 'ARC finalize branches'
@@ -3217,7 +3217,7 @@ H4E8397371575: '添加目录到Objective-C++语言SYSTEM包含搜索路径'
 # 'Add directory to the end of the list of include search paths'
 HA9C01D5A6394: '将目录添加到包含搜索路径列表的末尾'
 # 'Add directory to the internal system include search path with implicit extern "C" semantics; these are assumed to not be user-provided and are used to model system and standard headers\' paths.'
-HA6F738C6C497: '添加目录到内部系统包含搜索路径并隐含extern "C"语义；这些路径不被视为用户提供的，并用于模拟系统和标准头文件的路径。'
+HA6F738C6C497: '添加目录到内部系统包含搜索路径并隐含extern "C" 语义；这些路径不被视为用户提供的，并用于模拟系统和标准头文件的路径。'
 # "Add directory to the internal system include search path; these are assumed to not be user-provided and are used to model system and standard headers' paths."
 H76AF34D02BE9: '添加目录到内部系统包含搜索路径；这些路径不被视为用户提供的，并用于模拟系统和标准头文件的路径。'
 # 'Add dirs in env var <var> to include search path with warnings suppressed'
@@ -3415,7 +3415,7 @@ H93CADD3D554F: '对齐的分配/释放函数不可用'
 # 'Alignment of bundle for binary files'
 H746C20CFEB90: '二进制文件的捆绑对齐'
 # "All compile commands come from LSP and 'compile_commands.json' files are ignored"
-H35E96D7E99B1: "所有编译命令均来自LSP，忽略'compile_commands.json'文件"
+H35E96D7E99B1: "所有编译命令均来自LSP，忽略 'compile_commands.json' 文件"
 # "All compile commands come from the 'compile_commands.json' files"
 H2E03660ADBFF: "所有编译命令均来自 'compile_commands.json' 文件"
 # 'All decisions not in replay are inlined'
@@ -3987,11 +3987,11 @@ H7F681232E46A: '基本类型（int、bool等）。'
 # 'Base cost of vector insert/extract element'
 HA29AACEEF76F: '向量插入/提取元素的基础耗时'
 # 'Base file path for the interactive mode. The incoming filename should have the name <inliner-interactive-channel-base>.in, while the outgoing name should be <inliner-interactive-channel-base>.out'
-HED13A1932932: '交互模式的基础文件路径。输入文件名应为<inliner-interactive-channel-base>.in，输出文件名应为<inliner-interactive-channel-base>.out'
+HED13A1932932: '交互模式的基础文件路径。输入文件名应为 <inliner-interactive-channel-base>.in，输出文件名应为 <inliner-interactive-channel-base>.out'
 # 'Base file path for the interactive mode. The incoming filename should have the name <regalloc-evict-interactive-channel-base>.in, while the outgoing name should be <regalloc-evict-interactive-channel-base>.out'
-HEEBA85373FA8: '交互模式的基础文件路径。输入文件名应为<regalloc-evict-interactive-channel-base>.in，输出文件名应为<regalloc-evict-interactive-channel-base>.out'
+HEEBA85373FA8: '交互模式的基础文件路径。输入文件名应为 <regalloc-evict-interactive-channel-base>.in，输出文件名应为 <regalloc-evict-interactive-channel-base>.out'
 # 'Base file path for the interactive mode. The incoming filename should have the name <regalloc-priority-interactive-channel-base>.in, while the outgoing name should be <regalloc-priority-interactive-channel-base>.out'
-H9411EE803DAA: '交互模式的基础文件路径。输入文件名应为<regalloc-priority-interactive-channel-base>.in，输出文件名应为<regalloc-priority-interactive-channel-base>.out'
+H9411EE803DAA: '交互模式的基础文件路径。输入文件名应为 <regalloc-priority-interactive-channel-base>.in，输出文件名应为 <regalloc-priority-interactive-channel-base>.out'
 # 'Base penalty for splitting cold code (as a multiple of TCC_Basic)'
 H9A157E9C325A: '冷代码拆分的基础惩罚值（作为TCC_Basic的倍数）'
 # 'Base types (int, bool, etc.).'
@@ -4267,7 +4267,7 @@ H4386F29D7C1C: "CUDA 特殊函数 '%0' 必须有标量返回类型"
 # 'CUDA version %0 is only partially supported'
 HABB5F3AD45B9: 'CUDA 版本 %0 仅部分支持'
 # 'CUDA version%0 is newer than the latest%select{| partially}1 supported version %2'
-HC8470F3A3C10: 'CUDA 版本 %0 比最新%select{| 部分}1 支持的版本 %2 更新'
+HC8470F3A3C10: 'CUDA 版本 %0 比最新 %select{| 部分}1 支持的版本 %2 更新'
 # 'CXX Dump Options'
 HEC70FF6EBB76: 'CXX转储选项'
 # 'CXX Map Options'
@@ -4521,9 +4521,9 @@ H454E7FBEF67B: '用逗号分隔的通配符列表，用于白名单筛选安全�
 # 'Comma separated list of locations to filter actions from logging'
 H089CBD249A00: '要从日志中过滤操作的位置列表，用逗号分隔'
 # "Comma-separated list of comment prefixes to use from check file\n(defaults to 'COM,RUN'). Please avoid using this feature in\nLLVM's LIT-based test suites, which should be easier to\nmaintain if they all follow a consistent comment style. This\nfeature is meant for non-LIT test suites using FileCheck."
-H40AA0BE08629: "来自检查文件的注释前缀列表，用逗号分隔（默认为'COM,RUN'）。请避免在LLVM的基于LIT的测试套件中使用此功能，这些套件应遵循一致的注释风格以便维护。此功能专为使用FileCheck的非LIT测试套件设计。"
+H40AA0BE08629: "来自检查文件的注释前缀列表，用逗号分隔（默认为 'COM,RUN'）。请避免在LLVM的基于LIT的测试套件中使用此功能，这些套件应遵循一致的注释风格以便维护。此功能专为使用FileCheck的非LIT测试套件设计。"
 # "Comma-separated list of globs describing the list of callbacks to output. Globs are processed in order of appearance. Globs with the '-' prefix remove callbacks from the set. e.g. '*,-Macro*'."
-HB2EA0F3C4C38: '用通配符描述的回调列表，按出现顺序处理。带"-"前缀的通配符将从集合中移除回调。例如：*,-Macro*'
+HB2EA0F3C4C38: '用通配符描述的回调列表，按出现顺序处理。带 "-" 前缀的通配符将从集合中移除回调。例如：*,-Macro*'
 # 'Comma-separated list of vectorizer passes. If not set we run the predefined pipeline.'
 H5F9267E8F02A: '向量化pass的逗号分隔列表。若未设置则运行预定义管线。'
 # 'Command line options to pass to the downstream compiler.'
@@ -4541,7 +4541,7 @@ H10812CD37717: '比较选项'
 # 'Compare all elements.'
 HD1160DBAE7C6: '比较所有元素。'
 # 'Compare bits 62 and 61 of address (TBI should be disabled)'
-HC1881DEFBF5A: '比较地址的第 62 和 61位（应禁用TBI）'
+HC1881DEFBF5A: '比较地址的第 62 和 61 位（应禁用TBI）'
 # 'Compare with the result of XPAC (requires Armv8.3-a)'
 HBA5A269FECBF: '与XPAC的结果进行比较（需要Armv8.3-a）'
 # 'Compare with the result of XPACLRI'
@@ -4673,7 +4673,7 @@ HE1318392829D: '控制 vtordisp 的放置'
 # 'Control vtordisp placement on win32 targets'
 H1B28D470DA9E: '在 win32 目标平台上控制 vtordisp 的放置'
 # "Control where files for distributed backends are created. Expects 'oldprefix;newprefix' and if path prefix of output file is oldprefix it will be replaced with newprefix."
-HC0263D605A37: "控制分布式后端文件的创建位置。期望格式为'oldprefix;newprefix'，如果输出文件的路径前缀是oldprefix，则将其替换为newprefix。"
+HC0263D605A37: "控制分布式后端文件的创建位置。期望格式为 'oldprefix;newprefix'，如果输出文件的路径前缀是oldprefix，则将其替换为newprefix。"
 # 'Control whether the compiler can use scalable vectors to vectorize a loop'
 H6A90BC2050A3: '控制编译器是否可以使用可扩展向量来向量化循环'
 # 'Control whether unstable and experimental library features are enabled. This option enables various library features that are either experimental (also known as TSes), or have been but are not stable yet in the selected Standard Library implementation. It is not recommended to use this option in production code, since neither ABI nor API stability are guaranteed. This is intended to provide a preview of features that will ship in the future for experimentation purposes'
@@ -4835,7 +4835,7 @@ HD35403A45243: '在函数边界处消除危险'
 # 'Cull hazards on memory waits'
 HF9A83C7746B5: '在内存等待时消除危险'
 # 'Cutoff for generating "extract" instructions'
-HF67D76A2F279: '生成"extract"指令的阈值'
+HF67D76A2F279: '生成 "extract" 指令的阈值'
 # 'Cutoff percentages (times 10000) for generating detailed summary'
 HF12B62925337: '生成详细摘要的百分比阈值（乘以 10000）'
 # 'Cutoff value about how many symbols in profile symbol list will be used. This is very useful for performance debugging'
@@ -4983,7 +4983,7 @@ H7E06B3502FFA: '默认类型可见性'
 # 'Defer host/device related diagnostic messages for CUDA/HIP'
 HD7B0D94624F9: '延迟显示CUDA/HIP相关的主机/设备诊断信息'
 # "Define '__STDC__' to '1' in MSVC Compatibility mode"
-HE12E4DC30513: '在MSVC兼容模式下将"__STDC__"定义为"1"'
+HE12E4DC30513: '在MSVC兼容模式下将 "__STDC__" 定义为 "1"'
 # 'Define <macro> to <value> (or 1 if <value> omitted)'
 HC9C0FAB29C48: '将宏 <macro> 定义为 <value>（若省略 <value> 则定义为 1）'
 # 'Define __STDC__'
@@ -5037,9 +5037,9 @@ HB203EF80F1D6: '已弃用（类似于未指定/EH参数）'
 # 'Deprecated (set output file name); use /Fe or /Fe'
 H43E83CDF9C2D: '已弃用（设置输出文件名）；请改用/Fe或/Fe'
 # "Deprecated; use '-O3 -ffast-math -fstack-arrays' for the same behavior, or '-O3 -fstack-arrays' to enable only conforming optimizations"
-H894A29167B0A: '已弃用；如需相同行为请使用"-O3 -ffast-math -fstack-arrays"，或使用"-O3 -fstack-arrays"仅启用符合标准的优化'
+H894A29167B0A: '已弃用；如需相同行为请使用 "-O3 -ffast-math -fstack-arrays"，或使用 "-O3 -fstack-arrays" 仅启用符合标准的优化'
 # "Deprecated; use '-O3 -ffast-math' for the same behavior, or '-O3' to enable only conforming optimizations"
-H68FB98DB67B0: '已弃用；如需相同行为请使用"-O3 -ffast-math"，或使用"-O3"仅启用符合标准的优化'
+H68FB98DB67B0: '已弃用；如需相同行为请使用 "-O3 -ffast-math"，或使用 "-O3" 仅启用符合标准的优化'
 # 'Deprecated; use /EHsc'
 H0521F1C5E495: '已弃用；请改用/EHsc'
 # 'Depth limit for finding address space through traversal'
@@ -5059,7 +5059,7 @@ H2FE6FC8C4E2A: '检测并行性'
 # 'Detect single entry single exit regions'
 H9F71476F6AF4: '检测单入口单出口区域'
 # "Detect stack use after return if binary flag 'ASAN_OPTIONS=detect_stack_use_after_return' is set."
-H52A7D51EA3C5: "如果二进制标志'ASAN_OPTIONS=detect_stack_use_after_return'被设置，则检测栈使用后返回的情况。"
+H52A7D51EA3C5: "如果二进制标志 'ASAN_OPTIONS=detect_stack_use_after_return' 被设置，则检测栈使用后返回的情况。"
 # 'Determine based on deployment target'
 H73C787FF3B61: '根据部署目标确定'
 # 'Determine what attributes are manifested in the IR'
@@ -5551,7 +5551,7 @@ H9F6E8121BA35: '禁用不可分配物理寄存器复制优化'
 # 'Disable odd single-precision floating point registers'
 HC69012E33908: '禁用奇数单精度浮点寄存器'
 # "Disable omitting 'dls lr, lr' instructions"
-HBB8A633ECC4C: "禁用省略'dls lr, lr'指令"
+HBB8A633ECC4C: "禁用省略 'dls lr, lr' 指令"
 # 'Disable on-demand initialization of thread-local variables'
 HD53AA5AC4AC6: '禁用线程局部变量的按需初始化'
 # 'Disable one or more combiner rules temporarily in '
@@ -5813,7 +5813,7 @@ H8C53B2F32644: '禁用转换解释器中可能昂贵的检查，以更快的速�
 # 'Disables the global instruction selector'
 HD7298FC773DA: '禁用全局指令选择器'
 # "Disallow '$' in identifiers"
-HEC529DE7E6EB: '禁止在标识符中使用"$"'
+HEC529DE7E6EB: '禁止在标识符中使用 "$"'
 # 'Disallow MIPS delay filler to search backward.'
 H93B2211830F9: '禁止MIPS延迟填充向后搜索。'
 # 'Disallow MIPS delay filler to search forward.'
@@ -5823,7 +5823,7 @@ H806FD91060E7: '禁止MIPS延迟填充搜索后续基本块。'
 # 'Disallow __declspec as a keyword'
 HC17ADE50EB84: '禁用将__declspec作为关键字'
 # "Disallow alternative token representations '<:', ':>', '<%', '%>', '%:', '%:%:'"
-HF519C51A2110: '禁止使用替代的标记表示形式"<:", ":>", "<%", "%>", "%:", "%:%:"'
+HF519C51A2110: '禁止使用替代的标记表示形式 "<:", ":>", "<%", "%>", "%:", "%:%:"'
 # 'Disallow atomic operations to ignore denormal mode'
 HE8CD8EB9071A: '禁止原子操作忽略非正规模式'
 # 'Disallow complex IT blocks'
@@ -6357,7 +6357,7 @@ H2C209A90E709: '不为以下参数生成有关未使用参数的警告'
 # "Don't error out if the detected version of the CUDA install is too low for the requested CUDA gpu architecture."
 H16AC4195802C: '若检测到的CUDA安装版本过低且无法支持请求的CUDA GPU架构时，不报错'
 # "Don't expand conditional move related pseudos for Mips 16"
-H68A3ACC276BC: '不展开Mips 16相关的条件移动伪指令'
+H68A3ACC276BC: '不展开Mips 16 相关的条件移动伪指令'
 # "Don't export branch data (LCOV)"
 H15B1E91EF10C: '不导出分支数据（LCOV）'
 # "Don't export expanded source regions"
@@ -6733,7 +6733,7 @@ H1150FC4D6BB7: '要打印的元素。'
 # 'Elements to compare.'
 H7D8A91E768C7: '要比较的元素。'
 # 'Elide ElementsAttrs with "..." that have more elements than the given upper limit'
-HE475543A5C00: '省略具有超过给定上限元素的"..."形式的ElementsAttrs'
+HE475543A5C00: '省略具有超过给定上限元素的 "..." 形式的ElementsAttrs'
 # 'Elide printing value of resources if string is too long in chars.'
 H89DF7B30813D: '如果字符串过长（以字符为单位），则省略资源值的打印。'
 # 'Elide resources when generating bytecode'
@@ -6833,7 +6833,7 @@ H7926ECB4152F: '生成对陷井函数的调用而非陷井指令'
 # 'Emit a compilation database fragment to the specified directory'
 HBAB9D592240A: '将编译数据库片段输出到指定目录'
 # 'Emit a diagnostic when "fast" instruction selection falls back to SelectionDAG.'
-H88EB0DEF1034: '当"fast"指令选择回退到SelectionDAG时生成诊断信息'
+H88EB0DEF1034: '当 "fast" 指令选择回退到SelectionDAG时生成诊断信息'
 # 'Emit a fatal error if format parsing fails'
 H0EBAF7E7ADAA: '如果格式解析失败则生成致命错误'
 # "Emit a native object ('.o') file"
@@ -7007,7 +7007,7 @@ H2EC78B18E661: '在全局指令选择中启用/禁用SVE可扩展向量'
 # 'Enable / disable promotion of unnamed_addr constants into constant pools'
 HFAE28EE53BD3: '启用/禁用将unnamed_addr常量提升到常量池'
 # 'Enable 16-bit types and disable min precision types.Available in HLSL 2018 and shader model 6.2.'
-HAAC77E9561C2: '启用 16 位类型并禁用最小精度类型。适用于HLSL 2018和着色器模型 6.2。'
+HAAC77E9561C2: '启用 16 位类型并禁用最小精度类型。适用于HLSL 2018 和着色器模型 6.2。'
 # 'Enable <feature> in module map requires declarations'
 H5C8DA92AFFD8: '在模块映射需要声明时启用 <feature>'
 # 'Enable AArch64 SME memory operations to lower to librt functions'
@@ -7273,7 +7273,7 @@ H407986FED01C: '在v68上启用浮点类型（floatint point types）的自动�
 # 'Enable basic block tracing in sanitizer coverage'
 HB288E3CF4716: '启用sanitizer覆盖中的基本块跟踪'
 # 'Enable binary and hex Motorola integers (%110 and $ABC)'
-H929D942FA2B2: '启用二进制和十六进制Motorola整数（%110和$ABC）'
+H929D942FA2B2: '启用二进制和十六进制Motorola整数（%110 和$ABC）'
 # 'Enable binary and hex masm integers (0b110 and 0ABCh)'
 H299555A297D6: '启用二进制和十六进制masm整数（0b110和 0ABCh）'
 # 'Enable binary output on terminals'
@@ -7295,7 +7295,7 @@ HB9B531DB1BD2: '启用插入符号和列诊断（默认）'
 # 'Enable casting unknown expression results to id'
 H1BB41E97517E: '启用将未知表达式结果强制转换为id'
 # "Enable cf-protection in 'full' mode"
-HB3ADE4BC6E10: '在"full"模式下启用cf保护'
+HB3ADE4BC6E10: '在 "full" 模式下启用cf保护'
 # 'Enable chain commoning in PPC loop prepare pass.'
 HA72C1C0CBB48: '在PPC循环准备pass中启用链式公共子表达式优化。'
 # 'Enable char8_t from C++2a'
@@ -7831,7 +7831,7 @@ HB827608C6F32: '启用“快速”指令选择器'
 # 'Enable the "global" instruction selector'
 HC28B60B42675: '启用“全局”指令选择器'
 # "Enable the 'blocks' language feature"
-H8A0F69B5F85C: '启用"blocks"语言特性'
+H8A0F69B5F85C: '启用 "blocks" 语言特性'
 # "Enable the 'modules' language feature"
 H047278B48AFB: "启用 'modules' 语言特性"
 # 'Enable the AArch64 branch target pass'
@@ -8417,7 +8417,7 @@ H44D35D906559: '要检查的文件（默认为stdin）'
 # 'File to emit dot graph of new summary into'
 HB22275C53F6F: '将新摘要的dot图输出的文件'
 # 'File to read (analysis mode) or write (latency/uops/inverse_throughput modes) benchmark results. “-” uses stdin/stdout.'
-H44970F94DF2D: '读取（分析模式）或写入（延迟/uops/逆吞吐量模式）基准测试结果的文件。 "-"使用stdin/stdout。'
+H44970F94DF2D: '读取（分析模式）或写入（延迟/uops/逆吞吐量模式）基准测试结果的文件。 "-" 使用stdin/stdout。'
 # 'File to record the coroutines got elided'
 H175805F86595: '记录被省略的协程的文件'
 # 'File with the profile data obtained after an instrumented run'
@@ -8497,7 +8497,7 @@ HE1AD57EFF1BD: '视图拆分的文件夹名称。'
 # 'Folds all regular instructions (including pre-outputs)'
 HB765A3FB1AB5: '折叠所有常规指令（包括预输出指令）'
 # 'Follow Fortran 2003 rules for (re)allocating the LHS of the intrinsic assignment'
-H1CD29CD7E654: '遵循Fortran 2003规则重新分配固有赋值的左操作数'
+H1CD29CD7E654: '遵循Fortran 2003 规则重新分配固有赋值的左操作数'
 # 'Follow the AAPCS standard requirement stating that volatile bit-field width is dictated by the field container type. (ARM only).'
 H318AB39D2C02: '遵循AAPCS标准要求，即volatile位字段的宽度由字段容器类型决定。（仅限ARM）'
 # 'Follows the AAPCS standard that all volatile bit-field write generates at least one load. (ARM only).'
@@ -8545,7 +8545,7 @@ H3D3679C30C18: '在调试信息中，将目录 <old> 重映射为 <new>。如果
 # 'For sample profiles, list function names (with calling context for csspgo) for overlapped functions with similarities below the cutoff (percentage times 10000).'
 H463D2852BF2F: '对于采样配置文件，列出相似度低于阈值（百分比乘以 10000）的重叠函数名称（包含csspgo的调用上下文）'
 # 'For shared library loaded with the main program, change local-dynamic access(es) to initial-exec access(es) at the function level (AIX 64-bit only).'
-HD94E43E648D1: '针对与主程序一起加载的共享库，在函数级别将local-dynamic访问模式更改为initial-exec访问模式（仅限AIX 64位）'
+HD94E43E648D1: '针对与主程序一起加载的共享库，在函数级别将local-dynamic访问模式更改为initial-exec访问模式（仅限AIX 64 位）'
 # 'For show, read and extract profile metadata from debug info and show the functions it found. For merge, use the provided debug info to correlate the raw profile.'
 H3F78033E8267: '在显示时，从调试信息中读取并提取配置文件元数据并显示找到的函数。在合并时，使用提供的调试信息关联原始配置文件'
 # 'For symbols in profile symbol list, regard their profiles to be accurate. It may be overridden by profile-sample-accurate. '
@@ -8803,13 +8803,13 @@ H7F5648C19468: 'GNU OpenMP'
 # 'GNU decimal type extension not supported'
 HE1719E002830: 'GNU十进制类型扩展未被支持'
 # 'GNU vector conditional operand cannot be %select{void|a throw expression}0'
-H5DF13110207F: 'GNU向量条件操作数不能是%select{void|throw表达式}0'
+H5DF13110207F: 'GNU向量条件操作数不能是 %select{void|throw表达式}0'
 # 'GNU-style inline assembly is disabled'
 H2E56E6455BF0: '已禁用GNU风格的内联汇编'
 # 'GNUstep Objective-C runtime version %0 incompatible with target binary format'
 HBFB3FAB065B9: 'GNUstep Objective-C运行时版本 %0 与目标二进制格式不兼容'
 # "GPU arch %0 is supported by CUDA versions between %1 and %2 (inclusive), but installation at %3 is %4; use '--cuda-path' to specify a different CUDA install, pass a different GPU arch with '--cuda-gpu-arch', or pass '--no-cuda-version-check'"
-HA444373A0822: "GPU架构 %0 在CUDA %1 到 %2 版本（含）中受支持，但 %3 处的安装版本为 %4；请使用'--cuda-path'指定其他CUDA安装路径，或通过'--cuda-gpu-arch'指定不同GPU架构，或使用'--no-cuda-version-check'禁用版本检查"
+HA444373A0822: "GPU架构 %0 在CUDA %1 到 %2 版本（含）中受支持，但 %3 处的安装版本为 %4；请使用 '--cuda-path' 指定其他CUDA安装路径，或通过 '--cuda-gpu-arch' 指定不同GPU架构，或使用 '--no-cuda-version-check' 禁用版本检查"
 # 'Gang up loads and stores generated by inlining of memcpy'
 HE535C0271E93: '通过内联memcpy生成的合并加载和存储操作'
 # 'Gate the invocation of the tracing callbacks on a global variable. Currently only supported for trace-pc-guard and trace-cmp.'
@@ -9215,13 +9215,13 @@ H5EEF255AAE70: '通用选项'
 # 'Generic memory optimizations'
 H800F1622EB9A: '通用内存优化'
 # 'Get the symbol definition from <line> <start-column> <end-column>'
-H9C96E5C80114: '从第 <line> 行的<start-column>到<end-column>列获取符号定义'
+H9C96E5C80114: '从第 <line> 行的 <start-column> 到 <end-column> 列获取符号定义'
 # 'Give each function an independent TBAA tree (default)'
 H7A952E99A7FC: '为每个函数分配独立的TBAA树（默认）'
 # 'Give global C++ operator new and delete declarations hidden visibility'
 HAD504B33021E: '为全局C++的operator new和delete声明赋予隐藏可见性'
 # "Give global types 'default' visibility and global functions and variables 'hidden' visibility by default"
-H095BFBCE25DF: '默认情况下，全局类型采用"default"可见性，全局函数和变量采用"hidden"可见性'
+H095BFBCE25DF: '默认情况下，全局类型采用 "default" 可见性，全局函数和变量采用 "hidden" 可见性'
 # 'Give inline C++ member functions hidden visibility by default'
 HAF1CF839FC8A: '默认为内联C++成员函数赋予隐藏可见性'
 # 'Give the maximum number of instructions that we will use for creating a floating-point immediate value'
@@ -9285,7 +9285,7 @@ H9222F90CA7BE: 'HTML 输出'
 # "HTML start tag '%0' closed by '%1'"
 H5D28040DFF0A: "HTML开始标签 '%0' 被 '%1' 关闭"
 # "HTML start tag prematurely ended, expected attribute name or '>'"
-HB396911AC86C: "HTML开始标签提前结束，期望属性名或'>'"
+HB396911AC86C: "HTML开始标签提前结束，期望属性名或 '>'"
 # "HTML tag '%0' requires an end tag"
 HC3A525011E51: "HTML标签 '%0' 需要结束标签"
 # 'HTML tag started here'
@@ -9385,9 +9385,9 @@ H1C0F5065601C: 'Hexagon 常量扩展优化'
 # 'Hexagon early if conversion'
 H5C9514E28A85: 'Hexagon 早期if转换'
 # 'Hexagon generate "extract" instructions'
-H7636CC8F55F3: '生成Hexagon "extract"指令'
+H7636CC8F55F3: '生成Hexagon "extract" 指令'
 # 'Hexagon generate "insert" instructions'
-H3778EAC02853: 'Hexagon生成"insert"指令'
+H3778EAC02853: 'Hexagon生成 "insert" 指令'
 # 'Hexagon generate mux instructions'
 H5C45CA2F85F2: 'Hexagon 生成多路选择指令'
 # 'Hexagon generate predicate operations'
@@ -9451,7 +9451,7 @@ HD50D41502699: 'cgscc内联重放文件的格式'
 # "How cgscc inline replay treats sites that don't come from the replay. Original: defers to original advisor, AlwaysInline: inline all sites not in replay, NeverInline: inline no sites not in replay"
 H6F8523C009E8: 'cgscc内联重放如何处理来自重放的调用点以外的站点。Original：遵循原始建议器，AlwaysInline：内联所有不在重放中的站点，NeverInline：不内联任何不在重放中的站点'
 # "How many functions in a module could be used for MergeFunctions to pass a basic correctness check. '0' disables this check. Works only with '-debug' key."
-H65C2FF1A291C: "在模块中可用于MergeFunctions通过基本正确性检查的函数数量。'0' 禁用此检查。仅与'-debug'键一起使用"
+H65C2FF1A291C: "在模块中可用于MergeFunctions通过基本正确性检查的函数数量。'0' 禁用此检查。仅与 '-debug' 键一起使用"
 # 'How many idle instructions we would like before certain undef register reads'
 HAF5EEC679340: '在某些未定义寄存器读取之前希望有多少空闲指令'
 # 'How many kernel arguments to preload onto SGPRs'
@@ -9487,13 +9487,13 @@ HA8BDC735DCBC: 'IRTranslator LLVM IR -> 机器指令'
 # 'ISO C does not allow indirection on operand of type %0'
 HC4C25916B558: 'ISO C不允许对类型 %0 的操作数进行间接访问'
 # "ISO C does not support '~' for complex conjugation of %0"
-H592FB210723A: "ISO C不支持使用'~'对 %0 进行复数共轭"
+H592FB210723A: "ISO C不支持使用 '~' 对 %0 进行复数共轭"
 # "ISO C forbids forward references to 'enum' types"
 H3A2E43246AF1: "ISO C禁止向前引用 'enum' 类型"
 # "ISO C forbids taking the address of an expression of type 'void'"
 H5DC6DC421D10: "ISO C不允许为类型 'void' 的表达式取地址"
 # "ISO C requires a named parameter before '...'"
-HAAD7320B82D0: 'ISO C要求在"..."之前有一个命名参数'
+HAAD7320B82D0: 'ISO C要求在 "..." 之前有一个命名参数'
 # 'ISO C requires a translation unit to contain at least one declaration'
 HD453AE5DFC44: 'ISO C要求翻译单元中至少包含一个声明'
 # 'ISO C++ considers this destructor name lookup to be ambiguous'
@@ -9501,21 +9501,21 @@ H51664244F36F: 'ISO C++认为此析构函数名查找存在歧义'
 # 'ISO C++ does not allow %select{an attribute list|%0}1 to appear here'
 H6EEF885F4392: 'ISO C++不允许在此处出现%select{属性列表|%0}1'
 # 'ISO C++ does not allow %select{const_cast|static_cast|reinterpret_cast|dynamic_cast|C-style cast|functional-style cast|}0 from %1 to %2 because it casts away qualifiers, even though the source and destination types are unrelated'
-HA24736A782D5: 'ISO C++不允许在此处使用%select{const_cast|static_cast|reinterpret_cast|dynamic_cast|C-style cast|functional-style cast|}0从 %1 到 %2 进行转换，因为该转换会丢弃限定符，即使源类型和目标类型无关'
+HA24736A782D5: 'ISO C++不允许在此处使用 %select{const_cast|static_cast|reinterpret_cast|dynamic_cast|C-style cast|functional-style cast|}0 从 %1 到 %2 进行转换，因为该转换会丢弃限定符，即使源类型和目标类型无关'
 # "ISO C++ does not permit the 'bool' keyword after 'concept'"
 HED15AAEA01CD: "ISO C++禁止在 'concept' 之后使用 'bool' 关键字"
 # "ISO C++ forbids forward references to 'enum' types"
 H565E6A76B7E7: "ISO C++禁止向前引用 'enum' 类型"
 # "ISO C++ only allows ':' in member enumeration declaration to introduce a fixed underlying type, not an anonymous bit-field"
-HD765E30339DE: "ISO C++仅允许在成员枚举声明中使用':'来引入固定的基础类型，而不是匿名位字段"
+HD765E30339DE: "ISO C++仅允许在成员枚举声明中使用 ':' 来引入固定的基础类型，而不是匿名位字段"
 # 'ISO C++ requires a definition in this translation unit for %select{function|variable}0 %q1 because its type does not have linkage'
 HCF564C1243BB: 'ISO C++要求为%select{函数|变量}0 %q1在当前翻译单元中提供定义，因为其类型没有链接性'
 # 'ISO C++ requires field designators to be specified in declaration order; field %1 will be initialized after field %0'
 HF7272CADD93F: 'ISO C++ 要求字段设计符按声明顺序指定；字段 %1 将在字段 %0 之后初始化'
 # "ISO C++ requires the name after '::~' to be found in the same scope as the name before '::~'"
-H1B12535D9EA0: "ISO C++ 要求'::~'之后的名称与'::~'之前的名称处于同一作用域"
+H1B12535D9EA0: "ISO C++ 要求 '::~' 之后的名称与 '::~' 之前的名称处于同一作用域"
 # "ISO C++ specifies that qualified reference to %0 is a constructor name rather than a %select{template name|type}1 in this context, despite preceding %select{'typename'|'template'}2 keyword"
-H0AEAB31369D3: "ISO C++ 规定在此上下文中，对 %0 的限定引用是一个构造函数名称而非%select{模板名称|类型}1，尽管前面有%select{'typename'|'template'}2关键字"
+H0AEAB31369D3: "ISO C++ 规定在此上下文中，对 %0 的限定引用是一个构造函数名称而非%select{模板名称|类型}1，尽管前面有 %select{'typename'|'template'}2 关键字"
 # 'ISO C++ standards before C++17 do not allow new expression for type %0 to use list-initialization'
 H36A45BAF91C7: 'ISO C++17之前的版本不允许类型 %0 的new表达式使用列表初始化'
 # 'ISO C++11 does not allow access declarations; use using declarations instead'
@@ -9525,7 +9525,7 @@ HDCEA926F7FF8: 'ISO C++11 不允许将字符串字面量转换为 %0'
 # 'ISO C++11 requires a parenthesized pack declaration to have a name'
 H70DD46DED2FB: 'ISO C++11 要求括号化的打包声明必须具有名称'
 # "ISO C++17 does not allow 'register' storage class specifier"
-HFBD7E25436E2: 'ISO C++17 不允许使用"register"存储类说明符'
+HFBD7E25436E2: 'ISO C++17 不允许使用 "register" 存储类说明符'
 # 'ISO C++17 does not allow a decomposition group to be empty'
 H38C9A47FB6B4: 'ISO C++17 不允许分解组为空'
 # 'ISO C++17 does not allow dynamic exception specifications'
@@ -9535,7 +9535,7 @@ H8CE1E8E6EA54: 'ISO C++17 不允许对bool类型的表达式进行递增操作'
 # "ISO C++20 considers use of overloaded operator '%0' (with operand types %1 and %2) to be ambiguous despite there being a unique best viable function%select{ with non-reversed arguments|}3"
 HE2B331A9C128: 'ISO C++20 认为此处使用重载的运算符 "%0"（操作数类型为 %1 和 %2）存在歧义，尽管存在一个具有非反转参数的唯一最佳可行函数%select{ |}3'
 # "ISO C++20 requires return type of selected 'operator==' function for rewritten '%1' comparison to be 'bool', not %0"
-H96DD21560E53: 'ISO C++20 要求重写后的 "%1" 比较所选的"operator=="函数的返回类型应为"bool"，而非 %0'
+H96DD21560E53: 'ISO C++20 要求重写后的 "%1" 比较所选的 "operator==" 函数的返回类型应为 "bool"，而非 %0'
 # 'ISO C90 does not allow subscripting non-lvalue array'
 HB75A7925DCA5: 'ISO C90 不允许对非常量左值数组进行下标访问'
 # 'ISO C99 requires whitespace after the macro name'
@@ -9641,7 +9641,7 @@ H2050B14C1C4D: '忽略RecMII'
 # 'Ignore TTI attributes compatibility check between callee/caller during inline cost calculation'
 H6DBD3A9D0CF3: '忽略内联成本计算期间调用者/被调用者之间的TTI属性兼容性检查'
 # "Ignore all DWARF data. This relaxes the requirements for all statically linked libraries to have been compiled with '-g', but will result in false positives for 'CFI unprotected' instructions."
-H39BB8E06FB84: "忽略所有DWARF数据。这会松弛对所有静态链接库必须使用'-g'编译的要求，但会导致'CFI unprotected'指令出现误报。"
+H39BB8E06FB84: "忽略所有DWARF数据。这会松弛对所有静态链接库必须使用 '-g' 编译的要求，但会导致 'CFI unprotected' 指令出现误报。"
 # 'Ignore attribute objc_direct so that direct methods can be tested'
 HCF66187C2621: '忽略objc_direct属性以便测试直接方法'
 # 'Ignore balance information, always return (1: Even, 2: Odd).'
@@ -9725,7 +9725,7 @@ H1CA9E31B3F5D: '在OpenMP数据子句中将`a(N)`视为`a(N:N)`。'
 # 'In the dump requested by -dump-input, print <N> input lines\nbefore and <N> input lines after any lines specified by\n-dump-input-filter.  When there are multiple occurrences of\nthis option, the largest specified <N> has precedence.  The\ndefault is 5.\n'
 HEB48ED43B50E: '在由-dump-input请求的转储中，打印指定行之前和之后各 <N> 行输入行。如果该选项出现多次，则最大的 <N> 值优先。默认值为 5。\n'
 # "In the dump requested by -dump-input, print only input lines of\nkind <value> plus any context specified by -dump-input-context.\nWhen there are multiple occurrences of this option, the <value>\nthat appears earliest in the list below has precedence.  The\ndefault is 'error' when -dump-input=fail, and it's 'all' when\n-dump-input=always.\n"
-H9104E1DEC417: '仅打印类型为 <value> 的输入行以及由-dump-input-context指定的上下文。如果该选项出现多次，则列表中出现最早的 <value> 值优先。当-dump-input=fail时，默认值为"error"；当-dump-input=always时，默认值为"all"。\n'
+H9104E1DEC417: '仅打印类型为 <value> 的输入行以及由-dump-input-context指定的上下文。如果该选项出现多次，则列表中出现最早的 <value> 值优先。当-dump-input=fail时，默认值为 "error"；当-dump-input=always时，默认值为 "all"。\n'
 # 'In the report, sort the timers in each group in wall clock time order'
 H2F13A69F022D: '在报告中，按各组中的实时时钟时间对计时器进行排序'
 # 'Include BLOCKINFO details in low level dump'
@@ -9781,9 +9781,9 @@ HC64F11374476: '将CUDA设备端二进制文件合并到主机目标文件中。
 # 'Increase alignment of LDS if it is not on align boundary'
 H6B6D9E0BE911: '如果LDS未对齐到对齐边界，则增加其对齐'
 # "Increases 'x86-br-merging-base-cost' in cases that it is likely that all conditionals will be executed. For example for merging the conditionals (a == b && c > d), if its known that a == b is likely, then it is likely that if the conditionals are split both sides will be executed, so it may be desirable to increase the instruction cost threshold. Set to -1 to never merge likely branches."
-H9238554A10FA: '在所有条件分支可能都会执行的情况下，增加"x86-br-merging-base-cost"的值。例如对于合并条件（a == b && c > d），如果已知a == b很可能成立，则如果条件被拆分，两边都可能被执行，因此可能需要提高指令成本阈值。设置为-1以永远不合并可能的分支。'
+H9238554A10FA: '在所有条件分支可能都会执行的情况下，增加 "x86-br-merging-base-cost" 的值。例如对于合并条件（a == b && c > d），如果已知a == b很可能成立，则如果条件被拆分，两边都可能被执行，因此可能需要提高指令成本阈值。设置为-1以永远不合并可能的分支。'
 # "Increases 'x86-br-merging-base-cost' in cases that the target supports conditional compare instructions."
-H0EFC5555FAAB: '在目标支持条件比较指令的情况下，增加"x86-br-merging-base-cost"的值。'
+H0EFC5555FAAB: '在目标支持条件比较指令的情况下，增加 "x86-br-merging-base-cost" 的值。'
 # 'Incremental depth computation will be used for basic blocks with more instructions.'
 HE1566572AE0C: '对于指令较多的基本块，将使用增量深度计算。'
 # 'Index of module to extract'
@@ -9809,7 +9809,7 @@ H9EE07FA9B2FD: '抑制A15上S->D寄存器访问的优化'
 # 'Init Undef Pass'
 HA592C8476F8C: '初始化未定义Pass'
 # "Initialize trivial automatic stack variables. Defaults to 'uninitialized'"
-H413F6C855E54: '初始化平凡的自动栈变量。默认值为"uninitialized"'
+H413F6C855E54: '初始化平凡的自动栈变量。默认值为 "uninitialized"'
 # 'Inject absolute symbol definitions (syntax: <name>=<addr>)'
 HD553F9022403: '注入绝对符号定义（语法：<name>=<addr>）'
 # 'Inject symbol aliases (syntax: <alias-name>=<aliasee>)'
@@ -9937,7 +9937,7 @@ HD37C6649C311: '指令、代码行、作用域、符号和类型。'
 # 'Instrument (context sensitive) the IR to generate profile.'
 HAAB0AE0AE781: '（上下文敏感）对IR进行插桩以生成分析资料。'
 # 'Instrument - operations with pointer operands'
-HDBC71D3E6754: '为指针操作数的<, <=, >, >=运算符添加检测'
+HDBC71D3E6754: '为指针操作数的 <, <=, >, >=运算符添加检测'
 # 'Instrument <, <=, >, >= with pointer operands'
 H6DA2CC308CCE: '为指针操作数插入 <, <=, >, >='
 # 'Instrument <, <=, >, >=, - with pointer operands'
@@ -10031,15 +10031,15 @@ HD3F623D56EDC: '保留所有基准测试（默认）'
 # 'Keep all non-cold contexts (increases cloning overheads)'
 H4544ED3678BF: '保留所有非冷上下文（会增加克隆开销）'
 # 'Keep aside the last <num-test-traces> traces in the profile when computing the function order and instead use them to evaluate that order'
-H77D85A9D26A6: '在计算函数顺序时保留最后<num-test-traces>个配置文件中的轨迹，并使用它们来评估该顺序'
+H77D85A9D26A6: '在计算函数顺序时保留最后 <num-test-traces> 个配置文件中的轨迹，并使用它们来评估该顺序'
 # 'Keep copies of symbols in LTO indexing'
 HB94AF3670BCE: '在LTO索引中保留符号的副本'
 # 'Keep going on errors encountered'
 H418BF6CA6A97: '遇到错误时继续执行'
 # 'Keep going on errors encountered in trace 1'
-H99638570EFA7: '在trace 1中遇到错误时继续执行'
+H99638570EFA7: '在trace 1 中遇到错误时继续执行'
 # 'Keep going on errors encountered in trace 2'
-HCFE6CEB4DFCA: '在trace 2中遇到错误时继续执行'
+HCFE6CEB4DFCA: '在trace 2 中遇到错误时继续执行'
 # 'Keep initializers of constants'
 H36ACE3809A61: '保留常量的初始化器'
 # 'Keep max reading'
@@ -10233,7 +10233,7 @@ HEAF5A10A6293: '限制每个块的SLP调度区域大小'
 # 'Limit the size of the seed bundle to cap compilation time.'
 H4DFB40A73CC1: '限制种子包的大小以控制编译时间。'
 # 'Limits the range of tokens in -check file on which various features are tested. Example --check-lines=3-7 restricts testing to lines 3 to 7 (inclusive) or --check-lines=5 to restrict to one line. Default is testing entire file.'
-H2A6188976AA0: '限制-check文件中测试各项功能的行范围。示例：--check-lines=3-7 将测试限制在 3 到 7行（含），或--check-lines=5 限制为单行。默认测试整个文件。'
+H2A6188976AA0: '限制-check文件中测试各项功能的行范围。示例：--check-lines=3-7 将测试限制在 3 到 7 行（含），或--check-lines=5 限制为单行。默认测试整个文件。'
 # 'Linalg ODS Gen from YAML'
 H78D204B7569D: 'Linalg ODS Gen from YAML'
 # 'Line kind to use when printing lines.'
@@ -10297,7 +10297,7 @@ H7F26F6260A72: '助手模式下需要排除的包含编译或模块化问题的�
 # 'List of functions to print disassembly for. Accept demangled names only. Only work with show-disassembly-only'
 H3054F37FF6EE: '要反汇编的函数列表。仅接受展开的名称。仅与show-disassembly-only选项配合使用'
 # "List of key and value arguments. Required keywords are 'file' and 'triple'."
-H45A6C5D3DB8C: '键值参数列表。必需的关键词是"file"和"triple"。'
+H45A6C5D3DB8C: '键值参数列表。必需的关键词是 "file" 和 "triple"。'
 # 'List of modes to link in by default into XRay instrumented binaries.'
 HA0397880FB9D: '默认链接到XRay已插入二进制文件中的模式列表'
 # 'List of symbols to export from the resulting object file'
@@ -10367,7 +10367,7 @@ HAAA0526E734E: '位置和变量'
 # 'Locations only'
 H997812E5B96A: '仅位置'
 # "Log action execution to a file, or stderr if  '-' is passed"
-H7DDDF7706229: '将操作执行记录到文件中，如果设为"-"则记录到标准错误'
+H7DDDF7706229: '将操作执行记录到文件中，如果设为 "-" 则记录到标准错误'
 # 'Look up implicit modules in the prebuilt module path'
 H7389FC31B294: '在预构建模块路径中查找隐式模块'
 # 'LoongArch DAG->DAG Pattern Instruction Selection'
@@ -10859,7 +10859,7 @@ H62138B784DC3: '括号、方括号和大括号的最大嵌套层级'
 # 'Maximum num basic blocks before debug info dropped'
 HF7FD1D6C6637: '在丢弃调试信息前的基本块最大数量'
 # "Maximum number of 'operator->'s to call for a member access"
-H2363B77A7D06: "成员访问时调用的'operator->'的最大数量"
+H2363B77A7D06: "成员访问时调用的 'operator->' 的最大数量"
 # 'Maximum number of BBs allowed in a function after inlining (compile time constraint)'
 H02A0499B6C90: '内联后函数中允许的最大基本块数（编译时间约束）'
 # 'Maximum number of ISL operations to invest for known analysis; 0=no limit'
@@ -11009,7 +11009,7 @@ H647C9F0ED977: '如果采样配置文件加载器决定不内联调用站点，�
 # 'Merge the given AST file into the translation unit being compiled.'
 H044732F67319: '将给定的AST文件合并到正在编译的翻译单元中'
 # "Method to generate ID's for compilation units for single source offloading languages CUDA and HIP: 'hash' (ID's generated by hashing file path and command line options) | 'random' (ID's generated as random numbers) | 'none' (disabled). Default is 'hash'. This option will be overridden by option '-cuid=[ID]' if it is specified."
-HF56CB8DC51CB: "为CUDA和HIP单源offloading语言的编译单元生成ID的方法：'hash'（通过哈希文件路径和命令行选项生成ID） | 'random'（通过随机数生成ID） | 'none'（禁用）。默认是 'hash'。如果指定了选项'-cuid=[ID]'，此选项将被覆盖。"
+HF56CB8DC51CB: "为CUDA和HIP单源offloading语言的编译单元生成ID的方法：'hash'（通过哈希文件路径和命令行选项生成ID） | 'random'（通过随机数生成ID） | 'none'（禁用）。默认是 'hash'。如果指定了选项 '-cuid=[ID]'，此选项将被覆盖。"
 # 'MicroMips instruction size reduce pass'
 H43AA98943979: 'MicroMips指令大小缩减pass'
 # "Microsoft compiler version number to report in _MSC_VER (0 = don't define it (default))"
@@ -11069,9 +11069,9 @@ H78B91828296F: '块必须被执行的最小次数以保留'
 # "Minimum priority, runs on idle CPUs. May leave 'performance' cores unused."
 H2308F82368EA: '最低优先级，在空闲CPU上运行。可能会使‘performance’核心未被使用。'
 # "Minimum profile count required for an optimization remark to be output. Use 'auto' to apply the threshold from profile summary"
-H3D2B4D99467F: '输出优化备注所需的最小配置文件计数。使用"auto"应用来自配置文件摘要的阈值'
+H3D2B4D99467F: '输出优化备注所需的最小配置文件计数。使用 "auto" 应用来自配置文件摘要的阈值'
 # "Minimum profile count required for an optimization remark to be output. Use 'auto' to apply the threshold from profile summary."
-H05750FA1DE8F: '输出优化备注所需的最小配置文件计数。使用"auto"应用来自配置文件摘要的阈值'
+H05750FA1DE8F: '输出优化备注所需的最小配置文件计数。使用 "auto" 应用来自配置文件摘要的阈值'
 # 'Minimum ratio comparing relative sizes of each outline candidate and original function'
 H4C5E36FE2F68: '比较每个外联候选和原始函数相对大小的最小比率'
 # 'Minimum relative gain per loop threshold (1/X). Defaults to 12.5%'
@@ -11201,7 +11201,7 @@ HAC5287C54D8E: 'N元重新关联'
 # 'Natural Loop Information'
 HB731CE00868C: '自然循环信息'
 # 'Neon vector size must be 64 or 128 bits'
-H97DBFE49CD6B: 'NEON向量大小必须为 64 或 128位'
+H97DBFE49CD6B: 'NEON向量大小必须为 64 或 128 位'
 # 'Nested profile, the input should be CS flat profile'
 HA55917D514EC: '嵌套配置文件，输入应为CS平面配置文件'
 # 'Never'
@@ -11389,7 +11389,7 @@ H4D1372C43A35: '从虚表中省略RTTI组件'
 # "Omit the frame pointer from functions that don't need it. Some stack unwinding cases, such as profilers and sanitizers, may prefer specifying -fno-omit-frame-pointer. On many targets, -O1 and higher omit the frame pointer by default. -m[no-]omit-leaf-frame-pointer takes precedence for leaf functions"
 H40ED6B28D90F: '省略不需要它的函数的帧指针。某些堆栈展开情况（例如分析器和sanitizer）可能更倾向于指定-fno-omit-frame-pointer。在许多目标平台上，默认情况下-O1及以上级别会省略帧指针。-m[no-]omit-leaf-frame-pointer选项对叶子函数具有优先权'
 # 'On AIX, request creation of a build-id string, "0xHEXSTRING", in the string table of the loader section inside the linked binary'
-H9CC108588817: '在AIX上，请求在链接二进制文件的加载器节的字符串表中创建一个"0xHEXSTRING"格式的构建ID字符串'
+H9CC108588817: '在AIX上，请求在链接二进制文件的加载器节的字符串表中创建一个 "0xHEXSTRING" 格式的构建ID字符串'
 # 'On Windows, do not emit /defaultlib: directives to link compiler-rt libraries'
 H9E62CED5E13B: '在Windows上，不生成链接compiler-rt库的/defaultlib:指令'
 # 'On Windows, emit /defaultlib: directives to link compiler-rt libraries (default)'
@@ -11567,17 +11567,17 @@ HA5F584B3696E: "OpenACC '%0' 结构必须有一个终止条件"
 # "OpenACC '%0' construct must have at least one %1 clause"
 H5108FA0063F8: "OpenACC '%0' 结构必须至少包含一个 %1 子句"
 # "OpenACC '%0' construct must have initialization clause in canonical form ('var = init' or 'T var = init')"
-HB6396996D535: "OpenACC '%0' 结构必须以规范形式包含初始化子句（'var = init'或'T var = init'）"
+HB6396996D535: "OpenACC '%0' 结构必须以规范形式包含初始化子句（'var = init' 或 'T var = init'）"
 # "OpenACC '%0' variable must monotonically increase or decrease ('++', '--', or compound assignment)"
-H4842B31AA1BD: "OpenACC '%0' 变量必须单调递增或递减（使用'++'、'--'或复合赋值）"
+H4842B31AA1BD: "OpenACC '%0' 变量必须单调递增或递减（使用 '++'、'--' 或复合赋值）"
 # "OpenACC '%1' clause %select{|with more than 1 argument }0may not appear on a '%2' construct with a '%3' clause%select{ with more than 1 argument|}0"
-HE77D7FA4A4F6: "OpenACC '%1' 子句 %select{|带有超过 1 个参数的 }0不能出现在带有 '%3' 子句%select{ 带有超过 1 个参数的|}0的 '%2' 构造中"
+HE77D7FA4A4F6: "OpenACC '%1' 子句 %select{|带有超过 1 个参数的 }0不能出现在带有 '%3' 子句%select{ 带有超过 1 个参数的|}0 的 '%2' 构造中"
 # "OpenACC '%1' clause cannot appear more than once on a '%0' directive"
 H22BA6A918DDE: "OpenACC '%1' 子句在 '%0' 指令上不能出现多次"
 # "OpenACC '%1' clause is not valid on '%0' directive"
 H226495157F78: "OpenACC '%1' 子句在 '%0' 指令上无效"
 # "OpenACC 'bind' clause on a declaration must bind to the same name as previous bind clauses"
-H9E597FA760BB: '声明上的OpenACC "bind"子句必须绑定到与之前bind子句相同的名称'
+H9E597FA760BB: '声明上的OpenACC "bind" 子句必须绑定到与之前bind子句相同的名称'
 # "OpenACC 'collapse' clause loop count must be a %select{constant expression|positive integer value, evaluated to %1}0"
 HF187F732137C: "OpenACC 'collapse' 子句循环计数必须是 %select{常量表达式|正整数值，计算为 %1}0"
 # "OpenACC 'gang' clause may have at most one %select{unnamed or 'num'|'dim'|'static'}0 argument"
@@ -11595,7 +11595,7 @@ H18CDEE7EFD75: "OpenACC 'routine' 指令带有名称，该名称与下一行的�
 # "OpenACC 'tile' clause size expression must be %select{an asterisk or a constant expression|positive integer value, evaluated to %1}0"
 HA638C30812B2: "OpenACC 'tile' 子句尺寸表达式必须是 %select{星号或常量表达式|正整数值，计算为 %1}0"
 # "OpenACC 'update' construct may not appear in place of the statement following a%select{n if statement| while statement| do statement| switch statement| label statement}0"
-H3E931AFE1E4E: "OpenACC 'update' 构造不能出现在%select{if语句后的|while语句后的|do语句后的|switch语句后的|标签语句后的}0语句位置"
+H3E931AFE1E4E: "OpenACC 'update' 构造不能出现在 %select{if语句后的|while语句后的|do语句后的|switch语句后的|标签语句后的}0语句位置"
 # "OpenACC clause '%0' may not appear on the same construct as a '%1' clause on a '%2' construct"
 HFD5E5BF152EC: "OpenACC '%0' 子句不能与 '%1' 子句出现在同一 '%2' 构造中"
 # "OpenACC clause '%0' may not follow a '%1' clause in a '%2' construct"
@@ -11633,11 +11633,11 @@ H7C8F28679BDB: 'OpenACC子数组指定范围[%0:%1]超出了所下标数组 %2 �
 # 'OpenACC sub-array subscripted value is not an array or pointer'
 H64A7517C6764: 'OpenACC子数组所下标值不是数组或指针'
 # "OpenACC variable %select{in 'use_device' clause|on 'declare' construct}0 is not a valid variable name or array name"
-H5FFA8811F2EF: "OpenACC变量%select{'use_device' 子句中的|'declare' 结构中的}0不是一个有效的变量名或数组名"
+H5FFA8811F2EF: "OpenACC变量 %select{'use_device' 子句中的|'declare' 结构中的}0不是一个有效的变量名或数组名"
 # 'OpenACC variable in cache directive is not a valid sub-array or array element'
 H0DEC3018E66D: 'OpenACC在cache指令中的变量不是一个有效的子数组或数组元素'
 # 'OpenACC variable is not a valid variable name, sub-array, array element,%select{| member of a composite variable,}0 or composite variable member'
-HA8B26141C7C6: 'OpenACC变量不是一个有效的变量名、子数组、数组元素%select{|或复合变量的成员,}0或复合变量成员'
+HA8B26141C7C6: 'OpenACC变量不是一个有效的变量名、子数组、数组元素 %select{|或复合变量的成员,}0 或复合变量成员'
 # 'OpenCL extension %0 is core feature or supported optional core feature - ignoring'
 H1E2DAA7C8DD9: 'OpenCL扩展 %0 是核心特性或支持的可选核心特性 - 忽略'
 # 'OpenCL extension %0 unknown or does not require pragma - ignoring'
@@ -11659,7 +11659,7 @@ H3AFC0A3E3E23: '定义全局工作尺寸必须是传递给clEnqueueNDRangeKernel
 # 'OpenCL only. Disables all standard includes containing non-native compiler types and functions.'
 H89344E39C234: '禁用包含非本机编译器类型和函数的所有标准头文件。'
 # "OpenCL only. Enable or disable OpenCL extensions/optional features. The argument is a comma-separated sequence of one or more extension names, each prefixed by '+' or '-'."
-H2870B3BCDE72: "启用或禁用OpenCL扩展/可选特性。参数是用逗号分隔的一个或多个扩展名列表，每个扩展名前需加上'+'或'-'前缀。"
+H2870B3BCDE72: "启用或禁用OpenCL扩展/可选特性。参数是用逗号分隔的一个或多个扩展名列表，每个扩展名前需加上 '+' 或 '-' 前缀。"
 # 'OpenCL only. Generate kernel argument metadata.'
 HD27868AF8559: '生成内核参数元数据。'
 # 'OpenCL only. Sets -cl-finite-math-only and -cl-unsafe-math-optimizations, and defines __FAST_RELAXED_MATH__.'
@@ -11677,13 +11677,13 @@ H6B78DAFB84E5: 'OpenMP数组成形操作在此处不允许'
 # 'OpenMP captured regions are not yet supported in %select{streaming functions|functions with ZA state|functions with ZT0 state}0'
 HBFAEB31DF5F3: 'OpenMP捕获区域在%select{流函数|具有ZA状态的函数|具有ZT0状态的函数}0中尚未支持'
 # "OpenMP clause '%0' is only available as extension, use '-fopenmp-extensions'"
-H7D732B734761: "OpenMP子句 '%0' 仅作为扩展可用，请使用'-fopenmp-extensions'"
+H7D732B734761: "OpenMP子句 '%0' 仅作为扩展可用，请使用 '-fopenmp-extensions'"
 # 'OpenMP constructs may not be nested inside a simd region%select{| except for ordered simd, simd, scan, or atomic directive}0'
-HC65424272817: 'OpenMP结构不能嵌套在simd区域内%select{|，除非是ordered simd、simd、scan或atomic指令}0'
+HC65424272817: 'OpenMP结构不能嵌套在simd区域内 %select{|，除非是ordered simd、simd、scan或atomic指令}0'
 # 'OpenMP constructs may not be nested inside an atomic region'
 HE2C47884F9E6: 'OpenMP结构不能嵌套在原子区域内'
 # "OpenMP extension clause '%0' only allowed with '#pragma omp %1'"
-HB7695EC8B674: "OpenMP扩展子句 '%0' 仅允许与'#pragma omp %1'一起使用"
+HB7695EC8B674: "OpenMP扩展子句 '%0' 仅允许与 '#pragma omp %1' 一起使用"
 # 'OpenMP iterator is not allowed here'
 HB9668BC52F3C: 'OpenMP迭代器不允许在这里使用'
 # 'OpenMP loop iteration variable cannot have more than 64 bits size and will be narrowed'
@@ -11905,7 +11905,7 @@ H76E82EB3BAF1: '输出已启动内核的资源使用情况'
 # 'Output the total number corresponding to the count for the provided input file.'
 H8049C03B1803: '输出与提供的输入文件计数对应的总数。'
 # "Output trace to the given file name or '-' for stdout."
-H8DCBEA863061: '将跟踪输出到指定文件名或使用"-"表示标准输出'
+H8DCBEA863061: '将跟踪输出到指定文件名或使用 "-" 表示标准输出'
 # 'Outputs for view.'
 H377C2CC892EF: '用于视图的输出'
 # 'Overapproximation of dependences'
@@ -12101,7 +12101,7 @@ H1DFEDD2BDCE9: 'libomptarget-nvptx比特码库路径'
 # 'Path to libomptarget-spirv bitcode library'
 H17C48C664B7B: 'libomptarget-spirv比特码库路径'
 # "Path to opt. (default: search path for 'opt'.)"
-H87E2E1DC35F9: 'opt工具路径（默认：搜索路径中的"opt"）。'
+H87E2E1DC35F9: 'opt工具路径（默认：搜索路径中的 "opt"）。'
 # 'Path to ptxas (used for compiling CUDA code)'
 H902CF64E7382: 'ptxas的路径（用于编译CUDA代码）'
 # 'Path to saved model evaluating native size from IR.'
@@ -12459,7 +12459,7 @@ HFF2FE350C63E: '不需要重命名的结构体前缀，用逗号分隔'
 # 'Preload commands from file and start interactive mode'
 HF342699558DE: '从文件预加载命令并启动交互模式'
 # "Prepare '-aux-triple' only without populating '-aux-target-cpu' and '-aux-target-feature'."
-H5F5A3F872C66: "仅准备'-aux-triple'而不填充'-aux-target-cpu'和'-aux-target-feature'"
+H5F5A3F872C66: "仅准备 '-aux-triple' 而不填充 '-aux-target-cpu' 和 '-aux-target-feature'"
 # 'Prepare DWARF exceptions'
 H95C39A5915AA: '准备DWARF异常'
 # 'Prepare SjLj exceptions'
@@ -12523,7 +12523,7 @@ HF36ABB428107: '阻止函数去虚化'
 # 'Prevent misexpect diagnostics from being output if the profile counts are within N% of the expected. '
 HAB811F421D71: '若剖析计数在期望值的N%范围内，则抑制不期望的诊断输出。'
 # "Prevent optimization remarks from being output if they do not have at least this profile count. Use 'auto' to apply the threshold from profile summary"
-H80EFE9F96F6F: '如果优化建议的配置文件计数不足，则阻止其输出。使用"auto"以应用来自配置文件摘要的阈值'
+H80EFE9F96F6F: '如果优化建议的配置文件计数不足，则阻止其输出。使用 "auto" 以应用来自配置文件摘要的阈值'
 # 'Prevents emitting diagnostics when profile counts are within N% of the threshold..'
 H77AE0CC1048E: '当剖面计数在阈值N%范围内时抑制诊断信息的生成'
 # 'Primary key when ordering logical view (default: line).'
@@ -12567,7 +12567,7 @@ H183A70DB44AF: '打印选项'
 # 'Print SSA IDs using NameLocs as prefixes'
 H17EB8F4CEEED: '使用NameLocs作为前缀打印SSA IDs'
 # "Print a '-passes' compatible string describing the pipeline (best-effort only)."
-H4C4CBF86A7C9: '生成与"-passes"兼容的字符串描述管线（仅尽力而为）。'
+H4C4CBF86A7C9: '生成与 "-passes" 兼容的字符串描述管线（仅尽力而为）。'
 # 'Print a template comparison tree for differing templates'
 H94B203D5EC04: '为不同的模板打印模板比较树'
 # 'Print absolute paths in diagnostics'
@@ -12927,9 +12927,9 @@ HE92D60C3DD89: '处理三字符序列'
 # 'Processor register names.'
 H69E6140DD062: '处理器寄存器名称。'
 # 'Produce a faster access sequence for local-dynamic TLS variables where the offset from the TLS base is encoded as an immediate operand (AIX 64-bit only). This access sequence is not used for variables larger than 32KB.'
-H96608A9C1D3A: '为局部动态TLS变量生成更快的访问序列，其中TLS基址的偏移量被编码为立即操作数（仅AIX 64位）。该访问序列不用于大于 32KB的变量。'
+H96608A9C1D3A: '为局部动态TLS变量生成更快的访问序列，其中TLS基址的偏移量被编码为立即操作数（仅AIX 64 位）。该访问序列不用于大于 32KB的变量。'
 # 'Produce a faster access sequence for local-exec TLS variables where the offset from the TLS base is encoded as an immediate operand (AIX 64-bit only). This access sequence is not used for variables larger than 32KB.'
-HDB020B6BCE8A: '为局部执行TLS变量生成更快的访问序列，其中TLS基址的偏移量被编码为立即操作数（仅AIX 64位）。该访问序列不用于大于 32KB的变量。'
+HDB020B6BCE8A: '为局部执行TLS变量生成更快的访问序列，其中TLS基址的偏移量被编码为立即操作数（仅AIX 64 位）。该访问序列不用于大于 32KB的变量。'
 # 'Produce gcov notes files (*.gcno)'
 HA873BCAA45B3: '生成gcov注释文件（*.gcno）'
 # 'Produce progress indicator when performing measurements'
@@ -12945,7 +12945,7 @@ H3927BD641AFE: '为分布式后端生成独立索引。'
 # 'ProfGen Options'
 HA88661D355E6: 'ProfGen选项'
 # "Profile action execution to a file, or stderr if  '-' is passed"
-HF893EEFBCD55: '将性能分析结果输出到文件，或stderr（若传递"-"）'
+HF893EEFBCD55: '将性能分析结果输出到文件，或stderr（若传递 "-"）'
 # 'Profile file loaded by -sample-profile'
 HD83B6219FC6C: '-sample-profile加载的性能分析文件'
 # 'Profile kind supported by show:'
@@ -13239,7 +13239,7 @@ H9B54876630EC: '删除冗余的DEBUG_VALUE分析'
 # 'Remove Sign and Zero Extends for Args'
 H7F0FDF466871: '移除参数的符号和零扩展'
 # "Remove an attribute from a function. This can be a pair of 'function-name:attribute-name' to remove an attribute from a specific function. For example -force-remove-attribute=foo:noinline. Specifying only an attribute will remove the attribute from all functions in the module. This option can be specified multiple times."
-HC96183D47DE8: "移除函数的属性。这可以是'function-name:attribute-name'的键值对，用于移除特定函数的属性。例如 -force-remove-attribute=foo:noinline。仅指定属性名时，将从模块内所有函数中移除该属性。该选项可重复使用。"
+HC96183D47DE8: "移除函数的属性。这可以是 'function-name:attribute-name' 的键值对，用于移除特定函数的属性。例如 -force-remove-attribute=foo:noinline。仅指定属性名时，将从模块内所有函数中移除该属性。该选项可重复使用。"
 # 'Remove dead machine instructions'
 H849DB0ECAC7B: '删除死机器指令'
 # 'Remove duplicate DecoderTable entries generated due to HwModes'
@@ -13283,7 +13283,7 @@ H16B0416B17A1: '重新打包在任何维度上非连续的数组。若设置为f
 # 'Repeat compilation N times for timing'
 HD8053595EBB4: '重复编译N次以测量时间'
 # "Replace 'mul x, Const' with more effective instructions like SHIFT, LEA, etc."
-HC54A5626311D: '用更有效的指令（如SHIFT、LEA等）替换"mul x, Const"'
+HC54A5626311D: '用更有效的指令（如SHIFT、LEA等）替换 "mul x, Const"'
 # 'Replace ARM non-local ADR instructions with ADRP'
 H4558533FD5F3: '将ARM非本地ADR指令替换为ADRP'
 # 'Replace PHIs by their incoming values'
@@ -13719,7 +13719,7 @@ H24C3BD16186C: 'SCE 目标平台（例如 PS4）'
 # "SDK does not contain 'libarclite' at the path '%0'; try increasing the minimum deployment target"
 HBB626BB3124D: "SDK在路径 '%0' 中不包含 'libarclite'；尝试提高最低部署目标"
 # "SDK settings were ignored as 'SDKSettings.json' could not be parsed"
-HF609237E0BEB: "由于无法解析'SDKSettings.json'，SDK设置被忽略"
+HF609237E0BEB: "由于无法解析 'SDKSettings.json'，SDK设置被忽略"
 # "SEH '__try' is not supported on this target"
 H06D89FCA39AA: "SEH的 '__try' 在该目标平台上不受支持"
 # 'SI Fix SGPR copies'
@@ -13975,7 +13975,7 @@ HA1F9E472551C: '选择教程版本'
 # 'Select underlying type for wchar_t'
 H871CFB3D3DBF: '选择wchar_t的基础类型'
 # "Select which XRay instrumentation points to emit. Options: all, none, function-entry, function-exit, function, custom. Default is 'all'.  'function' includes both 'function-entry' and 'function-exit'."
-HF1CF9325D610: "选择要生成的XRay插桩点。选项：all, none, function-entry, function-exit, function, custom. 默认值为 'all'。  'function' 包括'function-entry'和'function-exit'"
+HF1CF9325D610: "选择要生成的XRay插桩点。选项：all, none, function-entry, function-exit, function, custom. 默认值为 'all'。  'function' 包括 'function-entry' 和 'function-exit'"
 # 'Select which denormal numbers the code is permitted to require'
 H2AC882EF26F4: '指定代码允许要求的非规格化数类型'
 # 'Select which denormal numbers the code is permitted to require for float'
@@ -14109,7 +14109,7 @@ H747561D1A3EA: '设置RISCV使用跳转表的最小条目数'
 # 'Set minimum number of entries to use a jump table.'
 HB0CDB46F3718: '设置使用跳转表所需的最小条目数。'
 # "Set multiple /O flags at once; e.g. '/O2y-' for '/O2 /Oy-'"
-HEBA0D85CE2CB: "一次性设置多个/O标志；例如'/O2y-' 表示 '/O2 /Oy-'"
+HEBA0D85CE2CB: "一次性设置多个/O标志；例如 '/O2y-' 表示 '/O2 /Oy-'"
 # 'Set output executable file name'
 H82C970101BA4: '设置输出可执行文件名'
 # 'Set output object file (with /c)'
@@ -14223,11 +14223,11 @@ H7736F9C56939: '设置WebAssembly加载和存储的p2align操作数'
 # 'Set the parallelization strategy'
 HF0A794612D46: '设置并行化策略'
 # "Set the profile instrumentation burst duration, which can range from 1 to the value of 'sampled-instr-period' (0 is invalid). This number of samples will be recorded for each 'sampled-instr-period' count update. Setting to 1 enables simple sampling, in which case it is recommended to set 'sampled-instr-period' to a prime number."
-H5CA10C80C24A: "设置配置文件采样突发时长，取值范围为 1 到'sampled-instr-period'的值（0无效）。每个采样周期将记录该数量的样本。设置为 1 时启用简单采样，此时建议将'sampled-instr-period'设为质数。"
+H5CA10C80C24A: "设置配置文件采样突发时长，取值范围为 1 到 'sampled-instr-period' 的值（0无效）。每个采样周期将记录该数量的样本。设置为 1 时启用简单采样，此时建议将 'sampled-instr-period' 设为质数。"
 # "Set the profile instrumentation sample period. A sample period of 0 is invalid. For each sample period, a fixed number of consecutive samples will be recorded. The number is controlled by 'sampled-instr-burst-duration' flag. The default sample period of 65536 is optimized for generating efficient code that leverages unsigned short integer wrapping in overflow, but this is disabled under simple sampling (burst duration = 1)."
-HC029DE20A3E1: "设置配置文件采样周期。0无效。每个采样周期将记录固定数量的连续样本。具体数量由'sampled-instr-burst-duration'参数控制。默认采样周期 65536 经过优化，可生成利用无符号短整型溢出的高效代码，但在简单采样（突发时长=1）时该优化会被禁用。"
+HC029DE20A3E1: "设置配置文件采样周期。0无效。每个采样周期将记录固定数量的连续样本。具体数量由 'sampled-instr-burst-duration' 参数控制。默认采样周期 65536 经过优化，可生成利用无符号短整型溢出的高效代码，但在简单采样（突发时长=1）时该优化会被禁用。"
 # "Set the rsp quoting to either 'posix', or 'windows'"
-HFF7A11383873: '设置RSP文件的引号方式为"posix"或"windows"'
+HFF7A11383873: '设置RSP文件的引号方式为 "posix" 或 "windows"'
 # 'Set the stack alignment'
 HAAE3F7EC9ADE: '设置堆栈对齐方式'
 # 'Set the stack probe size'
@@ -14581,7 +14581,7 @@ HD8341B8B44B5: '源代码分析 - 符号约束引擎'
 # 'Source prefix to elide'
 HF556E14613B2: '要省略的源前缀'
 # "Source-level compatibility for Altivec vectors (for PowerPC targets). This includes results of vector comparison (scalar for 'xl', vector for 'gcc') as well as behavior when initializing with a scalar (splatting for 'xl', element zero only for 'gcc'). For 'mixed', the compatibility is as 'gcc' for 'vector bool/vector pixel' and as 'xl' for other types. Current default is 'mixed'."
-HCF923B012626: "源级兼容性设置（针对PowerPC目标平台的AltiVec向量）。包括向量比较结果（'xl' 为标量，'gcc' 为向量）以及使用标量初始化时的行为（'xl' 为扩展，'gcc' 仅保留第一个元素）。对于 'mixed' 模式，'vector bool/vector pixel'类型与 'gcc' 兼容，其他类型与 'xl' 兼容。当前默认为 'mixed'。"
+HCF923B012626: "源级兼容性设置（针对PowerPC目标平台的AltiVec向量）。包括向量比较结果（'xl' 为标量，'gcc' 为向量）以及使用标量初始化时的行为（'xl' 为扩展，'gcc' 仅保留第一个元素）。对于 'mixed' 模式，'vector bool/vector pixel' 类型与 'gcc' 兼容，其他类型与 'xl' 兼容。当前默认为 'mixed'。"
 # 'SourceLocation in file %0 at offset %1 is invalid'
 H2A6519004798: '文件 %0 中偏移量 %1 处的SourceLocation无效'
 # 'Spawn a separate process for each cc1'
@@ -14611,7 +14611,7 @@ HB1694AF39E4A: '指定用于浮点运算的评估方法。'
 # 'Specifies the exception behavior of floating-point operations.'
 HF7A17A05FFEE: '指定浮点运算的异常行为。'
 # "Specifies the largest alignment guaranteed by '::operator new(size_t)'"
-H7C74E7BEFD7B: "指定'::operator new(size_t)'保证的最大对齐方式"
+H7C74E7BEFD7B: "指定 '::operator new(size_t)' 保证的最大对齐方式"
 # 'Specifies the name we should consider the input file'
 H048BF6366B06: '指定输入文件的名称'
 # 'Specifies the size of batches for processing CUs. Higher number has better performance, but more memory usage. Default value is 1.'
@@ -14637,9 +14637,9 @@ H6CD3C27C7374: '指定上下文敏感型PGO剖面文件'
 # "Specify a default target triple when it's not available in the module"
 H8905580ACB2D: '当模块中未提供时，指定默认目标三元组'
 # "Specify a directory where Clang can find 'include' and 'lib{,32,64}/gcc{,-cross}/$triple/$version'. Clang will use the GCC installation with the largest version"
-H5F9EC5F91118: "指定Clang可以找到 'include' 和'lib{,32,64}/gcc{,-cross}/$triple/$version'的目录。Clang将使用版本最大的GCC安装"
+H5F9EC5F91118: "指定Clang可以找到 'include' 和 'lib{,32,64}/gcc{,-cross}/$triple/$version' 的目录。Clang将使用版本最大的GCC安装"
 # "Specify a directory where Flang can find 'lib{,32,64}/gcc{,-cross}/$triple/$version'. Flang will use the GCC installation with the largest version"
-H59AA0290DBA6: "指定Flang可以找到'lib{,32,64}/gcc{,-cross}/$triple/$version'的目录。Flang将使用版本最大的GCC安装"
+H59AA0290DBA6: "指定Flang可以找到 'lib{,32,64}/gcc{,-cross}/$triple/$version' 的目录。Flang将使用版本最大的GCC安装"
 # 'Specify a plugin to optimize LFENCE insertion'
 H749CB0E11874: '指定优化LFENCE插入的插件'
 # 'Specify a reference program output (for miscompilation detection)'
@@ -14775,7 +14775,7 @@ HC274D886E608: '指定要构建的模块名称'
 # 'Specify the name of the root module.'
 H385C12B5E6FA: '指定根模块的名称。'
 # "Specify the output file type ('asm', 'null', or 'obj')"
-H908E78C67406: '指定输出文件类型（"asm"、"null"或"obj"）'
+H908E78C67406: '指定输出文件类型（"asm"、"null" 或 "obj"）'
 # 'Specify the output file. default: reduced.ll|.bc|.mir'
 HDB7BE70A48BF: '指定输出文件。默认值：reduced.ll|.bc|.mir'
 # 'Specify the output filename'
@@ -14795,7 +14795,7 @@ HD696058226F4: '指定“安全”后端程序的路径'
 # 'Specify the prebuilt module path'
 H3FAB39F2C50D: '指定预构建模块路径'
 # 'Specify the printf lowering scheme (AMDGPU only), allowed values are "hostcall"(printing happens during kernel execution, this scheme relies on hostcalls which require system to support pcie atomics) and "buffered"(printing happens after all kernel threads exit, this uses a printf buffer and does not rely on pcie atomic support)'
-H36B6C5D95ECD: '指定printf降级方案（仅AMDGPU），允许的取值为"hostcall"（在内核执行期间进行打印，该方案依赖于主机调用，需要系统支持pcie原子操作）和"buffered"（在所有内核线程退出后进行打印，使用printf缓冲区，不依赖pcie原子支持）'
+H36B6C5D95ECD: '指定printf降级方案（仅AMDGPU），允许的取值为 "hostcall"（在内核执行期间进行打印，该方案依赖于主机调用，需要系统支持pcie原子操作）和 "buffered"（在所有内核线程退出后进行打印，使用printf缓冲区，不依赖pcie原子支持）'
 # 'Specify the profile path in PGO use compilation'
 H383968EDB0F3: '在PGO使用编译中指定配置文件路径'
 # 'Specify the property to collect remarks by.'
@@ -14805,7 +14805,7 @@ HE59A5BD76AE3: '指定用于按属性分组注释的属性。'
 # 'Specify the size in bits of an RVV vector register'
 H0AB4126F0C29: '指定RVV向量寄存器的位数'
 # 'Specify the size in bits of an SVE vector register. Defaults to the vector length agnostic value of "scalable". (AArch64 only)'
-H2F3DFF504736: '指定SVE向量寄存器的位数。默认为与向量长度无关的"scalable"值。（仅限AArch64）'
+H2F3DFF504736: '指定SVE向量寄存器的位数。默认为与向量长度无关的 "scalable" 值。（仅限AArch64）'
 # 'Specify the stackmap encoding version (default = 3)'
 H7CF270813613: '指定栈映射编码版本（默认值=3）'
 # 'Specify the target Objective-C runtime kind and version'
@@ -14821,9 +14821,9 @@ HDBA609305F00: '指定要生成仅GPR代码的比较类型。'
 # 'Specify the version of the memprof format to use'
 H1B82817FBBA6: '指定要使用的memprof格式版本'
 # 'Specify the vscale maximum. Defaults to the vector length agnostic value of "0". (AArch64/RISC-V only)'
-HA66591A80BFB: '指定vscale最大值。默认为与向量长度无关的"0"值。（仅限AArch64/RISC-V）'
+HA66591A80BFB: '指定vscale最大值。默认为与向量长度无关的 "0" 值。（仅限AArch64/RISC-V）'
 # 'Specify the vscale minimum. Defaults to "1". (AArch64/RISC-V only)'
-H0C205532C01D: '指定vscale最小值。默认值为"1"。（仅限AArch64/RISC-V）'
+H0C205532C01D: '指定vscale最小值。默认值为 "1"。（仅限AArch64/RISC-V）'
 # 'Specify time trace file destination'
 HC99CB0CDDE38: '指定时间跟踪文件的目标位置'
 # 'Specify types of branches to align'
@@ -15313,7 +15313,7 @@ H7C463E6FF16B: '在调度前构建 DAG 时使用的限制，在达到此限制�
 # 'The list of function names in which Emscripten-style exception handling is enabled (see emscripten EMSCRIPTEN_CATCHING_ALLOWED options)'
 H0AFF9B181379: '启用Emscripten风格异常处理（见emscripten EMSCRIPTEN_CATCHING_ALLOWED选项）的功能名称列表'
 # 'The list of the names of classes being moved, e.g. "Foo,a::Foo,b::Foo".'
-HC13468BE141E: '被移动的类名列表，例如"Foo,a::Foo,b::Foo"'
+HC13468BE141E: '被移动的类名列表，例如 "Foo,a::Foo,b::Foo"'
 # 'The lower bound of size growth limit for proirity-based sample profile loader inlining.'
 HA4426ABB67AB: '基于优先级的样本配置文件加载程序内联的大小增长下限'
 # 'The lower limit of the difference between best II and base II in the window algorithm. If the difference is smaller than this lower limit, window scheduling will not be performed.'
@@ -15623,7 +15623,7 @@ H8A887C2C292E: '要嵌入到DWARF调试标志记录中的字符串'
 # 'The style name used for reformatting.'
 H6C1DBF661954: '用于代码格式化的样式名称。'
 # 'The style name used for reformatting. Default is "llvm"'
-H6E46319C3C34: '用于代码格式化的样式名称。默认值为"llvm"'
+H6E46319C3C34: '用于代码格式化的样式名称。默认值为 "llvm"'
 # 'The summary file to use for function importing.'
 H956C0535484D: '用于函数导入的摘要文件。'
 # 'The target Objective-C runtime supports ARC weak operations'
@@ -15667,7 +15667,7 @@ H67F478EEEC59: 'dllimport外部声明的可见性。如果指定Keep，则不调
 # 'The visibility for external declarations without an explicit DLL storage class. If Keep is specified the visibility is not adjusted [-fvisibility-from-dllstorageclass]'
 H64D964A1CD05: '未显式指定DLL存储类的外部声明的可见性。如果指定Keep，则不调整可见性 [-fvisibility-from-dllstorageclass]'
 # "The visibility for global C++ operator new and delete declarations. If 'source' is specified the visibility is not adjusted"
-H9A7A28615088: '全局C++ operator new和delete声明的可见性。如果指定"source"，则不调整可见性'
+H9A7A28615088: '全局C++ operator new和delete声明的可见性。如果指定 "source"，则不调整可见性'
 # 'The weight of backward jumps for ExtTSP value'
 H0E7F2365F191: 'ExtTSP值中后向跳转的权重'
 # 'The weight of conditional backward jumps for ExtTSP value'
@@ -15715,7 +15715,7 @@ HEF7B686F6202: '这是默认设置。TOC数据转换不会应用于任何变量�
 # 'This option is for testing purposes only. It forces BOLT to convert low_pc/high_pc to ranges always.'
 H46D236F6D0BE: '此选项仅用于测试目的。它强制BOLT始终将low_pc/high_pc转换为范围。'
 # "Thread pointer access method. For AArch32: 'soft' uses a function call, or 'tpidrurw', 'tpidruro' or 'tpidrprw' use the three CP15 registers. 'cp15' is an alias for 'tpidruro'. For AArch64: 'tpidr_el0', 'tpidr_el1', 'tpidr_el2', 'tpidr_el3' or 'tpidrro_el0' use the five system registers. 'elN' is an alias for 'tpidr_elN'."
-H7A1A2BC28705: '线程指针访问方法。对于AArch32："soft"使用函数调用，或"tpidrurw"、"tpidruro"或"tpidrprw"使用三个CP15寄存器。"cp15"是"tpidruro"的别名。对于AArch64："tpidr_el0"、"tpidr_el1"、"tpidr_el2"、"tpidr_el3"或"tpidrro_el0"使用五个系统寄存器。"elN"是"tpidr_elN"的别名。'
+H7A1A2BC28705: '线程指针访问方法。对于AArch32："soft" 使用函数调用，或 "tpidrurw"、"tpidruro" 或 "tpidrprw" 使用三个CP15寄存器。"cp15" 是 "tpidruro" 的别名。对于AArch64："tpidr_el0"、"tpidr_el1"、"tpidr_el2"、"tpidr_el3" 或 "tpidrro_el0" 使用五个系统寄存器。"elN" 是 "tpidr_elN" 的别名。'
 # 'Threshold (in bytes) for the runtime check guarding the memmove.'
 HD35FCD3FC79E: '运行时检查memmove的阈值（以字节为单位）'
 # 'Threshold (in bytes) to perform the transformation, if the runtime loop count (mem transfer size) is known at compile-time.'
@@ -16111,7 +16111,7 @@ H2733E473C4B3: '使用 F5 系列硬件乘法器'
 # 'Use GC exclusively for Objective-C related memory management'
 H2B28F501A8B5: '专用于Objective-C相关内存管理时仅使用GC'
 # "Use GCC installation in the specified directory. The directory ends with path components like 'lib{,32,64}/gcc{,-cross}/$triple/$version'. Note: executables (e.g. ld) used by the compiler are not overridden by the selected GCC installation"
-HA7E84A833041: "使用指定目录中的GCC安装。该目录包含类似'lib{,32,64}/gcc{,-cross}/$triple/$version'的路径组件。注意：编译器使用的可执行文件（例如ld）不会被选定的GCC安装覆盖"
+HA7E84A833041: "使用指定目录中的GCC安装。该目录包含类似 'lib{,32,64}/gcc{,-cross}/$triple/$version' 的路径组件。注意：编译器使用的可执行文件（例如ld）不会被选定的GCC安装覆盖"
 # 'Use GCNDownwardRPTracker for GCNRegPressurePrinter pass'
 HC666D46EACA0: '为GCNRegPressurePrinter pass使用GCNDownwardRPTracker'
 # 'Use GOT indirection instead of PLT to make external function calls (x86 only)'
@@ -16127,7 +16127,7 @@ HCD3F9F572B30: '使用GlobalISel的预期合法性，而非尝试使用与选择
 # 'Use HLFIR lowering (experimental)'
 HBF33CE828D70: '使用HLFIR降级（实验性）'
 # 'Use IEEE 754 quadruple-precision for long double'
-H52864CA1A557: '使用IEEE 754四倍精度表示long double'
+H52864CA1A557: '使用IEEE 754 四倍精度表示long double'
 # 'Use INTEGER(KIND=8) for the result type in size-related intrinsics'
 H31BCF654D576: '在与尺寸相关的内建函数中使用INTEGER(KIND=8)作为结果类型'
 # 'Use InstrItineraryData for latency lookup'
@@ -16521,7 +16521,7 @@ H9063D587CE9C: '在内联时使用llvm.experimental.noalias.scope.decl内建函�
 # 'Use the named plugin action in addition to the default action'
 H2C8F63F64ACF: '在默认操作外附加使用命名插件操作'
 # 'Use the named plugin action instead of the default action (use "help" to list available options)'
-HEB1C020DB399: '用命名插件操作替代默认操作（使用"help"列出可用选项）'
+HEB1C020DB399: '用命名插件操作替代默认操作（使用 "help" 列出可用选项）'
 # 'Use the native __fp16 type for arguments and returns (and skip ABI-specific lowering)'
 H638090B7484A: '使用__fp16参数和返回值的本机类型（并跳过与ABI相关的降级）'
 # 'Use the native half type for __fp16 instead of promoting to float'
@@ -17159,11 +17159,11 @@ H34DCBA8F9AA1: '[no]neon不能作为修饰符使用，请改用[no]simd'
 # '\\%0 used with no following hex digits'
 H4ACD9688DA19: '\\%0 使用时未跟随十六进制数字'
 # "\\%0 used with no following hex digits; treating as '\\' followed by identifier"
-H34C9A007F8A0: "\\%0 使用时未跟随十六进制数字；将视为'\\'后跟标识符"
+H34C9A007F8A0: "\\%0 使用时未跟随十六进制数字；将视为 '\\' 后跟标识符"
 # '^^ is a reserved operator in OpenCL'
 H0C0A23A57F10: '^^在OpenCL中是保留运算符'
 # '_Atomic cannot be applied to %select{incomplete |array |function |reference |atomic |qualified |sizeless ||integer |}0type %1 %select{|||||||which is not trivially copyable||in C23}0'
-H323CC2CB8E5D: '_Atomic不能应用于%select{不完整 |数组 |函数 |引用 |原子 |限定 |无尺寸 ||整数 |}0类型 %1 %select{|||||||无法被简单复制||在C23中}0'
+H323CC2CB8E5D: '_Atomic不能应用于%select{不完整 |数组 |函数 |引用 |原子 |限定 |无尺寸 ||整数 |}0 类型 %1 %select{|||||||无法被简单复制||在C23中}0'
 # '_GLOBAL_OFFSET_TABLE_'
 HE310DB69A9CE: '_GLOBAL_OFFSET_TABLE_'
 # '_Pragma takes a parenthesized string literal'
@@ -17189,13 +17189,13 @@ H10FB78A8E9A5: '__block属性不允许在具有变长修改类型的声明中使
 # '__block attribute not allowed, only allowed on local variables'
 HE188099287CD: '__block属性不允许使用，仅允许在局部变量上使用'
 # '__block variable %0 cannot be captured in a %select{lambda expression|captured statement}1'
-HD7DB9752FAAD: '__block变量 %0 不能被捕获到%select{lambda表达式|被捕获的语句}1中'
+HD7DB9752FAAD: '__block变量 %0 不能被捕获到 %select{lambda表达式|被捕获的语句}1中'
 # '__builtin_btf_type_id argument %0 not a constant'
 H48F1BECDC866: '__builtin_btf_type_id参数 %0 不是常量'
 # '__builtin_longjmp is not supported for the current target'
 H53A6EFDFCD17: '__builtin_longjmp不支持当前目标平台'
 # "__builtin_mul_overflow does not support 'signed _BitInt' operands of more than %0 bits"
-H24B9AB05270A: "__builtin_mul_overflow不支持超过 %0 位的'signed _BitInt'操作数"
+H24B9AB05270A: "__builtin_mul_overflow不支持超过 %0 位的 'signed _BitInt' 操作数"
 # '__builtin_preserve_enum_value argument %0 invalid'
 H341194DCABD7: '__builtin_preserve_enum_value参数 %0 无效'
 # '__builtin_preserve_enum_value argument %0 not a constant'
@@ -17235,7 +17235,7 @@ HAD92983EAEB2: '__weak 属性不能指定在字段声明上'
 # '__weak attribute cannot be specified on an automatic variable when ARC is not enabled'
 HC15AE9021482: '__weak 属性在未启用 ARC 时不能指定在自动变量上'
 # '`#pragma const_seg` for section %1 will not apply to %0 due to the presence of a %select{mutable field||non-trivial constructor|non-trivial destructor}2'
-H8811D5F6122A: "'#pragma const_seg'为 %1 节将不适用于 %0，因为存在%select{可变字段||非平凡构造函数|非平凡析构函数}2"
+H8811D5F6122A: "'#pragma const_seg' 为 %1 节将不适用于 %0，因为存在%select{可变字段||非平凡构造函数|非平凡析构函数}2"
 # 'a %select{function|block}0 declaration without a prototype is deprecated %select{in all versions of C|}0'
 HA427D7F1B8D9: '没有原型的 %select{函数|块}0 声明在所有 C 版本中已弃用 %select{ | 和在 C23 中不受支持}0'
 # "a %select{pack indexing|'decltype'}0 specifier cannot be used in a declarative nested name specifier"
@@ -17289,9 +17289,9 @@ H86B74E3E67C6: 'requires表达式不能包含显式对象参数'
 # 'a requires expression must contain at least one requirement'
 HA35998709F70: 'requires表达式必须包含至少一个约束条件'
 # "a space is required between a right angle bracket and an equals sign (use '> =')"
-H9BFA1E21C4F4: '右尖括号和等号之间需要空格（使用"> =")'
+H9BFA1E21C4F4: '右尖括号和等号之间需要空格（使用 "> =")'
 # "a space is required between consecutive right angle brackets (use '> >')"
-H529B67153B9E: '连续的右尖括号之间需要空格（使用"> >")'
+H529B67153B9E: '连续的右尖括号之间需要空格（使用 "> >")'
 # 'a static lambda cannot have any captures'
 H2E5388A18076: '静态lambda不能有任何捕获'
 # 'a static_assert declaration cannot be a template'
@@ -17307,7 +17307,7 @@ H878607247E5C: 'typedef不能是模板'
 # 'absolute value function %0 given an argument of type %1 but has parameter of type %2 which may cause truncation of value'
 H2B4AC1EEC989: '绝对值函数 %0 的参数类型为 %2，但传入的实参类型为 %1，可能导致数值被截断'
 # "abstract class is marked '%select{final|sealed}0'"
-H9546D737D23E: "抽象类被标记为'%select{final|sealed}0'"
+H9546D737D23E: "抽象类被标记为 '%select{final|sealed}0'"
 # 'access declarations are deprecated; use using declarations instead'
 H3431BA5113E5: '访问声明已弃用；请改用using声明'
 # 'access qualifier %0 cannot be used for %1 %select{|prior to OpenCL C version 2.0 or in version 3.0 and without __opencl_c_read_write_images feature}2'
@@ -17337,7 +17337,7 @@ H48500D7C1CF8: "添加 'constexpr'"
 # "add 'export' here if this is intended to be a module interface unit"
 H8499B2C3202C: "如果这是模块接口单元，请在此添加 'export'"
 # "add 'module;' to the start of the file to introduce a global module fragment"
-H1399A9153C66: "在文件开头添加'module;'以引入全局模块片段"
+H1399A9153C66: "在文件开头添加 'module;' 以引入全局模块片段"
 # "add 'typename' to treat this using declaration as a type"
 H2514B140BEE5: "添加 'typename' 以将此using声明视为类型"
 # "add 'u8' prefix to form a 'char8_t' string literal"
@@ -17387,7 +17387,7 @@ H540EC7EBFA01: '重新声明中添加默认参数会使此构造函数成为 %se
 # 'address argument to atomic builtin cannot be const-qualified (%0 invalid)'
 H05DD72B70C0D: '原子内建函数的地址参数不能是 const 限定的 (%0 无效)'
 # 'address argument to atomic builtin must be a pointer %select{|to a non-zero-sized object }1(%0 invalid)'
-H25FC8322E786: '原子内建函数的地址参数必须是 %select{指向非零大小对象的|}1指针 (%0 无效)'
+H25FC8322E786: '原子内建函数的地址参数必须是 %select{指向非零大小对象的|}1 指针 (%0 无效)'
 # 'address argument to atomic builtin must be a pointer to 1,2,4,8 or 16 byte type (%0 invalid)'
 H8F0926664FBC: '原子内建函数的地址参数必须是指向 1、2、4、8 或 16 字节类型的指针 (%0 无效)'
 # 'address argument to atomic builtin must be a pointer to integer or pointer (%0 invalid)'
@@ -17395,13 +17395,13 @@ H05518FC9E223: '原子内建函数的地址参数必须是指向整型或指针�
 # 'address argument to atomic builtin must be a pointer to integer, floating-point or pointer (%0 invalid)'
 H4BE1CF542714: '原子内建函数的地址参数必须是指向整型、浮点型或指针的指针（%0 无效）'
 # 'address argument to atomic operation must be a pointer to %select{|atomic }0integer (%1 invalid)'
-H45F0D7833F1F: '原子操作的地址参数必须是指向%select{|原子 }0整型的指针（%1 无效）'
+H45F0D7833F1F: '原子操作的地址参数必须是指向 %select{|原子 }0整型的指针（%1 无效）'
 # 'address argument to atomic operation must be a pointer to %select{|atomic }0integer or pointer (%1 invalid)'
-HD792403A7931: '原子操作的地址参数必须是指向%select{|原子 }0整型或指针的指针（%1 无效）'
+HD792403A7931: '原子操作的地址参数必须是指向 %select{|原子 }0整型或指针的指针（%1 无效）'
 # 'address argument to atomic operation must be a pointer to %select{|atomic }0integer or supported floating point type (%1 invalid)'
-H645D002EEC1B: '原子操作的地址参数必须是指向%select{|原子 }0整型或受支持的浮点类型的指针（%1 无效）'
+H645D002EEC1B: '原子操作的地址参数必须是指向 %select{|原子 }0整型或受支持的浮点类型的指针（%1 无效）'
 # 'address argument to atomic operation must be a pointer to %select{|atomic }0integer, pointer or supported floating point type (%1 invalid)'
-HF8B6B0144FE9: '原子操作的地址参数必须是指向%select{|原子 }0整型、指针或受支持的浮点类型的指针（%1 无效）'
+HF8B6B0144FE9: '原子操作的地址参数必须是指向 %select{|原子 }0整型、指针或受支持的浮点类型的指针（%1 无效）'
 # 'address argument to atomic operation must be a pointer to _Atomic type (%0 invalid)'
 HED971913A5AB: '原子操作的地址参数必须是指向_Atomic类型的指针（%0 无效）'
 # 'address argument to atomic operation must be a pointer to a trivially-copyable type (%0 invalid)'
@@ -17523,17 +17523,17 @@ H5F21C338A420: 'alignof表达式与C++98不兼容'
 # 'all paths through this function will call itself'
 H40E0BDFB048F: '通过此函数的所有路径都将调用自身'
 # "allocate directive specifies %select{default|'%1'}0 allocator while previously used %select{default|'%3'}2"
-HC639234B285B: "分配指令指定了%select{默认|'%1'}0分配器，而之前使用了%select{默认|'%3'}2"
+HC639234B285B: "分配指令指定了%select{默认|'%1'}0 分配器，而之前使用了%select{默认|'%3'}2"
 # 'allocated size %0 is not a multiple of size %1 of element type %2'
 H279696362CDE: '分配的大小 %0 不是元素类型 %2 大小 %1 的倍数'
 # "allocated with 'new%select{[]|}0' here"
-H1AA44259E5AA: "此处使用'new%select{[]|}0'分配"
+H1AA44259E5AA: "此处使用 'new%select{[]|}0' 分配"
 # 'allocating an object of abstract class type %0'
 H07CDBA71F9A5: '尝试分配抽象类类型 %0 的对象'
 # 'allocation of %select{incomplete|sizeless}0 type %1'
 HD40A80B2E772: '分配了%select{不完整|无大小}0类型 %1'
 # 'allocation performed here was not deallocated%plural{0:|: (along with %0 other memory leak%s0)}0'
-H04A2F923450C: '此处分配的内存未被释放%plural{0:|:（以及 %0 其他内存泄漏%s0）}0'
+H04A2F923450C: '此处分配的内存未被释放 %plural{0:|:（以及 %0 其他内存泄漏%s0）}0'
 # "allocator must be specified in the 'uses_allocators' clause"
 H6A6EDC2E2834: "必须在 'uses_allocators' 子句中指定分配器"
 # "allocator with the 'thread' trait access has unspecified behavior on '%0' directive"
@@ -17549,11 +17549,11 @@ H1792F22F4481: "%0 中缺少允许的客户端：'%1'"
 # "allowable clients do not match: '%0' (provided) vs '%1' (found)"
 H73C7C1046F8D: "允许的客户端不匹配：'%0'（提供）与 '%1'（找到）"
 # "already inside '#pragma clang arc_cf_code_audited'"
-H490BE327E34C: "已在'#pragma clang arc_cf_code_audited'作用域内"
+H490BE327E34C: "已在 '#pragma clang arc_cf_code_audited' 作用域内"
 # "already inside '#pragma clang assume_nonnull'"
-H59F0A861C85D: "已在'#pragma clang assume_nonnull'作用域内"
+H59F0A861C85D: "已在 '#pragma clang assume_nonnull' 作用域内"
 # "already inside '#pragma unsafe_buffer_usage'"
-H94EE60235FE3: "已在'#pragma unsafe_buffer_usage'作用域内"
+H94EE60235FE3: "已在 '#pragma unsafe_buffer_usage' 作用域内"
 # 'also accessed here'
 H4EBEB7641C26: '此处也被访问'
 # 'also found'
@@ -17625,13 +17625,13 @@ H3AB5357520EE: '附加到结构化绑定声明的属性说明符序列与C++2c�
 # 'an explicit object parameter can only appear as the first parameter of a member function'
 HB251EBFE2CF5: '显式对象参数只能作为成员函数的第一个参数出现'
 # 'an explicit object parameter can only appear as the first parameter of the %select{function|lambda}0'
-H7FA58E3ABF3F: '显式对象参数只能作为%select{函数|lambda}0的第一个参数出现'
+H7FA58E3ABF3F: '显式对象参数只能作为%select{函数|lambda}0 的第一个参数出现'
 # 'an explicit object parameter cannot appear in a %select{constructor|destructor}0'
 H75A07B3C23F5: '显式对象参数不能出现在%select{构造函数|析构函数}0中'
 # 'an explicit object parameter cannot appear in a %select{static|virtual|non-member}0 %select{function|lambda}1'
-HF679F4DDA00F: '显式对象参数不能出现在%select{静态|虚|非成员}0 %select{函数|lambda}1中'
+HF679F4DDA00F: '显式对象参数不能出现在%select{静态|虚|非成员}0 %select{函数|lambda}1 中'
 # "an explicitly-defaulted %select{copy|move}0 assignment operator may not have 'const'%select{, 'constexpr'|}1 or 'volatile' qualifiers"
-HC61798127DDC: "显式默认的%select{复制|移动}0赋值运算符不能带有 'const'%select{, 'constexpr'|}1或 'volatile' 限定符"
+HC61798127DDC: "显式默认的%select{复制|移动}0赋值运算符不能带有 'const'%select{, 'constexpr'|}1 或 'volatile' 限定符"
 # 'an explicitly-defaulted %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}0 cannot be variadic'
 HE8693CE23671: '显式默认的%select{默认构造函数|拷贝构造函数|移动构造函数|拷贝赋值运算符|移动赋值运算符|析构函数}0不能是可变参数'
 # 'an explicitly-defaulted %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}0 cannot have default arguments'
@@ -17649,15 +17649,15 @@ H156EC948497C: "分析器约束管理器 'z3' 仅当LLVM用-DLLVM_ENABLE_Z3_SOLV
 # "analyzer-config option '%0' has a key but no value"
 H5FB74FAA9043: "分析器配置选项 '%0' 有键但无值"
 # "analyzer-config option '%0' should contain only one '='"
-HC4A2A9D28ED1: "'analyzer-config'选项 '%0' 应该只包含一个'='"
+HC4A2A9D28ED1: "'analyzer-config' 选项 '%0' 应该只包含一个 '='"
 # 'angle brackets contain both a %select{type|protocol}0 (%1) and a %select{protocol|type}0 (%2)'
 H6C951E1E776A: '尖括号同时包含了一个%select{类型|协议}0（%1）和一个%select{协议|类型}0（%2）'
 # 'angle-bracketed include <%0> cannot be aliased to double-quoted include "%1"'
-H6DC7B4C3CA94: '尖括号包含的头文件<%0>不能被别名为双引号包含的头文件“%1”'
+H6DC7B4C3CA94: '尖括号包含的头文件 <%0> 不能被别名为双引号包含的头文件“%1”'
 # 'annotate %select{%1|anonymous %1}0 with an availability attribute to silence this warning'
-H1B283AC48C5C: '为%select{%1|匿名 %1}0添加一个可用性属性以消除此警告'
+H1B283AC48C5C: '为 %select{%1|匿名 %1}0 添加一个可用性属性以消除此警告'
 # "annotating the 'if %select{constexpr|consteval}0' statement here"
-HE2CC6E318B60: "在此处注释'if %select{constexpr|consteval}0'语句"
+HE2CC6E318B60: "在此处注释 'if %select{constexpr|consteval}0' 语句"
 # 'annotating the infinite loop here'
 H4CC614D1531D: '在此处注释无限循环'
 # 'annotation-type remark to collect count for'
@@ -17705,7 +17705,7 @@ H3FE1C37A16FD: "命名空间或全局作用域中的匿名联合必须声明为 
 # 'append PID to saved profile file name (default: false)'
 HFDE8729E14B7: '将PID附加到保存的配置文件名称（默认：false）'
 # "application of '%select{alignof|sizeof}1' to interface %0 is not supported on this architecture and platform"
-H7F7758BA5771: "对接口 %0 应用'%select{alignof|sizeof}1'在此架构和平台上不受支持"
+H7F7758BA5771: "对接口 %0 应用 '%select{alignof|sizeof}1' 在此架构和平台上不受支持"
 # 'apply additional analysis to remove stores (experimental)'
 H0FDD6748AD67: '应用额外分析以移除存储（实验性）'
 # 'apply unchecked-ld-st when the target is definitely within range'
@@ -17731,7 +17731,7 @@ H873B3444BA19: "'preferred_name' 属性的参数 %0 不是 %1 的特化类型的
 # 'argument %0 value should represent a contiguous bit field'
 H004B84FF9E91: '参数 %0 的值应表示连续的位字段'
 # "argument '%0' is deprecated%select{|, use '%2' instead}1"
-H549CE16A2419: '参数‘%0’已弃用%select{|，请改用‘%2’}1'
+H549CE16A2419: '参数‘%0’已弃用 %select{|，请改用‘%2’}1'
 # "argument '%0' is deprecated, %1"
 HFF8BB35E32E8: '参数‘%0’已弃用，%1'
 # "argument '%0' requires profile-guided optimization information"
@@ -17747,7 +17747,7 @@ HC935448BE70B: "参数不能使用 'void' 类型"
 # 'argument must be a function'
 H4B920E91F120: '参数必须是函数'
 # 'argument must be a string literal%select{| of char type}0'
-HE9E2C9450B76: '参数必须是字符串字面量%select{|的char类型}0'
+HE9E2C9450B76: '参数必须是字符串字面量 %select{|的char类型}0'
 # "argument not in expected state; expected '%0', observed '%1'"
 H081944E631B6: "参数不在期望状态；期望 '%0'，实际 '%1'"
 # "argument of OpenMP clause '%0' must reference the same object in all threads"
@@ -17801,7 +17801,7 @@ HB64B7DD3183B: '_BitInt 类型的原子内建函数参数不受支持'
 # 'argument to ptrauth_sign_constant must refer to a global variable or function'
 HC3F35A99F4A4: 'ptrauth_sign_constant 的参数必须引用全局变量或函数'
 # "argument type %0 doesn't match specified %1 type tag %select{that requires %3|}2"
-H3BF4CB740E62: '参数类型 %0 与指定的 %1 类型标签%select{需要 %3|}2不匹配'
+H3BF4CB740E62: '参数类型 %0 与指定的 %1 类型标签%select{需要 %3|}2 不匹配'
 # 'argument type %0 is incomplete'
 HAB2CACB541C5: '参数类型 %0 是不完整的'
 # 'argument type %0 is not a real floating point type'
@@ -17821,7 +17821,7 @@ H6F3268D97079: '#pragma omp %0 的参数必须具有%select{全局存储|静态�
 # "arguments of OpenMP clause '%0' for 'min' or 'max' must be of %select{scalar|arithmetic}1 type"
 HCCCABB9B57BC: "'min' 或 'max' 的OpenMP子句 '%0' 的参数必须是%select{标量|算术}1类型"
 # "arguments of OpenMP clause '%0' in '#pragma omp %2' directive cannot be of variably-modified type %1"
-HCB3B0D762A59: "在'#pragma omp %2'指令中，OpenMP子句 '%0' 的参数不能是可变修改类型 %1"
+HCB3B0D762A59: "在 '#pragma omp %2' 指令中，OpenMP子句 '%0' 的参数不能是可变修改类型 %1"
 # "arguments of OpenMP clause '%0' with bitwise operators cannot be of floating type"
 H7CE92A7D3184: "带有位运算符的OpenMP子句 '%0' 的参数不能是浮点类型"
 # 'arguments to __annotation must be wide string constants'
@@ -17837,13 +17837,13 @@ H84236342B8A2: '对可能重叠的字面量地址进行算术运算具有未指�
 # 'arithmetic on pointer to interface %0, which is not a constant size for this architecture and platform'
 H9C9B045DAD4E: '对指针进行算术运算，该指针指向接口 %0，而该接口在此架构和平台上不是固定大小'
 # 'arithmetic on%select{ a|}0 pointer%select{|s}0 to void'
-H58D09A5B5E7F: '对%select{一个|}0 void%select{|s}0指针进行算术运算'
+H58D09A5B5E7F: '对%select{一个|}0 void%select{|s}0 指针进行算术运算'
 # 'arithmetic on%select{ a|}0 pointer%select{|s}0 to void is a GNU extension'
-HB4BACD25A732: '对%select{一个|}0 void%select{|s}0指针进行算术运算是一个GNU扩展'
+HB4BACD25A732: '对%select{一个|}0 void%select{|s}0 指针进行算术运算是一个GNU扩展'
 # 'arithmetic on%select{ a|}0 pointer%select{|s}0 to%select{ the|}2 function type%select{|s}2 %1%select{| and %3}2'
-H1FD9A476B84E: '对%select{一个|}0指向%select{该|}2函数类型%select{|s}2 %1%select{|和 %3}2的%select{|s}0指针进行算术运算'
+H1FD9A476B84E: '对%select{一个|}0 指向%select{该|}2 函数类型 %select{|s}2 %1%select{|和 %3}2 的 %select{|s}0 指针进行算术运算'
 # 'arithmetic on%select{ a|}0 pointer%select{|s}0 to%select{ the|}2 function type%select{|s}2 %1%select{| and %3}2 is a GNU extension'
-H94DE585BA344: '对%select{一个|}0指向%select{该|}2函数类型%select{|s}2 %1%select{|和 %3}2的%select{|s}0指针进行算术运算是一个GNU扩展'
+H94DE585BA344: '对%select{一个|}0 指向%select{该|}2 函数类型 %select{|s}2 %1%select{|和 %3}2 的 %select{|s}0 指针进行算术运算是一个GNU扩展'
 # 'array %0 declared here'
 HD94D934376D0: '此处声明的数组 %0'
 # "array 'new' cannot have initialization arguments"
@@ -17873,7 +17873,7 @@ HB32CD52AC2F7: '数组索引 %0 超出数组末尾（该数组类型为 %1%selec
 # 'array index %0 refers past the last possible element for an array in %1-bit address space containing %2-bit (%3-byte) elements (max possible %4 element%s5)'
 H8C89DC3E13D9: '地址空间 %1 位中的数组包含 %2 位（%3 字节）元素，索引 %0 超出最大 %4 元素%s5'
 # 'array initializer must be an initializer list%select{| or string literal| or wide string literal}0'
-H4C9486DBC430: '数组初始化器必须是初始化列表%select{|或字符串字面量|或宽字符串字面量}0'
+H4C9486DBC430: '数组初始化器必须是初始化列表 %select{|或字符串字面量|或宽字符串字面量}0'
 # 'array is too large (%0 elements)'
 H898DDC47DE13: '数组过大（包含 %0 个元素）'
 # 'array of %0 type is invalid in OpenCL'
@@ -17887,7 +17887,7 @@ HF62708756DE6: '数组参数缺少空安全性类型说明符（_Nonnull、_Null
 # 'array section %select{lower bound|length}0 is not an integer'
 H54C64A3BE980: '数组区间的%select{下界|长度}0不是整数'
 # "array section %select{lower bound|length}0 is of type 'char'"
-H553F40D88798: '数组区间的%select{下界|长度}0类型为"char"'
+H553F40D88798: '数组区间的%select{下界|长度}0类型为 "char"'
 # 'array section does not specify contiguous storage'
 HD0B03CAA79AA: '数组区间未指定连续存储'
 # 'array section does not specify length for outermost dimension'
@@ -17901,7 +17901,7 @@ H521C171EF9F9: '数组成形操作的维度不是整数'
 # 'array size expression has incomplete class type %0'
 H48253C816CFD: '数组大小表达式具有不完全类类型 %0'
 # 'array size expression must have integral or %select{|unscoped }0enumeration type, not %1'
-H46181D36F61E: '数组大小表达式必须是整型或%select{|未命名 }0枚举类型，而不是 %1'
+H46181D36F61E: '数组大小表达式必须是整型或 %select{|未命名 }0枚举类型，而不是 %1'
 # 'array size expression of type %0 requires explicit conversion to type %1'
 H08A74EE986A3: '类型 %0 的数组大小表达式需要显式转换为类型 %1'
 # 'array size is negative'
@@ -17919,7 +17919,7 @@ HA2673E710254: '数组类型不能进行值初始化'
 # 'array-to-pointer decay of array member without known bound is not supported'
 HAB3F18D32404: '未知边界的数组成员的数组到指针衰减不受支持'
 # "as specified in %select{'collapse'|'ordered'|'collapse' and 'ordered'}0 clause%select{||s}0"
-H1ABDD2AD30EB: "如%select{'collapse'|'ordered'|'collapse' 和 'ordered'}0子句%select{||s}0中所述"
+H1ABDD2AD30EB: "如 %select{'collapse'|'ordered'|'collapse' 和 'ordered'}0 子句 %select{||s}0 中所述"
 # 'ascending'
 HF393CC9965C7: '升序'
 # 'asm constraint has an unexpected number of alternatives: %0 vs %1'
@@ -17963,7 +17963,7 @@ H95E39CFC8758: '每个变量类别只能出现一个defaultmap子句'
 # "at most one overload for a given name may lack the 'overloadable' attribute"
 H9206D4731FC1: "给定名称最多有一个重载函数可以不带 'overloadable' 属性"
 # "at most three expressions are allowed in '%0' clause in 'target teams ompx_bare' construct"
-HC1194A65DC15: "在'target teams ompx_bare'构造中的 '%0' 子句最多允许三个表达式"
+HC1194A65DC15: "在 'target teams ompx_bare' 构造中的 '%0' 子句最多允许三个表达式"
 # 'atomic %select{load|store}0 requires runtime support that is not available for this target'
 HD7BAEC48A8AF: '%select{加载|存储}0原子操作需要目标不支持的运行时支持'
 # "atomic by default property %0 has a user defined %select{getter|setter}1 (property should be marked 'atomic' if this is intended)"
@@ -17983,7 +17983,7 @@ H6E5B5738458E: '尝试在非堆%select{对象 %2|对象：块表达式|对象：
 # 'attempt to specialize declaration here'
 HF06CAF52936D: '尝试在此处特化声明'
 # 'attempt to use a deleted function%select{|: %1}0'
-HA9C947D267C4: '尝试使用已删除的函数%select{|: %1}0'
+HA9C947D267C4: '尝试使用已删除的函数 %select{|: %1}0'
 # 'attempt to use a poisoned identifier'
 H3643F70789A4: '尝试使用已被毒化的标识符'
 # 'attempting to use the forward class %0 as superclass of %1'
@@ -18069,7 +18069,7 @@ H05F9B2ABFA42: '该属性仅适用于输出参数'
 # 'attribute with scope specifier cannot follow default scope specifier'
 HFC36C268C353: '带作用域说明符的属性不能跟随默认作用域说明符'
 # 'attributes \'%0("%2")\' and \'%1("%2")\' are mutually exclusive'
-H56F1BA7862B2: '属性\'%0("%2")\'和\'%1("%2")\'是互斥的'
+H56F1BA7862B2: '属性\'%0("%2")\' 和\'%1("%2")\' 是互斥的'
 # 'attributes cannot be specified on a nested namespace definition'
 H4264DC0CBC46: '嵌套的命名空间定义不能指定属性'
 # 'attributes cannot be specified on namespace alias'
@@ -18085,15 +18085,15 @@ H0B109C7F8F74: '自动属性综合正在综合未显式综合的属性'
 # 'auto property synthesis will not synthesize property %0 because it cannot share an ivar with another synthesized property'
 HB5E0DEB40CE6: '自动属性综合不会合成属性 %0，因为它无法与其他综合属性共享实例变量'
 # "auto property synthesis will not synthesize property %0 because it is 'readwrite' but it will be synthesized 'readonly' via another property"
-H2BD61AD864B9: '自动属性综合不会合成属性 %0，因为它被标记为"readwrite"，但将通过另一个属性被综合为"readonly"'
+H2BD61AD864B9: '自动属性综合不会合成属性 %0，因为它被标记为 "readwrite"，但将通过另一个属性被综合为 "readonly"'
 # 'auto property synthesis will not synthesize property %0 declared in protocol %1'
 HA0C341D1A812: '自动属性综合不会合成在协议 %1 中声明的属性 %0'
 # 'auto property synthesis will not synthesize property %0; it will be implemented by its superclass, use @dynamic to acknowledge intention'
 H0457D53851AF: '自动属性综合不会合成属性 %0；它将由超类实现，请使用@dynamic声明此意图'
 # 'automatic variable qualified with an%select{| invalid}0 address space'
-H122ACAE25198: '自动变量使用%select{|无效}0地址空间限定'
+H122ACAE25198: '自动变量使用 %select{|无效}0地址空间限定'
 # 'autosynthesized property %0 will use %select{|synthesized}1 instance variable %2, not existing instance variable %3'
-H4495EA68D322: '自动综合的属性 %0 将使用%select{|综合的}1实例变量 %2，而非现有实例变量 %3'
+H4495EA68D322: '自动综合的属性 %0 将使用 %select{|综合的}1实例变量 %2，而非现有实例变量 %3'
 # 'availability does not match previous declaration'
 H583F2A1BC062: '可用性声明与之前的声明不匹配'
 # 'available multilibs are:%0'
@@ -18121,7 +18121,7 @@ H4B76670DCEA2: '基类具有不完整类型'
 # 'base class initializer %0 names both a direct base class and an inherited virtual base class'
 HAE21C251743B: '基类初始化项 %0 同时指定了直接基类和继承的虚基类'
 # 'base of member reference is a function; perhaps you meant to call it%select{| with no arguments}0?'
-H224FA72A413F: '成员引用的基础是一个函数；或许您想调用它%select{|无参数}0？'
+H224FA72A413F: '成员引用的基础是一个函数；或许您想调用它 %select{|无参数}0？'
 # 'base specifier must name a class'
 HBDBF7667EBAE: '基类说明符必须指定一个类'
 # 'basic register allocator'
@@ -18129,9 +18129,9 @@ HFEA9765B5A50: '基础寄存器分配器'
 # 'basic statistics'
 HAA78894D50F2: '基本统计信息'
 # 'because %select{base class of |field of |}0type %1 has a user-provided %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}2'
-HA75BA84DF85B: '因为 %select{基类的|字段的|}0类型 %1 包含用户提供的 %select{默认构造函数|拷贝构造函数|移动构造函数|拷贝赋值运算符|移动赋值运算符|析构函数}2'
+HA75BA84DF85B: '因为 %select{基类的|字段的|}0 类型 %1 包含用户提供的 %select{默认构造函数|拷贝构造函数|移动构造函数|拷贝赋值运算符|移动赋值运算符|析构函数}2'
 # 'because %select{base class of |field of |}0type %1 has no default constructor'
-HC07ABEF26326: '因为 %select{基类的|字段的|}0类型 %1 没有默认构造函数'
+HC07ABEF26326: '因为 %select{基类的|字段的|}0 类型 %1 没有默认构造函数'
 # 'because field %0 has an initializer'
 H7DB53EF856A5: '因为字段 %0 有初始化器'
 # 'because it has a default argument'
@@ -18149,11 +18149,11 @@ H708967A94C80: '因为替换后的约束表达式存在语法错误 %0'
 # 'because the function selected to %select{construct|copy|move|copy|move|destroy}2 %select{base class|field}0 of type %1 is not trivial'
 H1F152D129667: '因为选择用于%select{构造|复制|移动|复制|移动|销毁}2 %select{基类|字段}0 的类型 %1 的函数不是平凡的'
 # 'because type %0 has a member with %select{no|no|__strong|__weak|__autoreleasing}1 ownership'
-HE992EBFC669B: '因为类型 %0 有一个成员具有%select{无|无|__strong|__weak|__autoreleasing}1所有权'
+HE992EBFC669B: '因为类型 %0 有一个成员具有%select{无|无|__strong|__weak|__autoreleasing}1 所有权'
 # 'because type %0 has a virtual %select{member function|base class}1'
 H45351AACBEF7: '因为类型 %0 包含虚 %select{成员函数|基类}1'
 # "befriending %1 without '%select{struct|interface|union|class|enum}0' keyword is incompatible with C++98"
-HDE958FBB8995: "在没有'%select{struct|interface|union|class|enum}0'关键字的情况下友元声明 %1 与C++98不兼容"
+HDE958FBB8995: "在没有 '%select{struct|interface|union|class|enum}0' 关键字的情况下友元声明 %1 与C++98不兼容"
 # 'binary RIFF format'
 H555066C6C2A6: '二进制 RIFF 格式'
 # 'binary fold expression has unexpanded parameter packs in both operands'
@@ -18189,13 +18189,13 @@ H6CEDF6C3E571: '将引用成员 %0 绑定到栈分配的%select{变量|参数}2 
 # "binding type '%0' is invalid"
 HD0FB3A3589D6: "绑定类型 '%0' 无效"
 # "binding type '%select{t|u|b|s|c|i}0' cannot be applied more than once"
-H9FC4B2C35AB9: "绑定类型'%select{t|u|b|s|c|i}0'不能重复使用"
+H9FC4B2C35AB9: "绑定类型 '%select{t|u|b|s|c|i}0' 不能重复使用"
 # "binding type '%select{t|u|b|s|c}0' only applies to %select{SRV resources|UAV resources|constant buffer resources|sampler state|numeric variables in the global scope}0"
-H9DB6D490A30A: "绑定类型'%select{t|u|b|s|c}0'仅适用于%select{SRV资源|UAV资源|常量缓冲区资源|采样器状态|全局作用域中的数值变量}0"
+H9DB6D490A30A: "绑定类型 '%select{t|u|b|s|c}0' 仅适用于 %select{SRV资源|UAV资源|常量缓冲区资源|采样器状态|全局作用域中的数值变量}0"
 # "binding type '%select{t|u|b|s|c}0' only applies to types containing %select{SRV resources|UAV resources|constant buffer resources|sampler state|numeric types}0"
-H1CE73AE71EA5: "绑定类型'%select{t|u|b|s|c}0'仅适用于包含%select{SRV资源|UAV资源|常量缓冲区资源|采样器状态|数值类型}0的类型"
+H1CE73AE71EA5: "绑定类型 '%select{t|u|b|s|c}0' 仅适用于包含 %select{SRV资源|UAV资源|常量缓冲区资源|采样器状态|数值类型}0的类型"
 # "binding type 'b' only applies to constant buffers. The 'bool constant' binding type is no longer supported"
-HC83E5E495198: "绑定类型 'b' 仅适用于常量缓冲区。'bool constant'绑定类型已不再支持"
+HC83E5E495198: "绑定类型 'b' 仅适用于常量缓冲区。'bool constant' 绑定类型已不再支持"
 # "binding type 'c' ignored in buffer declaration. Did you mean 'packoffset'?"
 H937D8317B6A5: "绑定类型 'c' 在缓冲区声明中被忽略。您是指 'packoffset' 吗？"
 # "binding type 'i' ignored. The 'integer constant' binding type is no longer supported"
@@ -18223,7 +18223,7 @@ H7CE8DAA0A6CB: '强烈不建议使用位掩码来检查 Objective-C 对象指针
 # 'bitwise comparison always evaluates to %select{false|true}0'
 H8A4398170F46: '按位比较始终计算为 %select{false|true}0'
 # "bitwise negation of a boolean expression%select{;| always evaluates to 'true';}0 did you mean logical negation?"
-HE532D6128324: "布尔表达式的按位取反%select{;|始终计算为 'true';}0 是否应改为逻辑非运算？"
+HE532D6128324: "布尔表达式的按位取反 %select{;|始终计算为 'true';}0 是否应改为逻辑非运算？"
 # 'bitwise or with non-zero value always evaluates to true'
 H6F8F36ACC41B: '与非零值进行按位或运算始终计算为 true'
 # 'block cannot return %select{array|function}0 type %1'
@@ -18245,7 +18245,7 @@ H659E73E5BC81: '块将被%select{被捕获的对象|该对象强引用的对象}
 # 'blocks support disabled - compile with -fblocks or %select{pick a deployment target that supports them|for OpenCL C 2.0 or OpenCL C 3.0 with __opencl_c_device_enqueue feature}0'
 H870F6FD76494: '块功能被禁用 - 编译时需添加-fblocks选项或%select{选择支持块功能的部署目标|使用支持__opencl_c_device_enqueue特性的OpenCL C 2.0或 3.0}0'
 # "blocks used in enqueue_kernel call are expected to have parameters of type 'local void*'"
-H5A1C0A69E254: "enqueue_kernel调用中的block参数期望具有类型'local void*'类型"
+H5A1C0A69E254: "enqueue_kernel调用中的block参数期望具有类型 'local void*' 类型"
 # 'blocks with parameters are not accepted in this prototype of enqueue_kernel call'
 H6F73FE38020E: '此enqueue_kernel调用的原型不接受带有参数的块'
 # 'body of cpu_dispatch function will be ignored'
@@ -18259,7 +18259,7 @@ H8D491EEC35CA: '用于基本块对齐的边界'
 # 'brace elision for designated initializer is a C99 extension'
 H98B26CB02BEA: '指定初始化器的花括号省略是C99扩展'
 # 'braces around %select{scalar |}0initializer'
-H5FA1CA5D46EC: '初始化器周围的%select{标量 |}0花括号'
+H5FA1CA5D46EC: '初始化器周围的%select{标量 |}0 花括号'
 # 'bracket nesting level exceeded maximum of %0'
 HAE0DB07D013C: '超过最大嵌套层级 %0'
 # 'brackets are not allowed here; to declare an array, place the brackets after the %select{identifier|name}0'
@@ -18293,9 +18293,9 @@ HFC2F5B50372D: '内建头文件属于系统模块，且_Builtin_模块在处理c
 # 'builtin is not supported on this target'
 H6C31A7E5443F: '此目标不支持内建函数'
 # 'builtin requires%select{| at least one of the following extensions}0: %1'
-HBE3E35E72C33: '内建函数需要%select{|以下至少一个扩展}0: %1'
+HBE3E35E72C33: '内建函数需要 %select{|以下至少一个扩展}0: %1'
 # "but in %select{'%1'|definition here}0 found %select{%3 referenced %plural{1:protocol|:protocols}3|%ordinal3 referenced protocol with different name %4}2"
-HD3683C05282A: "但在%select{'%1'|此处的定义}0 发现 %select{引用了 %3 %plural{1:协议|:协议}3|%ordinal3 参考的协议名称不同 %4}2"
+HD3683C05282A: "但在 %select{'%1'|此处的定义}0 发现 %select{引用了 %3 %plural{1:协议|:协议}3|%ordinal3 参考的协议名称不同 %4}2"
 # "but in %select{'%1'|definition here}0 found %select{%select{method %4|constructor|destructor}3 that has %5 parameter%s5|%select{method %4|constructor|destructor}3 with %ordinal5 parameter of type %6%select{| decayed from %8}7|%select{method %4|constructor|destructor}3 with %ordinal5 parameter named %6}2"
 HF69A42480F6D: "但在 %select{'%1'|此处定义}0 发现 %select{%select{方法 %4|构造函数|析构函数}3 具有 %5 参数%s5|%select{方法 %4|构造函数|析构函数}3 的第 %ordinal5 参数类型为 %6%select{| 从 %8 衰减而来}7|%select{方法 %4|构造函数|析构函数}3 的第 %ordinal5 参数名为 %6}2"
 # "but in %select{'%1'|definition here}0 found %select{%select{no super class|super class with type %4}3|instance variable '%3' access control is %select{|@private|@protected|@public|@package}4}2"
@@ -18303,7 +18303,7 @@ H07A5F408116E: "但在 %select{'%1'|定义处}0 发现 %select{%select{无基类
 # "but in %select{'%1'|definition here}0 found %select{end of class|public access specifier|private access specifier|protected access specifier|static assert|field|method|type alias|typedef|data member|friend declaration|function template|method|instance variable|property}2"
 H901B5EFBD082: "但在 %select{'%1'|定义处}0 发现 %select{类结束|公共访问说明符|私有访问说明符|保护访问说明符|静态断言|数据成员|方法|类型别名|typedef|数据成员|友元声明|函数模板|方法|实例变量|属性}2"
 # "but in %select{'%1'|definition here}0 found %select{field %3|field %3 with type %4|%select{non-|}4bit-field %3|bit-field %3 with different width expression|%select{non-|}4mutable field %3|field %3 with %select{no|an}4 initializer|field %3 with a different initializer}2"
-H4C900A5437EA: "但在 %select{'%1'|定义处}0 发现 %select{字段 %3|类型为 %4 的字段 %3|%select{非-|}4位域 %3|宽度表达式不同的位域 %3|%select{非-|}4mutable字段 %3|字段 %3 具有 %select{无|一个}4初始化器|字段 %3 具有不同的初始化器}2"
+H4C900A5437EA: "但在 %select{'%1'|定义处}0 发现 %select{字段 %3|类型为 %4 的字段 %3|%select{非-|}4 位域 %3|宽度表达式不同的位域 %3|%select{非-|}4mutable字段 %3|字段 %3 具有 %select{无|一个}4初始化器|字段 %3 具有不同的初始化器}2"
 # "but in %select{'%1'|definition here}0 found %select{method %3 with different return type %4|method %3 as %select{class|instance}4 method|%select{no|'required'|'optional'}3 method control|method %3 with %select{no designated initializer|designated initializer}4|%select{regular|direct}4 method %3|different method %3}2"
 H9C08666CA7C3: "但在 %select{'%1'|定义处}0 发现 %select{返回类型不同的方法 %3 %4|作为 %select{类|实例}4 方法的 %3 方法|%select{无|'required'|'optional'}3 方法控制|方法 %3 具有 %select{非指定初始化器|命名初始化器}4|%select{常规|直接}4方法 %3|不同的方法 %3}2"
 # "but in %select{'%1'|definition here}0 found %select{property %3|property %3 with type %4|%select{no|'required'|'optional'}3 property control|property %3 with different '%select{none|readonly|getter|assign|readwrite|retain|copy|nonatomic|setter|atomic|weak|strong|unsafe_unretained|nullability|null_resettable|class|direct}4' attribute}2"
@@ -18321,9 +18321,9 @@ H926097C3EBA4: "但在 '%0' 中发现 %select{不同返回类型 %2|第 %ordinal
 # "but in '%0' found %select{enum that is %select{not scoped|scoped}2|enum scoped with keyword %select{struct|class}2|enum %select{without|with}2 specified type|enum with specified type %2|enum with %2 element%s2|%ordinal2 element has name %3|%ordinal2 element %3 %select{has|does not have}4 an initializer|%ordinal2 element %3 has different initializer|}1"
 H44D066860BB7: "但在 '%0' 中发现%select{枚举类型是%select{非命名空间|命名空间}2|使用 %select{struct|class}2 关键字作用域的枚举|枚举%select{没有|有}2指定类型|具有指定类型 %2 的枚举|包含 %2 个元素%s2的枚举|第%ordinal2个元素名为 %3|第%ordinal2个元素 %3%select{有|没有}4初始值设定项|第%ordinal2个元素 %3 具有不同的初始值设定项|}1"
 # "but in '%0' found %select{static assert with different condition|static assert with different message|static assert with %select{|no }2message|%select{method %3|constructor|destructor}2|%select{method %3|constructor|destructor}2 is %select{not deleted|deleted}4|%select{method %3|constructor|destructor}2 is %select{not defaulted|defaulted}4|%select{method %3|constructor|destructor}2 is %select{|pure }4%select{not virtual|virtual}5|%select{method %3|constructor|destructor}2 is %select{not static|static}4|%select{method %3|constructor|destructor}2 is %select{not volatile|volatile}4|%select{method %3|constructor|destructor}2 is %select{not const|const}4|%select{method %3|constructor|destructor}2 is %select{not inline|inline}4|%select{method %3|constructor|destructor}2 with %ordinal4 parameter with%select{out|}5 a default argument|%select{method %3|constructor|destructor}2 with %ordinal4 parameter with a different default argument|%select{method %3|constructor|destructor}2 with %select{no |}4template arguments|%select{method %3|constructor|destructor}2 with %4 template argument%s4|%select{method %3|constructor|destructor}2 with %4 for %ordinal5 template argument|%select{method %3|constructor|destructor}2 with %select{no body|body}4|%select{method %3|constructor|destructor}2 with different body|friend %select{class|function}2|friend %2|friend function %2|function template %2 with %3 template parameter%s3|function template %2 with %ordinal3 template paramter being a %select{type|non-type|template}4 template parameter|function template %2 with %ordinal3 template parameter %select{with no name|named %5}4|function template %2 with %ordinal3 template parameter with %select{no |}4default argument|function template %2 with %ordinal3 template parameter with default argument %4|function template %2 with %ordinal3 template parameter with different type|function template %2 with %ordinal3 template parameter %select{not |}4being a template parameter pack|}1"
-H650FCD73F7BC: "但在 '%0' 中发现 %select{具有不同条件的静态断言|具有不同消息的静态断言|具有%select{|无 }2消息的静态断言|%select{方法 %3|构造函数|析构函数}2|%select{方法 %3|构造函数|析构函数}2 是 %select{未删除|已删除}4|%select{方法 %3|构造函数|析构函数}2 是 %select{未默认|已默认}4|%select{方法 %3|构造函数|析构函数}2 是 %select{|纯 }4%select{非虚|虚}5|%select{方法 %3|构造函数|析构函数}2 是 %select{非静态|静态}4|%select{方法 %3|构造函数|析构函数}2 是 %select{非volatile|volatile}4|%select{方法 %3|构造函数|析构函数}2 是 %select{非const|const}4|%select{方法 %3|构造函数|析构函数}2 是 %select{非内联|内联}4|%select{方法 %3|构造函数|析构函数}2 的第 %ordinal4 参数带有%select{出|}5 默认参数|%select{方法 %3|构造函数|析构函数}2 的第 %ordinal4 参数具有不同默认参数|%select{方法 %3|构造函数|析构函数}2 具有%select{无|有}4模板参数|%select{方法 %3|构造函数|析构函数}2 具有 %4 模板参数%s4|%select{方法 %3|构造函数|析构函数}2 具有 %4 作为第 %ordinal5 模板参数|%select{方法 %3|构造函数|析构函数}2 具有%select{无|有}4函数体|%select{方法 %3|构造函数|析构函数}2 具有不同函数体|友元 %select{类|函数}2|友元 %2|友元函数 %2|函数模板 %2 具有 %3 模板参数%s3|函数模板 %2 具有第 %ordinal3 模板参数是 %select{类型|非类型|模板}4 模板参数|函数模板 %2 具有第 %ordinal3 模板参数%select{无名称|名称为 %5}4|函数模板 %2 具有第 %ordinal3 模板参数%select{无|}4默认参数|函数模板 %2 具有第 %ordinal3 模板参数默认参数 %4|函数模板 %2 具有第 %ordinal3 模板参数类型不同|函数模板 %2 具有第 %ordinal3 模板参数%select{不|}4是模板参数包|}1"
+H650FCD73F7BC: "但在 '%0' 中发现 %select{具有不同条件的静态断言|具有不同消息的静态断言|具有 %select{|无 }2消息的静态断言|%select{方法 %3|构造函数|析构函数}2|%select{方法 %3|构造函数|析构函数}2 是 %select{未删除|已删除}4|%select{方法 %3|构造函数|析构函数}2 是 %select{未默认|已默认}4|%select{方法 %3|构造函数|析构函数}2 是 %select{|纯 }4%select{非虚|虚}5|%select{方法 %3|构造函数|析构函数}2 是 %select{非静态|静态}4|%select{方法 %3|构造函数|析构函数}2 是 %select{非volatile|volatile}4|%select{方法 %3|构造函数|析构函数}2 是 %select{非const|const}4|%select{方法 %3|构造函数|析构函数}2 是 %select{非内联|内联}4|%select{方法 %3|构造函数|析构函数}2 的第 %ordinal4 参数带有%select{出|}5 默认参数|%select{方法 %3|构造函数|析构函数}2 的第 %ordinal4 参数具有不同默认参数|%select{方法 %3|构造函数|析构函数}2 具有%select{无|有}4模板参数|%select{方法 %3|构造函数|析构函数}2 具有 %4 模板参数%s4|%select{方法 %3|构造函数|析构函数}2 具有 %4 作为第 %ordinal5 模板参数|%select{方法 %3|构造函数|析构函数}2 具有%select{无|有}4函数体|%select{方法 %3|构造函数|析构函数}2 具有不同函数体|友元 %select{类|函数}2|友元 %2|友元函数 %2|函数模板 %2 具有 %3 模板参数%s3|函数模板 %2 具有第 %ordinal3 模板参数是 %select{类型|非类型|模板}4 模板参数|函数模板 %2 具有第 %ordinal3 模板参数%select{无名称|名称为 %5}4|函数模板 %2 具有第 %ordinal3 模板参数%select{无|}4 默认参数|函数模板 %2 具有第 %ordinal3 模板参数默认参数 %4|函数模板 %2 具有第 %ordinal3 模板参数类型不同|函数模板 %2 具有第 %ordinal3 模板参数%select{不|}4 是模板参数包|}1"
 # "but in '%0' found %select{unnamed template parameter %2|template parameter %3|template parameter with %select{no |}2default argument|template parameter with different default argument}1"
-HA18966A0FC1B: "但在 '%0' 中发现 %select{无名称模板参数 %2|模板参数 %3|模板参数%select{无 |}2默认参数|模板参数具有不同默认参数}1"
+HA18966A0FC1B: "但在 '%0' 中发现 %select{无名称模板参数 %2|模板参数 %3|模板参数%select{无 |}2 默认参数|模板参数具有不同默认参数}1"
 # "by value capture of '*this' is incompatible with C++ standards before C++17"
 H60BDFA125D23: "在C++17之前的C++标准中，通过值捕获 '*this' 是不兼容的"
 # 'by-copy capture of value of abstract type %0'
@@ -18343,13 +18343,13 @@ H00D075778CD9: '%select{立即|consteval}1 函数 %q0 的调用不是常量表�
 # 'call to %select{non-static|explicit}0 member function without an object argument'
 H63B47EF20C66: '调用%select{非静态|显式}0 成员函数时缺少对象参数'
 # 'call to %select{placement|class-specific}0 %1'
-H295DBDE7B5BD: '调用%select{placement|类特异性}0 %1'
+H295DBDE7B5BD: '调用 %select{placement|类特异性}0 %1'
 # "call to '%0' declared with 'error' attribute: %1"
 HDBB58BF71CEC: "调用用 'error' 属性声明的 '%0' 函数： %1"
 # "call to '%0' declared with 'warning' attribute: %1"
 H3865B6C0D901: "调用用 'warning' 属性声明的 '%0' 函数： %1"
 # "call to '%select{__builtin_operator_new|__builtin_operator_delete}0' selects non-usual %select{allocation|deallocation}0 function"
-H676581AF4E96: "调用'%select{__builtin_operator_new|__builtin_operator_delete}0'选择了非常规%select{分配|释放}0函数"
+H676581AF4E96: "调用 '%select{__builtin_operator_new|__builtin_operator_delete}0' 选择了非常规%select{分配|释放}0函数"
 # "call to '%select{initial_suspend|final_suspend}0' implicitly required by the %select{initial suspend point|final suspend point}0"
 H1C6B1E5ADCED: '在%select{初始挂起点|最终挂起点}0处隐式调用 %select{initial_suspend|final_suspend}0'
 # "call to 'await_transform' implicitly required by 'co_await' here"
@@ -18365,11 +18365,11 @@ H41309CFB27F8: "调用流式函数需要 'sme'"
 # 'call to constructor of %0 is ambiguous'
 H00A38B0315FF: '调用 %0 构造函数时存在歧义'
 # 'call to deleted constructor of %0%select{|: %2}1'
-HAA8E5FBCBA79: '调用已删除的 %0 构造函数%select{|： %2}1'
+HAA8E5FBCBA79: '调用已删除的 %0 构造函数 %select{|： %2}1'
 # 'call to deleted function call operator in type %0%select{|: %2}1'
-H8F857BEAC26F: '调用类型 %0 中的已删除函数调用运算符%select{|： %2}1'
+H8F857BEAC26F: '调用类型 %0 中的已删除函数调用运算符 %select{|： %2}1'
 # 'call to deleted%select{| member}0 function %1%select{|: %3}2'
-H6B002A51A7D4: '调用已删除%select{|成员}0函数 %1%select{|： %3}2'
+H6B002A51A7D4: '调用已删除 %select{|成员}0函数 %1%select{|： %3}2'
 # 'call to function %0 that is neither visible in the template definition nor found by argument-dependent lookup'
 H225588528963: '调用在模板定义中不可见且无法通过参数相关查找找到的函数 %0'
 # 'call to global function %0 not configured'
@@ -18433,27 +18433,27 @@ HA2E8E747932F: '候选%select{构造函数|模板}0被忽略：继承的构造�
 # 'candidate %select{constructor|template}0 ignored: instantiation %select{takes|would take}0 its own class type by value'
 H5F81F51806D8: '候选%select{构造函数|模板}0被忽略：实例化%select{需要|需要}0按值获取自身类类型'
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 has been %select{explicitly made unavailable|explicitly deleted|implicitly deleted}3"
-HDF3920A3A1F2: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1已被%select{显式禁用|显式删除|隐式删除}3"
+HDF3920A3A1F2: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式 'operator==' 运算符|继承构造函数}0%select{|模板| %2}1 已被%select{显式禁用|显式删除|隐式删除}3"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: %ordinal5 argument (%3) would lose %select{const|restrict|const and restrict|volatile|const and volatile|volatile and restrict|const, volatile, and restrict}4 qualifier%select{||s||s|s|s}4"
-H95E4AEB3B23E: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1不可行：第%ordinal5参数（%3）将丢失 %select{const|restrict|const和restrict|volatile|const和volatile|volatile和restrict|const、volatile和restrict}4 限定符%select{||s||s|s|s}4"
+H95E4AEB3B23E: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式 'operator==' 运算符|继承构造函数}0%select{|模板| %2}1 不可行：第%ordinal5参数（%3）将丢失 %select{const|restrict|const和restrict|volatile|const和volatile|volatile和restrict|const、volatile和restrict}4 限定符 %select{||s||s|s|s}4"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: %select{%ordinal7|'this'}6 argument (%3) has %select{no|__unsafe_unretained|__strong|__weak|__autoreleasing}4 ownership, but parameter has %select{no|__unsafe_unretained|__strong|__weak|__autoreleasing}5 ownership"
-H8D414CDC2F4E: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1不可行：%select{第%ordinal7|'this'}6参数（%3）具有%select{无|__unsafe_unretained|__strong|__weak|__autoreleasing}4所有权，但参数需要%select{无|__unsafe_unretained|__strong|__weak|__autoreleasing}5所有权"
+H8D414CDC2F4E: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式 'operator==' 运算符|继承构造函数}0%select{|模板| %2}1 不可行：%select{第%ordinal7|'this'}6 参数（%3）具有%select{无|__unsafe_unretained|__strong|__weak|__autoreleasing}4 所有权，但参数需要%select{无|__unsafe_unretained|__strong|__weak|__autoreleasing}5 所有权"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: %select{%ordinal7|'this'}6 argument (%3) has %select{no|__weak|__strong}4 ownership, but parameter has %select{no|__weak|__strong}5 ownership"
-HFD1E148AC849: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1不可行：%select{第%ordinal7|'this'}6参数（%3）具有%select{无|__weak|__strong}4所有权，但参数需要%select{无|__weak|__strong}5所有权"
+HFD1E148AC849: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式 'operator==' 运算符|继承构造函数}0%select{|模板| %2}1 不可行：%select{第%ordinal7|'this'}6 参数（%3）具有%select{无|__weak|__strong}4 所有权，但参数需要%select{无|__weak|__strong}5 所有权"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: %select{cannot convert initializer list|too few initializers in list|too many initializers in list}7 argument to %4"
-H4C57102C9323: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1不可行：%select{无法转换初始化列表|列表初始化器太少|列表初始化器过多}7参数到 %4"
+H4C57102C9323: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式 'operator==' 运算符|继承构造函数}0%select{|模板| %2}1 不可行：%select{无法转换初始化列表|列表初始化器太少|列表初始化器过多}7参数到 %4"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: %select{requires at least|allows at most single|requires single}3 %select{|non-object }6argument %4, but %plural{0:no|:%5}5 arguments were provided"
 H8AD4B8B6097C: "候选 %select{函数|函数|参数顺序反转的函数|构造函数|隐式默认构造函数|隐式拷贝构造函数|隐式移动构造函数|隐式赋值运算符|隐式移动赋值运算符|隐式 'operator=='（对应三向比较运算符）|继承的构造函数}0%select{| 模板| %2}1 不可用：需要 %select{至少|最多一个|一个}3 %select{非对象|}6 参数 %4，但提供 %plural{0:0|:%5}5 个参数"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: 'this' argument has type %3, but method is not marked %select{const|restrict|const or restrict|volatile|const or volatile|volatile or restrict|const, volatile, or restrict}4"
-HE6BBB39EEE68: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1不可行：'this' 参数具有类型 %3，但方法未标记为 %select{const|restrict|const或restrict|volatile|const或volatile|volatile或restrict|const、volatile或restrict}4"
+HE6BBB39EEE68: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式 'operator==' 运算符|继承构造函数}0%select{|模板| %2}1 不可行：'this' 参数具有类型 %3，但方法未标记为 %select{const|restrict|const或restrict|volatile|const或volatile|volatile或restrict|const、volatile或restrict}4"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: 'this' object is in %3, but method expects object in %4"
-H7EDBF536C9E0: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1不可行：'this' 对象处于 %3 状态，但方法期望处于 %4 状态"
+H7EDBF536C9E0: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式 'operator==' 运算符|继承构造函数}0%select{|模板| %2}1 不可行：'this' 对象处于 %3 状态，但方法期望处于 %4 状态"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: call to %select{__device__|__global__|__host__|__host__ __device__|invalid}3 function from %select{__device__|__global__|__host__|__host__ __device__|invalid}4 function"
-HB286FD7ADB16: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1不可行：从%select{__device__|__global__|__host__|__host__ __device__|无效}4函数调用%select{__device__|__global__|__host__|__host__ __device__|无效}3函数"
+HB286FD7ADB16: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式 'operator==' 运算符|继承构造函数}0%select{|模板| %2}1 不可行：从 %select{__device__|__global__|__host__|__host__ __device__|无效}4函数调用 %select{__device__|__global__|__host__|__host__ __device__|无效}3函数"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: cannot %select{convert from|convert from|bind}3 %select{base class pointer|superclass|base class object of type}3 %4 to %select{derived class pointer|subclass|derived class reference}3 %5 for %ordinal6 argument"
-H9EF538024430: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1不可行：无法%select{将|将|绑定}3%select{基类指针|基类|基类对象}3 %4 转换为%select{派生类指针|派生类|派生类引用}3 %5 作为第%ordinal6参数"
+H9EF538024430: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式 'operator==' 运算符|继承构造函数}0%select{|模板| %2}1 不可行：无法%select{将|将|绑定}3%select{基类指针|基类|基类对象}3 %4 转换为%select{派生类指针|派生类|派生类引用}3 %5 作为第%ordinal6参数"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: cannot %select{pass pointer to|bind reference in}5 %3 %select{as a pointer to|to object in}5 %4 in %ordinal6 argument"
-HEE13EA6B12B0: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1不可行：无法%select{将指针转换为|在引用中绑定}5 %3 %select{作为指向|到}5 %4 的%ordinal6参数"
+HEE13EA6B12B0: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式 'operator==' 运算符|继承构造函数}0%select{|模板| %2}1 不可行：无法%select{将指针转换为|在引用中绑定}5 %3 %select{作为指向|到}5 %4 的%ordinal6参数"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: cannot convert argument of incomplete type %diff{$ to $|to parameter type}3,4 for %select{%ordinal6 argument|object argument}5%select{|; dereference the argument with *|; take the address of the argument with &|; remove *|; remove &}7"
 H3F2CD3D64E80: "候选 %select{函数|函数|函数（参数顺序反转）|构造函数|构造函数（隐式默认构造函数）|构造函数（隐式拷贝构造函数）|构造函数（隐式移动构造函数）|函数（隐式拷贝赋值运算符）|函数（隐式移动赋值运算符）|函数（为此 'operator<=>' 隐式生成的 'operator=='）|继承的构造函数}0%select{|模板| %2}1 不可用：无法将不完整类型 %diff{的参数从 $ 转换为 $|的参数类型转换为参数类型}3,4 的 %select{%ordinal6 参数|对象参数}5%select{|; 通过 * 解引用参数|; 使用 & 获取参数的地址|; 移除 *|; 移除 &}7"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: cannot implicitly convert argument %diff{of type $ to $|type to parameter type}3,4 for %select{%ordinal6 argument|object argument}5 under ARC"
@@ -18469,7 +18469,7 @@ H327F9AFBF1B4: "候选 %select{函数|函数|函数（参数顺序反转）|构�
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: requires%select{ at least| at most|}3 %4 %select{|non-object }6argument%s4, but %5 %plural{1:was|:were}5 provided"
 HE70B20B055FA: "候选 %select{函数|函数|函数（参数顺序反转）|构造函数|构造函数（隐式默认构造函数）|构造函数（隐式拷贝构造函数）|构造函数（隐式移动构造函数）|函数（隐式拷贝赋值运算符）|函数（隐式移动赋值运算符）|函数（为此 'operator<=>' 隐式生成的 'operator=='）|继承的构造函数}0%select{|模板| %2}1 不可用：需要%select{ 至少| 至多|}3 %4 %select{|非对象 }6参数%s4，但提供了 %5 %plural{1:1个|:多个}5"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %3}1%select{| has different class%diff{ (expected $ but has $)|}5,6| has different number of parameters (expected %5 but has %6)| has type mismatch at %ordinal5 parameter%diff{ (expected $ but has $)|}6,7| has different return type%diff{ ($ expected but has $)|}5,6| has different qualifiers (expected %5 but found %6)| has different exception specification}4"
-H8C85DA7348D1: "候选%select{函数|函数|参数顺序反转的函数|构造函数|隐式的默认构造函数|隐式的拷贝构造函数|隐式的移动构造函数|隐式的拷贝赋值运算符|隐式的移动赋值运算符|为该'operator<=>'隐式声明的'operator==|继承的构造函数}0%select{|模板| %3}1%select{| 类型不同%diff{（期望$ 但实际为$)|}5,6| 参数数量不同（期望 %5 但实际为 %6)| 第%ordinal5个参数类型不匹配%diff{（期望$ 但实际为$)|}6,7| 返回类型不同%diff{（$ 期望但实际为$)|}5,6| 返回类型修饰符不同（期望 %5 但实际为 %6)| 异常规格说明不同}4"
+H8C85DA7348D1: "候选%select{函数|函数|参数顺序反转的函数|构造函数|隐式的默认构造函数|隐式的拷贝构造函数|隐式的移动构造函数|隐式的拷贝赋值运算符|隐式的移动赋值运算符|为该 'operator<=>' 隐式声明的'operator==|继承的构造函数}0%select{|模板| %3}1%select{| 类型不同%diff{（期望$ 但实际为$)|}5,6| 参数数量不同（期望 %5 但实际为 %6)| 第%ordinal5个参数类型不匹配%diff{（期望$ 但实际为$)|}6,7| 返回类型不同%diff{（$ 期望但实际为$)|}5,6| 返回类型修饰符不同（期望 %5 但实际为 %6)| 异常规格说明不同}4"
 # 'candidate address cannot be taken because parameter %0 has pass_object_size attribute'
 H9C284929AC5A: '无法获取候选地址，因为参数 %0 具有 pass_object_size 属性'
 # 'candidate constructor ignored: cannot be used to construct an object in address space %0'
@@ -18499,7 +18499,7 @@ HC96827B6C1DA: '候选模板被忽略：推导出的%select{冲突的类型|冲�
 # 'candidate template ignored: deduced too few arguments for expanded pack %0; no argument for %ordinal1 expanded parameter in deduced argument pack %2'
 HCCA72493BB47: '候选模板被忽略：为展开的参数包 %0 推断出的参数过少；在推断出的参数包 %2 中没有为第%ordinal1 展开的参数提供参数'
 # 'candidate template ignored: deduced type %diff{$ of %select{|element of }4%ordinal0 parameter does not match adjusted type $ of %select{|element of }4argument|of %select{|element of }4%ordinal0 parameter does not match adjusted type of %select{|element of }4argument}1,2%3'
-HF6006A393B95: '候选模板被忽略：推导出的类型%diff{$ of %select{|element of }4%ordinal0参数与调整后的类型$ of %select{|element of }4实参不匹配|of %select{|element of }4%ordinal0参数与调整后的%select{|element of }4实参类型不匹配}1,2%3'
+HF6006A393B95: '候选模板被忽略：推导出的类型 %diff{$ of %select{|element of }4%ordinal0参数与调整后的类型$ of %select{|element of }4实参不匹配|of %select{|element of }4%ordinal0参数与调整后的 %select{|element of }4实参类型不匹配}1,2%3'
 # 'candidate template ignored: deduced values %diff{of conflicting types for parameter %0 (%1 of type $ vs. %3 of type $)|%1 and %3 of conflicting types for parameter %0}2,4'
 H300B96CC7A66: '模板候选被忽略：推导值 %diff{为参数 %0 的类型冲突（%1 类型 $ 与 %3 类型 $）|参数 %0 的 %1 和 %3 类型冲突}2,4'
 # 'candidate template ignored: disabled by %0%1'
@@ -18519,9 +18519,9 @@ HF32FE861D856: '候选模板被忽略：替换失败 %0%1'
 # 'candidate template ignored: target attributes do not match'
 H8F2E4648A7AB: '候选模板被忽略：目标属性不匹配'
 # "cannot %select{#include files|import headers}0 inside '#pragma clang arc_cf_code_audited'"
-HE8C6864AFFBD: "无法在'#pragma clang arc_cf_code_audited'内%select{包含文件|导入头文件}0"
+HE8C6864AFFBD: "无法在 '#pragma clang arc_cf_code_audited' 内%select{包含文件|导入头文件}0"
 # "cannot %select{#include files|import headers}0 inside '#pragma clang assume_nonnull'"
-H5A02E21DB221: "无法在'#pragma clang assume_nonnull'内%select{包含文件|导入头文件}0"
+H5A02E21DB221: "无法在 '#pragma clang assume_nonnull' 内%select{包含文件|导入头文件}0"
 # 'cannot %select{access base class of|access derived class of|access field of|access array element of|ERROR|access real component of|access imaginary component of}0 pointer past the end of object'
 HBEBB0813D273: '无法%select{访问超出对象结尾的基类指针|访问超出对象结尾的派生类指针|访问超出对象结尾的字段|访问超出对象结尾的数组元素|ERROR|访问超出对象结尾的实部指针|访问超出对象结尾的虚部指针}0'
 # 'cannot %select{access base class of|access derived class of|access field of|access array element of|perform pointer arithmetic on|access real component of|access imaginary component of}0 null pointer'
@@ -18543,7 +18543,7 @@ H40A5A6DFAC87: "无法 %select{使用内建运算符 '<=>'|默认 'operator<=>' 
 # 'cannot %select{use type %1 for a function/method parameter|use type %1 for function/method return|default-initialize an object of type %1|declare an automatic variable of type %1|copy-initialize an object of type %1|assign to a variable of type %1|construct an automatic compound literal of type %1|capture a variable of type %1|cannot use volatile type %1 where it causes an lvalue-to-rvalue conversion}3 since it %select{contains|is}2 a union that is non-trivial to %select{default-initialize|destruct|copy}0'
 H72F7777296D1: '无法 %select{使用类型 %1 作为函数/方法参数|使用类型 %1 作为函数/方法返回类型|默认初始化类型 %1 的对象|声明类型 %1 的自动变量|拷贝初始化类型 %1 的对象|将变量赋值为类型 %1|构造类型 %1 的自动复合字面量|捕获类型 %1 的变量|使用会导致左值转右值的易失性类型 %1}3，因为它 %select{包含|是}2 一个难以 %select{默认初始化|销毁|复制}0 的联合类型'
 # 'cannot %select{||reinterpret_cast||C-style cast||}0 from member pointer type %1 to member pointer type %2 of different size'
-H4DC29F600065: '无法%select{||reinterpret_cast||C-style cast||}0 将成员指针类型 %1 转换为不同大小的成员指针类型 %2'
+H4DC29F600065: '无法 %select{||reinterpret_cast||C-style cast||}0 将成员指针类型 %1 转换为不同大小的成员指针类型 %2'
 # "cannot add 'abi_tag' attribute in a redeclaration"
 H48F70104AB1E: '无法在重新声明中添加 "abi_tag" 属性'
 # 'cannot add a default template argument to the definition of a member of a class template'
@@ -18617,7 +18617,7 @@ HB63F6FC3F823: "无法将非零值 '%0' 转换为 'event_t'"
 # 'cannot cast object of dynamic type %0 to type %1'
 H29A99B2195B9: '无法将动态类型为 %0 的对象转换为类型 %1'
 # 'cannot catch %select{|reference to }0sizeless type %1'
-HFDB51E9BFE05: '不能捕获%select{|引用到}0大小不明确的类型 %1'
+HFDB51E9BFE05: '不能捕获 %select{|引用到}0大小不明确的类型 %1'
 # 'cannot catch an Objective-C object by value'
 HE53524ADBBC8: '不能按值捕获Objective-C对象'
 # 'cannot catch an exception thrown with @throw in C++ in the non-unified exception model'
@@ -18685,7 +18685,7 @@ H8E19851C2991: '不能在 friend 中声明显式特化'
 # 'cannot declare class extension for %0 after class implementation'
 H472ADAE23CEA: '类实现后不能为 %0 声明类扩展'
 # "cannot declare implementation of a class declared with the 'objc_class_stub' attribute"
-H831B35F688CB: '无法将命名空间"std"声明为内联'
+H831B35F688CB: '无法将命名空间 "std" 声明为内联'
 # "cannot declare the namespace 'std' to be inline"
 H1345EF64CB88: '无法在@interface或@protocol内声明变量'
 # 'cannot declare variable inside @interface or @protocol'
@@ -18705,13 +18705,13 @@ HE08DBE349649: '无法分解 %0 的二义性基类 %1 的成员：%2'
 # 'cannot decompose members of inaccessible base class %1 of %0'
 HA6ED46C6B298: '无法分解 %0 的不可访问基类 %1 的成员'
 # "cannot decompose this type; 'std::tuple_element<%0>::type' does not name a type"
-H4AD140BFCF3D: "无法分解此类型；'std::tuple_element<%0>::type'不是一个类型名称"
+H4AD140BFCF3D: "无法分解此类型；'std::tuple_element<%0>::type' 不是一个类型名称"
 # "cannot decompose this type; 'std::tuple_size<%0>::value' is not a valid integral constant expression"
-HE140F3EE6033: "无法分解此类型；'std::tuple_size<%0>::value'不是一个有效的整数常量表达式"
+HE140F3EE6033: "无法分解此类型；'std::tuple_size<%0>::value' 不是一个有效的整数常量表达式"
 # 'cannot decrement expression of type bool'
 H9DABD4A4074A: '不能递减类型为bool的表达式'
 # "cannot deduce 'decltype(auto)' from initializer list"
-H0294CF60338E: "无法从初始化列表推导'decltype(auto)'类型"
+H0294CF60338E: "无法从初始化列表推导 'decltype(auto)' 类型"
 # 'cannot deduce actual type for %1 from %select{parenthesized|nested}0 initializer list'
 H1C99EC9B7047: '无法从%select{括号包围的|嵌套}0初始化列表推导 %1 的实际类型'
 # 'cannot deduce actual type for variable %0 with type %1 from initializer list'
@@ -18753,7 +18753,7 @@ HF67617A49B06: '无法定义非内联dllimport模板特化'
 # 'cannot define or redeclare %0 here because namespace %1 does not enclose namespace %2'
 HFA38E82744C2: '无法在此处定义或重新声明 %0，因为命名空间 %1 不包含命名空间 %2'
 # 'cannot define the implicit copy assignment operator for %0, because non-static %select{reference|const}1 member %2 cannot use copy assignment operator'
-H50812469123A: '无法为 %0 推导隐式拷贝赋值运算符，因为非静态%select{引用|const}1成员 %2 无法使用拷贝赋值运算符'
+H50812469123A: '无法为 %0 推导隐式拷贝赋值运算符，因为非静态%select{引用|const}1 成员 %2 无法使用拷贝赋值运算符'
 # 'cannot delete expression of type %0'
 H8F9B57A837EE: '无法删除类型 %0 的表达式'
 # "cannot delete expression with pointer-to-'void' type %0"
@@ -18779,15 +18779,15 @@ H49EEB2061C19: '无法导出 %0，因为它不在命名空间作用域中'
 # 'cannot export redeclaration %0 here since the previous declaration %select{is not exported|has internal linkage|has module linkage}1'
 H805545AFF107: '由于之前的声明%select{未导出|具有内部链接性|具有模块链接性}1，因此无法在此处导出 %0 的重新声明'
 # "cannot find CUDA installation; provide its path via '--cuda-path', or pass '-nocudainc' to build without CUDA includes"
-H483DC86F4594: "无法找到CUDA安装路径；请通过'--cuda-path'提供其路径，或使用'-nocudainc'选项不包含CUDA头文件进行编译"
+H483DC86F4594: "无法找到CUDA安装路径；请通过 '--cuda-path' 提供其路径，或使用 '-nocudainc' 选项不包含CUDA头文件进行编译"
 # "cannot find HIP Standard Parallelism Acceleration library; provide it via '--hipstdpar-path'"
-H20ABDE201926: "无法找到HIP标准并行加速库；请通过'--hipstdpar-path'提供其路径"
+H20ABDE201926: "无法找到HIP标准并行加速库；请通过 '--hipstdpar-path' 提供其路径"
 # "cannot find HIP device library%select{| for %1}0; provide its path via '--hip-path' or '--hip-device-lib-path', or pass '-nogpulib' to build without HIP device library"
-H74B6BE24033A: "无法找到HIP设备库%select{|用于 %1}0；请通过'--hip-path'或'--hip-device-lib-path'提供其路径，或使用'-nogpulib'选项不链接HIP设备库进行编译"
+H74B6BE24033A: "无法找到HIP设备库 %select{|用于 %1}0；请通过 '--hip-path' 或 '--hip-device-lib-path' 提供其路径，或使用 '-nogpulib' 选项不链接HIP设备库进行编译"
 # "cannot find HIP runtime; provide its path via '--rocm-path', or pass '-nogpuinc' to build without HIP runtime"
-H11EBFA045BE3: "无法找到HIP运行时；请通过'--rocm-path'提供其路径，或使用'-nogpuinc'选项不包含HIP运行时进行编译"
+H11EBFA045BE3: "无法找到HIP运行时；请通过 '--rocm-path' 提供其路径，或使用 '-nogpuinc' 选项不包含HIP运行时进行编译"
 # "cannot find ROCm device library%select{| for %1| for ABI version %1}0; provide its path via '--rocm-path' or '--rocm-device-lib-path', or pass '-nogpulib' to build without ROCm device library"
-H7B7F4A357272: "无法找到ROCm设备库%select{|用于 %1|用于ABI版本 %1}0；请通过'--rocm-path'或'--rocm-device-lib-path'提供其路径，或使用'-nogpulib'选项不链接ROCm设备库进行编译"
+H7B7F4A357272: "无法找到ROCm设备库 %select{|用于 %1|用于ABI版本 %1}0；请通过 '--rocm-path' 或 '--rocm-device-lib-path' 提供其路径，或使用 '-nogpulib' 选项不链接ROCm设备库进行编译"
 # 'cannot find a valid user-defined mapper for type %0 with name %1'
 H0907A5973C27: '未找到类型 %0 且名称为 %1 的有效用户自定义映射器'
 # "cannot find end ('%1') of expected %0"
@@ -18801,7 +18801,7 @@ H691319D1E232: '未找到 %0 的接口声明（%1 的基类）；是否是指 %2
 # 'cannot find interface declaration for %0; did you mean %1?'
 H3FD5BD5869C6: '未找到 %0 的接口声明；是否是指 %1？'
 # "cannot find libdevice for %0; provide path to different CUDA installation via '--cuda-path', or pass '-nocudalib' to build without linking with libdevice"
-H9C8FBD27D916: "无法找到 %0 的libdevice；请通过'--cuda-path'提供其他CUDA安装路径，或使用'-nocudalib'选项不链接libdevice进行编译"
+H9C8FBD27D916: "无法找到 %0 的libdevice；请通过 '--cuda-path' 提供其他CUDA安装路径，或使用 '-nocudalib' 选项不链接libdevice进行编译"
 # 'cannot find protocol declaration for %0'
 H8559765777E9: '未找到 %0 的协议声明'
 # 'cannot find protocol declaration for %0; did you mean %1?'
@@ -18811,11 +18811,11 @@ H30EC809C2E8C: '未找到 %0 的协议定义'
 # "cannot find re-exported %select{framework|library}0: '%1'"
 HFF74F7CAAAC8: "无法找到导出的%select{框架|库}0：'%1'"
 # "cannot find rocPrim, which is required by the HIP Standard Parallelism Acceleration library; provide it via '--hipstdpar-prim-path'"
-H7420A8DBF79F: "无法找到由HIP标准并行加速库所需的rocPrim；请通过'--hipstdpar-prim-path'提供其路径"
+H7420A8DBF79F: "无法找到由HIP标准并行加速库所需的rocPrim；请通过 '--hipstdpar-prim-path' 提供其路径"
 # "cannot find rocThrust, which is required by the HIP Standard Parallelism Acceleration library; provide it via '--hipstdpar-thrust-path'"
-HF20DC196E1CB: "找不到rocThrust，这是HIP标准并行加速库所必需的；请通过'--hipstdpar-thrust-path'提供它"
+HF20DC196E1CB: "找不到rocThrust，这是HIP标准并行加速库所必需的；请通过 '--hipstdpar-thrust-path' 提供它"
 # "cannot find start ('{{') of expected %0"
-H727EB43115FC: "无法找到期望 %0 的起始标记'{{'"
+H727EB43115FC: "无法找到期望 %0 的起始标记 '{{'"
 # "cannot find start of regex ('{{') in %0"
 HD5BDA70A3617: "在 %0 中找不到正则表达式的起始符（'{{'）"
 # 'cannot find suitable %select{getter|setter}0 for property %1'
@@ -18829,9 +18829,9 @@ H45A1DB7A6AF3: '无法形成引用类型 %1 的成员 %0 的成员指针'
 # "cannot form a reference to 'void'"
 H6E82068C4FE4: "无法形成对 'void' 的引用"
 # "cannot form member pointer of type %0 without '&' and class name"
-HA98A1BC7CEC4: "无法在没有'&'和类名的情况下形成类型 %0 的成员指针"
+HA98A1BC7CEC4: "无法在没有 '&' 和类名的情况下形成类型 %0 的成员指针"
 # 'cannot generate code for reduction on %select{|array section, which requires a }0variable length array'
-H328E15AAC013: '无法为%select{|数组段，需要一个}0变长数组生成代码'
+H328E15AAC013: '无法为 %select{|数组段，需要一个}0变长数组生成代码'
 # 'cannot have both throw() and noexcept() clause on the same function'
 H93A58AAAE480: '同一个函数不能同时使用throw()和noexcept()子句'
 # 'cannot implement a category for class %0 that is only visible via the Objective-C runtime'
@@ -18925,9 +18925,9 @@ H92D6BE5E0D10: '无法在%select{从|到}0%select{构造函数|析构函数}1执
 # 'cannot perform a tail call from this return statement'
 HD566EFBB0F10: '无法从此返回语句执行尾调用'
 # 'cannot perform a tail call to function%select{| %1}0 because it uses an incompatible calling convention'
-H32E425482ACE: '无法对%select{| %1}0函数执行尾调用，因为它使用了不兼容的调用约定'
+H32E425482ACE: '无法对 %select{| %1}0 函数执行尾调用，因为它使用了不兼容的调用约定'
 # 'cannot perform a tail call to function%select{| %1}0 because its signature is incompatible with the calling function'
-HB6791E3481C6: '无法对%select{| %1}0函数执行尾调用，因为其签名与调用函数不兼容'
+HB6791E3481C6: '无法对 %select{| %1}0 函数执行尾调用，因为其签名与调用函数不兼容'
 # 'cannot perform atomic operation on a pointer to type %0: type has non-trivial ownership'
 H33A9E57472E9: '无法对类型 %0 的指针执行原子操作：该类型具有非平凡所有权'
 # "cannot read configuration file '%0': %1"
@@ -18949,11 +18949,11 @@ H3ACCC42BDE35: '不能在代码块内引用具有变长类型声明的变量'
 # 'cannot refer to declaration with an array type inside block'
 HBA9381EF3C23: '不能在代码块内引用具有数组类型的声明'
 # 'cannot refer to element %0 of %select{array of %2 element%plural{1:|:s}2|non-array object}1 in a constant expression'
-H97B7B294ED7C: '不能在常量表达式中引用%select{包含 %2 元素的数组%plural{1:|:s}2|非数组对象}1的元素 %0'
+H97B7B294ED7C: '不能在常量表达式中引用%select{包含 %2 元素的数组 %plural{1:|:s}2|非数组对象}1的元素 %0'
 # "cannot refer to member %0 in %1 with '%select{.|->}2'"
-HF25CD96D4723: "无法使用'%select{.|->}2'在 %1 中引用成员 %0"
+HF25CD96D4723: "无法使用 '%select{.|->}2' 在 %1 中引用成员 %0"
 # "cannot refer to type member %0 in %1 with '%select{.|->}2'"
-H982BCA02E9FD: "无法使用'%select{.|->}2'在 %1 中引用类型成员 %0"
+H982BCA02E9FD: "无法使用 '%select{.|->}2' 在 %1 中引用类型成员 %0"
 # 'cannot reference member of primary template because deduced class template specialization %0 is %select{instantiated from a partial|an explicit}1 specialization'
 HF04074EDD691: '无法引用主模板的成员，因为推导出的类模板特化 %0 是%select{部分特化|显式}1的特化'
 # 'cannot resolve lock expression'
@@ -18967,11 +18967,11 @@ H50389542B8AD: '不能为不完全类型 %0 设置虚表指针认证'
 # 'cannot set vtable pointer authentication on monomorphic type %0'
 H365AD22227CA: '不能为单态类型 %0 设置虚表指针认证'
 # "cannot specialize %select{|(with 'template<>') }0a member of an unspecialized template"
-H21C951459621: "不能特化未特化的模板成员%select{|(使用'template<>' )}0"
+H21C951459621: "不能特化未特化的模板成员 %select{|(使用 'template<>' )}0"
 # 'cannot specialize a %select{dependent template|template template parameter}0'
 HC5BFF931F55D: '不能特化%select{依赖模板|模板模板参数}0'
 # "cannot specify '%0%1' when compiling multiple source files"
-HFD3172559132: "在编译多个源文件时不能指定'%0%1'"
+HFD3172559132: "在编译多个源文件时不能指定 '%0%1'"
 # "cannot specify '%1' along with '%0'"
 H9F94923DAC7E: "不能同时指定 '%1' 和 '%0'"
 # 'cannot specify -o when generating multiple output files'
@@ -18979,7 +18979,7 @@ HE249C344BFD2: '生成多个输出文件时不能指定 -o'
 # 'cannot specify a default vtable pointer authentication %select{key|address discrimination mode|discriminator}0 with no default set'
 H3A1B9264D760: '未设置默认值时无法指定默认 vtable 指针验证 %select{密钥|地址鉴别模式|鉴别符}0'
 # "cannot specify any part of a return type in the declaration of a conversion function%select{; put the complete type after 'operator'|; use a typedef to declare a conversion to %1|; use an alias template to declare a conversion to %1|}0"
-HAA40A3FFF9F4: "在转换函数声明中不能指定返回类型的任何部分%select{; 在 'operator' 后面写出完整类型|; 使用 typedef 声明向 %1 的转换|; 使用别名模板声明向 %1 的转换|}0"
+HAA40A3FFF9F4: "在转换函数声明中不能指定返回类型的任何部分 %select{; 在 'operator' 后面写出完整类型|; 使用 typedef 声明向 %1 的转换|; 使用别名模板声明向 %1 的转换|}0"
 # 'cannot specify any part of a return type in the declaration of a deduction guide'
 H390B6E7B14DB: '在推导指引的声明中不能指定返回类型的任何部分'
 # 'cannot specify deduction guide for %select{<error>|function template|variable template|alias template|template template parameter|concept|dependent template name}0 %1'
@@ -19025,7 +19025,7 @@ H485C835C56BA: '无法将 @selector 表达式进行类型转换'
 # "cannot use %select{'auto'|<ERROR>|'__auto_type'}0 with %select{initializer list|array}1 in C"
 HE2E4F9E6D620: "不能在 C 中将 %select{'auto'|<ERROR>|'__auto_type'}0 与 %select{初始化列表|数组}1 一起使用"
 # "cannot use %select{C++ 'try'|Objective-C '@try'}0 in the same function as SEH '__try'"
-H455974313E2A: "不能在同一函数中同时使用%select{C++ 'try'|Objective-C '@try'}0和SEH的 '__try'"
+H455974313E2A: "不能在同一函数中同时使用 %select{C++ 'try'|Objective-C '@try'}0 和SEH的 '__try'"
 # 'cannot use %select{dot|arrow}0 operator on a type'
 H546BD63E07E0: '不能对类型使用 %select{点|箭头}0 运算符'
 # "cannot use %select{unicode|wide}0 string literal in 'asm'"
@@ -19071,11 +19071,11 @@ H9F644F56E9E3: '不能将类型 %0 用作范围'
 # 'cannot use type %0 as an iterator'
 H45599EAAF2D8: '不能将类型 %0 用作迭代器'
 # "cannot use type '%0' within '#pragma clang fp eval_method'; type is set according to the default eval method for the translation unit"
-HD91CCA267FD1: "不能在'#pragma clang fp eval_method'中使用类型 '%0'；该类型由翻译单元的默认求值方法决定"
+HD91CCA267FD1: "不能在 '#pragma clang fp eval_method' 中使用类型 '%0'；该类型由翻译单元的默认求值方法决定"
 # 'cannot use variable %1 in collapsed imperfectly-nested loop %select{init|condition|increment}0 statement'
 H40887EDB8E4A: '无法在折叠的嵌套循环 %select{init|condition|increment}0 语句中使用变量 %1'
 # 'cannot use variable-length arrays in %select{__device__|__global__|__host__|__host__ __device__}0 functions'
-H33A7639314BD: '不能在%select{__device__|__global__|__host__|__host__ __device__}0函数中使用变长数组'
+H33A7639314BD: '不能在 %select{__device__|__global__|__host__|__host__ __device__}0 函数中使用变长数组'
 # "cannot write file '%0': %1"
 H57D82DC5A945: '无法写入文件 "%0": %1'
 # 'cannot yet @encode type %0'
@@ -19097,9 +19097,9 @@ HA00333F0A82E: '在设备或混合设备lambda函数中通过this指针捕获主
 # 'capture host variable %0 by reference in device or host device lambda function'
 H4218AAE93F26: '在设备或混合设备lambda函数中按引用捕获主机变量 %0'
 # "capture of '*this' by copy is a C++17 extension"
-H9C3948693023: '按值捕获"*this"是C++17扩展'
+H9C3948693023: '按值捕获 "*this" 是C++17扩展'
 # "capture of variable '%0' as type %1 calls %select{private|protected}3 %select{default |copy |move |*ERROR* |*ERROR* |*ERROR* |}2constructor"
-H6489D0544330: '将变量 "%0" 作为类型 %1 捕获调用%select{私有|保护}3%select{默认 |拷贝 |移动 |*ERROR* |*ERROR* |*ERROR* |}2构造函数'
+H6489D0544330: '将变量 "%0" 作为类型 %1 捕获调用%select{私有|保护}3%select{默认 |拷贝 |移动 |*ERROR* |*ERROR* |*ERROR* |}2 构造函数'
 # 'captured structured bindings are a C++20 extension'
 HED60DD4C6A62: '捕获结构化绑定是C++20扩展'
 # 'captured structured bindings are incompatible with C++ standards before C++20'
@@ -19117,7 +19117,7 @@ H94092A9759CB: 'case范围与C2y之前的C标准不兼容'
 # 'case value not in enumerated type %0'
 H4866E4105494: '枚举类型 %0 中不存在该case值'
 # 'cast %diff{from $ to $ |}0,1converts to incompatible function type'
-HAE54FE7B3C1C: '将%diff{从$转为$ |}0,1转换为不兼容的函数类型'
+HAE54FE7B3C1C: '将%diff{从$转为$ |}0,1 转换为不兼容的函数类型'
 # "cast between incompatible calling conventions '%0' and '%1'; calls through this pointer may abort at runtime"
 HB4A395B83746: '在调用约定类型 "%0" 和 "%1" 之间进行转换；通过该指针调用可能在运行时中止'
 # 'cast between pointer-to-function and pointer-to-object is an extension'
@@ -19129,7 +19129,7 @@ H1D7499C23CFE: '将表达式强制转换为void以消除警告'
 # 'cast from %0 is not allowed in a constant expression %select{in C++ standards before C++2c|because the pointed object type %2 is not similar to the target type %3}1'
 H542ED6DEC45B: '%select{在 C++2c 之前的 C++ 标准中|因为指向对象类型 %2 不与目标类型 %3 兼容}1 不允许将 %0 转换为常量表达式'
 # 'cast from %0 to %1 drops %select{const and volatile qualifiers|const qualifier|volatile qualifier}2'
-HA3B03023258D: '从 %0 转换到 %1 会丢失%select{const和volatile限定符|const限定符|volatile限定符}2'
+HA3B03023258D: '从 %0 转换到 %1 会丢失 %select{const和volatile限定符|const限定符|volatile限定符}2'
 # 'cast from %0 to %1 increases required alignment from %2 to %3'
 H4A02BB23383F: '将 %0 转换为 %1 需要的对齐从 %2 增加到 %3'
 # 'cast from %0 to %1 must have all intermediate pointers const qualified to be safe'
@@ -19139,7 +19139,7 @@ H8CE3B0EB72DC: '将函数调用类型 %0 强制转换为不匹配的类型 %1'
 # 'cast from pointer to smaller type %2 loses information'
 H60D928000B5D: '将指向较小类型 %2 的指针强制转换会丢失信息'
 # 'cast of %select{Objective-C|block|C}0 pointer type %1 to %select{Objective-C|block|C}2 pointer type %3 cannot use %select{__bridge|__bridge_transfer|__bridge_retained}4'
-H2F5F45B60576: '将 %select{Objective-C|block|C}0 指针类型 %1 强制转换为 %select{Objective-C|block|C}2 指针类型 %3 时不能使用%select{__bridge|__bridge_transfer|__bridge_retained}4'
+H2F5F45B60576: '将 %select{Objective-C|block|C}0 指针类型 %1 强制转换为 %select{Objective-C|block|C}2 指针类型 %3 时不能使用 %select{__bridge|__bridge_transfer|__bridge_retained}4'
 # 'cast of type %0 to %1 is deprecated; use sel_getName instead'
 HC7428E5162D0: '将类型 %0 转换为 %1 的强制转换已弃用；请改用sel_getName'
 # 'cast one or both operands to int to silence this warning'
@@ -19157,7 +19157,7 @@ H07ADEAB6CDD8: '将联合类型进行强制转换是GNU扩展'
 # 'casting from randomized structure pointer type %0 to %1'
 H760D7A3D8C24: '将随机化结构体指针类型 %0 强制转换为 %1'
 # "casting to dereferenceable pointer removes 'noderef' attribute"
-H435CE65222D6: '将指针强制转换为可解引用指针会移除"noderef"属性'
+H435CE65222D6: '将指针强制转换为可解引用指针会移除 "noderef" 属性'
 # 'casting to type %0 is not allowed'
 H05073823504A: '转换为类型 %0 是不允许的'
 # 'catch-all handler must come last'
@@ -19165,7 +19165,7 @@ H18423565AC35: '默认异常处理程序必须放在最后'
 # 'category is implementing a method which will also be implemented by its primary class'
 H12CCDCE8A3DF: '分类正在实现一个方法，该方法也会由其主类实现'
 # "chained comparison 'X %0 Y %1 Z' does not behave the same as a mathematical expression"
-HF2403FB0CB87: '链式比较"X %0 Y %1 Z"的行为与数学表达式不同'
+HF2403FB0CB87: '链式比较 "X %0 Y %1 Z" 的行为与数学表达式不同'
 # 'change layout of basic blocks in a function'
 HFA932943E87E: '更改函数中基本块的布局'
 # "change return type to 'int'"
@@ -19175,11 +19175,11 @@ HC31A5632ABB1: '将大小参数更改为目标类型的大小'
 # 'change the argument to be the free space in the destination buffer minus the terminating null byte'
 H66702CDAA7E2: '将参数更改为目标缓冲区的可用空间减去终止空字节'
 # "change this ',' to a ';' to call %0"
-H5A1EAB3B7F87: "将此','改为';'以调用 %0"
+H5A1EAB3B7F87: "将此 ',' 改为 ';' 以调用 %0"
 # "change type of %0 to '%select{std::span' to preserve bounds information|std::array' to label it for hardening|std::span::iterator' to preserve bounds information}1%select{|, and change %2 to '%select{std::span|std::array|std::span::iterator}1' to propagate bounds information between them}3"
-H1123F3B73559: "将 %0 的类型更改为'%select{std::span'以保留边界信息|std::array'以标记为强化|std::span::iterator'以保留边界信息}1%select{|，并将 %2 更改为'%select{std::span|std::array|std::span::iterator}1'以在它们之间传播边界信息}3"
+H1123F3B73559: "将 %0 的类型更改为 '%select{std::span' 以保留边界信息|std::array'以标记为强化|std::span::iterator'以保留边界信息}1%select{|，并将 %2 更改为 '%select{std::span|std::array|std::span::iterator}1' 以在它们之间传播边界信息}3"
 # "change type of %0 to '%select{std::span' to preserve bounds information|std::array' to label it for hardening|std::span::iterator' to preserve bounds information}1%select{|, and change %2 to safe types to make function %4 bounds-safe}3"
-H9C76AEF6C221: "将 %0 的类型更改为'%select{std::span'以保留边界信息|std::array'以标记为强化|std::span::iterator'以保留边界信息}1%select{|，并将 %2 更改为安全类型以使函数 %4 具有边界安全性}3"
+H9C76AEF6C221: "将 %0 的类型更改为 '%select{std::span' 以保留边界信息|std::array'以标记为强化|std::span::iterator'以保留边界信息}1%select{|，并将 %2 更改为安全类型以使函数 %4 具有边界安全性}3"
 # 'char is signed'
 H28989E053B4F: 'char是有符号类型'
 # 'char is unsigned'
@@ -19187,7 +19187,7 @@ H2C9C5C4D7121: 'char是无符号类型'
 # "character '%0' cannot be specified by a universal character name"
 H9FDECB7636A6: "字符 '%0' 不能通过通用字符名指定"
 # 'character <U+%0> not allowed %select{in|at the start of}1 an identifier'
-H0604F74F1073: '字符<U+%0>不允许%select{在|在开头}1标识符中'
+H0604F74F1073: '字符 <U+%0> 不允许%select{在|在开头}1标识符中'
 # 'character constant too long for its type'
 H99E005D8F34A: '字符常量的长度超过其类型允许的范围'
 # 'character literal with user-defined suffix cannot be used here'
@@ -19285,7 +19285,7 @@ HC409A532BB3A: '%0 的类模板参数推导为复制列表初始化选中了一�
 # 'class template argument deduction for alias templates is incompatible with C++ standards before C++20'
 H0A109AC10809: '别名模板的类模板参数推导与 C++20 之前的 C++ 标准不兼容'
 # 'class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0'
-HCFEDA0AEF7C1: '类模板参数推导与C++17之前的C++标准不兼容%select{|; 为兼容性，请显式指定类型名 %1}0'
+HCFEDA0AEF7C1: '类模板参数推导与C++17之前的C++标准不兼容 %select{|; 为兼容性，请显式指定类型名 %1}0'
 # 'class template partial specialization %0 cannot be redeclared'
 HD6C67286FA78: '类模板部分特化 %0 不能被重新声明'
 # "class with destructor marked '%select{final|sealed}0' cannot be inherited from"
@@ -19355,7 +19355,7 @@ H4D3F55AAB37F: "两个数组的比较已被弃用；要比较数组地址，请�
 # "comparison between two arrays is ill-formed in C++26; to compare array addresses, use unary '+' to decay operands to pointers"
 H20B4EE22A6C2: "在C++26中比较两个数组是不符合规范的；要比较数组地址，请使用一元 '+' 运算符将操作数转换为指针"
 # "comparison of %select{address of|function|array}0 '%1' %select{not |}2equal to a null pointer is always %select{true|false}2"
-H61B7557646A7: "%select{地址的|函数|数组}0 '%1' 与空指针 %select{不 |}2相等的比较始终为 %select{true|false}2"
+H61B7557646A7: "%select{地址的|函数|数组}0 '%1' 与空指针 %select{不 |}2 相等的比较始终为 %select{true|false}2"
 # 'comparison of address of base class subobject %0 of class %1 to field %2 has unspecified value'
 HCEA4BEB9DFF0: '对类 %1 的基类子对象 %0 的地址与字段 %2 进行比较具有未指定值'
 # 'comparison of address of fields %0 and %2 of %4 with differing access specifiers (%1 vs %3) has unspecified value'
@@ -19373,7 +19373,7 @@ H1D24D97A54FF: '比较不同指针类型%diff{ ($ 和 $)|}0,1'
 # 'comparison of integers of different signs: %0 and %1'
 H8C3AA027FA1B: '不同符号的整数比较：%0 和 %1'
 # "comparison of nonnull %select{function call|parameter}0 '%1' %select{not |}2equal to a null pointer is '%select{true|false}2' on first encounter"
-H9EDFDB49F3E3: "对非空 %select{函数调用|参数}0 '%1' 与空指针 %select{不 |}2相等的比较在首次遇到时为 '%select{true|false}2'"
+H9EDFDB49F3E3: "对非空 %select{函数调用|参数}0 '%1' 与空指针 %select{不 |}2 相等的比较在首次遇到时为 '%select{true|false}2'"
 # "comparison of numeric address '%0' with pointer '%1' can only be performed at runtime"
 HFBF28443EB32: "对数值地址 '%0' 与指针 '%1' 的比较只能在运行时进行"
 # 'comparison of pointer to virtual member function %0 has unspecified value'
@@ -19475,11 +19475,11 @@ HD53AB264ABE6: "选项 '-fcoro-aligned-allocation' 与 '-fno-aligned-allocation'
 # 'conflicting parameter qualifier %0 on parameter %1'
 HC7B786535E39: '参数 %1 上存在冲突的参数限定符 %0'
 # 'conflicting parameter types in declaration of %0%diff{: $ vs $|}1,2'
-HCBD5D6ED758A: '在 %0 的声明中参数类型冲突%diff{: $ vs $|}1,2'
+HCBD5D6ED758A: '在 %0 的声明中参数类型冲突 %diff{: $ vs $|}1,2'
 # 'conflicting parameter types in declaration of %0: %1 vs %2'
 HF405BA99A067: '在 %0 的声明中参数类型冲突：%1 与 %2'
 # 'conflicting parameter types in implementation of %0%diff{: $ vs $|}1,2'
-H64F50A39ECB1: '在 %0 的实现中参数类型冲突%diff{: $ vs $|}1,2'
+H64F50A39ECB1: '在 %0 的实现中参数类型冲突 %diff{: $ vs $|}1,2'
 # 'conflicting parameter types in implementation of %0: %1 vs %2'
 HC0C8356B7475: '在 %0 的实现中参数类型冲突：%1 与 %2'
 # 'conflicting pass_object_size attributes on parameters'
@@ -19489,11 +19489,11 @@ HF896EFD79698: '冲突的原型在此处'
 # "conflicting re-export of module '%0' as '%1' or '%2'"
 H8B0F3A29C0A1: "冲突的模块重导出：'%0' 作为 '%1' 或 '%2'"
 # 'conflicting return type in declaration of %0%diff{: $ vs $|}1,2'
-H2BB3153B6C50: '在 %0 的声明中返回类型冲突%diff{: $ vs $|}1,2'
+H2BB3153B6C50: '在 %0 的声明中返回类型冲突 %diff{: $ vs $|}1,2'
 # 'conflicting return type in declaration of %0: %1 vs %2'
 H5D783A189DCF: '在 %0 的声明中返回类型冲突：%1 与 %2'
 # 'conflicting return type in implementation of %0%diff{: $ vs $|}1,2'
-HEB354C372ED1: '在 %0 的实现中返回类型冲突%diff{: $ vs $|}1,2'
+HEB354C372ED1: '在 %0 的实现中返回类型冲突 %diff{: $ vs $|}1,2'
 # 'conflicting return type in implementation of %0: %1 vs %2'
 H5C54E8625E6A: '在 %0 的实现中返回类型冲突：%1 与 %2'
 # 'conflicting super class name %0'
@@ -19507,7 +19507,7 @@ H2A0A12EA2AF3: '方法及其实现的可变参数声明冲突'
 # 'conformance of forward class %0 to protocol %1 cannot be confirmed'
 H978A4E78BB8C: '无法确认前向类 %0 对协议 %1 的符合性'
 # "consecutive right angle brackets are incompatible with C++98 (use '> >')"
-H77515E521F08: "连续的右尖括号与C++98不兼容（请使用'> >'）"
+H77515E521F08: "连续的右尖括号与C++98不兼容（请使用 '> >'）"
 # 'conservative handling of inline assembly'
 H316430B34522: '内联汇编的保守处理'
 # "consider adding '%0' to the header search path"
@@ -19597,7 +19597,7 @@ H9CBE3FDAF244: 'constexpr变量不能具有类型 %0'
 # 'constexpr variable declaration must be a definition'
 H28D5C206A058: 'constexpr变量声明必须是一个定义'
 # 'constrained by %select{|implicitly }1%select{private|protected}0 inheritance here'
-HA215ECA901D4: '受%select{|隐式 }1%select{private|protected}0 继承的约束'
+HA215ECA901D4: '受 %select{|隐式 }1%select{private|protected}0 继承的约束'
 # "constrained placeholder types other than simple 'auto' on non-type template parameters not supported yet"
 HA5CE432D2BF4: "非类型模板参数上的非简单 'auto' 约束占位类型尚未支持"
 # "constraint '%0' is already present here"
@@ -19679,7 +19679,7 @@ HC6DC2FD11DE6: '通过虚基类 %2 将类 %0 的成员指针转换为类 %1 的�
 # 'conversion from string literal to %0 is deprecated'
 H1DEAC81E3C65: '将字符串字面量转换为 %0 是已弃用的'
 # 'conversion function %diff{from $ to $|between types}0,1 invokes a deleted function%select{|: %3}2'
-H302A0E48B3BA: '转换函数 %diff{从 $ 到 $|在类型之间}0,1 调用了被删除的函数%select{|: %3}2'
+H302A0E48B3BA: '转换函数 %diff{从 $ 到 $|在类型之间}0,1 调用了被删除的函数 %select{|: %3}2'
 # 'conversion function cannot be redeclared'
 HA31D9D61E048: '转换函数不能被重新声明'
 # 'conversion function cannot be variadic'
@@ -19715,11 +19715,11 @@ HFA594BB552D0: '将类型 %0 的delete表达式转换为类型 %1 会调用显�
 # 'converting the enum constant to a boolean'
 HC26D67935F61: '将枚举常量转换为布尔值'
 # "converting the result of '<<' to a boolean always evaluates to %select{false|true}0"
-H66F90B0804A0: "将运算符'<<'的结果转换为布尔值始终会计算为 %select{false|true}0"
+H66F90B0804A0: "将运算符 '<<' 的结果转换为布尔值始终会计算为 %select{false|true}0"
 # "converting the result of '<<' to a boolean; did you mean '(%0) != 0'?"
-HB5F0E9F35B11: "将运算符'<<'的结果转换为布尔值；是否想表达'(%0) != 0'？"
+HB5F0E9F35B11: "将运算符 '<<' 的结果转换为布尔值；是否想表达 '(%0) != 0'？"
 # "converting the result of '?:' with integer constants to a boolean always evaluates to 'true'"
-H0B52D2457927: "将带有整型常量的运算符'?:'的结果转换为布尔值始终会计算为 'true'"
+H0B52D2457927: "将带有整型常量的运算符 '?:' 的结果转换为布尔值始终会计算为 'true'"
 # 'converting to boxing syntax requires casting %0 to %1'
 HDE90319BAAF3: '转换为装箱语法需要将 %0 转换为 %1'
 # 'coprocessor %0 must be configured as %select{GCP|CDE}1'
@@ -19743,11 +19743,11 @@ H55F92FED58CA: '无法通过调用带有循环上下限的operator-计算迭代�
 # 'could not determine the original source location for %0:%1:%2'
 H596D1B547578: '无法确定 %0:%1:%2 的原始源代码位置'
 # "could not find ';' after @import"
-H808D2C4625A0: "在@import后找不到';'"
+H808D2C4625A0: "在@import后找不到 ';'"
 # 'could not find Objective-C class %0 to convert %1 to %2'
 H8A434A2F54F7: '找不到Objective-C类 %0 来将 %1 转换为 %2'
 # 'could not match %diff{$ against $|types}0,1'
-HB17669DA1C41: '无法匹配%diff{$ against $|types}0,1'
+HB17669DA1C41: '无法匹配 %diff{$ against $|types}0,1'
 # "could not open '%0' for embedding"
 HF452E067B4E2: "无法打开 '%0' 用于嵌入"
 # "could not read %0 input list '%1': %2"
@@ -19767,7 +19767,7 @@ H399ED19E4A74: "当前API版本是 '%0'，但插件是使用版本 '%1' 编译�
 # 'current file is older than dependency %0'
 HCE89B30434E7: '当前文件比依赖项 %0 更旧'
 # "current handling of vector bool and vector pixel types in this context are deprecated; the default behaviour will soon change to that implied by the '-altivec-compat=xl' option"
-H2144886C992F: "在此上下文中处理向量布尔类型和向量像素类型的方式已弃用；默认行为将很快更改为由'-altivec-compat=xl'选项暗示的行为"
+H2144886C992F: "在此上下文中处理向量布尔类型和向量像素类型的方式已弃用；默认行为将很快更改为由 '-altivec-compat=xl' 选项暗示的行为"
 # "current_version does not match: '%0' (provided) vs '%1' (found)"
 H84F45A8B13FB: "current_version不匹配：提供的 '%0' 与找到的 '%1'"
 # "cycle in acquired_before/after dependencies, starting with '%0'"
@@ -19809,7 +19809,7 @@ H96F07A99E632: '检测到声明 %0 在多个模块单元中定义，第一个来
 # "declaration '%0' is %select{weak defined|thread local}1, but symbol is not in dynamic library"
 HFB32CBE0F1C5: '声明‘%0’是%select{弱定义|线程局部}1，但符号不在动态库中'
 # "declaration '%0' is marked %select{available|unavailable}1, but symbol is %select{not |}2exported in dynamic library"
-H01B92D3A7F34: '声明‘%0’被标记为%select{可用|不可用}1，但符号在动态库中%select{未|}2导出'
+H01B92D3A7F34: '声明‘%0’被标记为%select{可用|不可用}1，但符号在动态库中%select{未|}2 导出'
 # "declaration cannot be inferred '%0' because it has no definition in this translation unit"
 HFACBBC5D211B: '无法推断声明‘%0’，因为它在此翻译单元中没有定义'
 # 'declaration conflicts with target of using declaration already in scope'
@@ -19917,9 +19917,9 @@ HA2F652501D84: "此处用类 '%0' 声明"
 # 'declared with index %0 here'
 H29E8DAE209C5: '此处用索引 %0 声明'
 # 'declaring function parameter of type %0 is not allowed%select{; did you forget * ?|}1'
-H45BA30613376: '不允许声明类型为 %0 的函数参数%select{; 是否忘记添加*？|}1'
+H45BA30613376: '不允许声明类型为 %0 的函数参数 %select{; 是否忘记添加*？|}1'
 # 'declaring function return value of type %0 is not allowed %select{; did you forget * ?|}1'
-HC0F56D942DA5: '不允许声明类型为 %0 的函数返回值%select{; 是否忘记添加*？|}1'
+HC0F56D942DA5: '不允许声明类型为 %0 的函数返回值 %select{; 是否忘记添加*？|}1'
 # "declaring overloaded %0 as 'static' is a C++23 extension"
 H3416DF62F662: "将重载的 %0 声明为 'static' 是C++23扩展"
 # "declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23"
@@ -19933,7 +19933,7 @@ H745CF12AB2DC: '分解声明 %0 需要初始值设定项'
 # 'decomposition declaration cannot be a template'
 H12444CAF9EB2: '分解声明不能是模板'
 # "decomposition declaration cannot be declared %plural{1:'%1'|:with '%1' specifiers}0"
-HEDAF4E9407D4: "分解声明不能被声明%plural{1:'%1'|:具有 '%1' 说明符}0"
+HEDAF4E9407D4: "分解声明不能被声明 %plural{1:'%1'|:具有 '%1' 说明符}0"
 # "decomposition declaration cannot be declared with constrained 'auto'"
 H33CAEB57113F: "分解声明不能被声明为具有约束条件的 'auto'"
 # 'decomposition declaration cannot be declared with parentheses'
@@ -19941,9 +19941,9 @@ H02314396E4F0: '分解声明不能用括号声明'
 # "decomposition declaration cannot be declared with type %0; declared type must be 'auto' or reference to 'auto'"
 H3DD0947995B7: "分解声明声明的类型 %0 无效；声明类型必须为 'auto' 或 'auto' 的引用"
 # "decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is a C++20 extension"
-HED6397EE7170: "分解声明被声明%plural{1:'%1'|:具有 '%1' 说明符}0是C++20扩展"
+HED6397EE7170: "分解声明被声明 %plural{1:'%1'|:具有 '%1' 说明符}0是C++20扩展"
 # "decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20"
-H3B1B7DD7D4A6: "分解声明被声明%plural{1:'%1'|:具有 '%1' 说明符}0与C++20之前的标准不兼容"
+H3B1B7DD7D4A6: "分解声明被声明 %plural{1:'%1'|:具有 '%1' 说明符}0与C++20之前的标准不兼容"
 # 'decomposition declaration must be the only declaration in its group'
 H36F7861E46A5: '分解声明必须是其组中的唯一声明'
 # 'decomposition declaration not permitted in this context'
@@ -19953,19 +19953,19 @@ H41B58BACEDBD: '分解声明是C++17扩展'
 # 'decomposition declarations are incompatible with C++ standards before C++17'
 H6F6939D7899C: '分解声明与C++17之前的标准不兼容'
 # 'deduced conflicting types %diff{($ vs $) |}0,1for initializer list element type'
-H41EB8FB5647B: '推导出冲突的类型%diff{($ vs $)|}0,1作为初始列表元素类型'
+H41EB8FB5647B: '推导出冲突的类型 %diff{($ vs $)|}0,1 作为初始列表元素类型'
 # 'deduced incomplete pack %0 for template parameter %1'
 H03080CBC4C1A: '推导出模板参数 %1 的不完整包 %0'
 # 'deduced non-type template argument does not have the same type as the corresponding template parameter%diff{ ($ vs $)|}0,1'
 H6489085BE16C: '推导出的非类型模板实参与对应的模板参数类型不一致%diff{ ($ vs $)|}0,1'
 # "deduced return type for defaulted %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator must be 'auto', not %1"
-H209B0E7EFC40: "默认实现的%select{<ERROR>|equality|three-way|equality|relational}0比较运算符的推导返回类型必须为 'auto'，而非 %1"
+H209B0E7EFC40: "默认实现的 %select{<ERROR>|equality|three-way|equality|relational}0 比较运算符的推导返回类型必须为 'auto'，而非 %1"
 # 'deduced return types are a C++14 extension'
 HB07F9BCAC63A: '推导返回类型是C++14扩展'
 # 'deduced type %0 does not satisfy %1'
 H9431BF910A33: '推导出的类型 %0 不满足 %1'
 # 'deduced type %1 of deduction guide is not %select{|written as }2a specialization of template %0'
-H902D2FE80122: '推导指引的推导类型 %1 不是%select{|以}2模板 %0 的特化形式'
+H902D2FE80122: '推导指引的推导类型 %1 不是 %select{|以}2模板 %0 的特化形式'
 # 'deduction guide cannot be %select{explicitly instantiated|explicitly specialized}0'
 HA3A632F69A86: '推导指引不能%select{显式实例化|显式特化}0'
 # "deduction guide cannot be declared '%0'"
@@ -20057,13 +20057,13 @@ H6F959181B71C: '默认的 %0 因隐式删除，因为使用该转换的内建比
 # 'defaulted %0 is implicitly deleted because class %1 has a reference member'
 HDDAEEF62F6DD: '默认的 %0 因隐式删除，因为类 %1 有引用成员'
 # "defaulted %0 is implicitly deleted because implied %select{|'==' |'<' }1comparison %select{|for member %3 |for base class %3 }2is ambiguous"
-H8204A4BEFE67: "默认的 %0 因隐式删除，因为隐含的%select{|'==' |'<' }1比较%select{|对于成员 %3 |对于基类 %3 }2是模棱两可的"
+H8204A4BEFE67: "默认的 %0 因隐式删除，因为隐含的 %select{|'==' |'<' }1比较 %select{|对于成员 %3 |对于基类 %3 }2是模棱两可的"
 # 'defaulted %0 is implicitly deleted because it would invoke a %select{private|protected}3 %4%select{ member of %6| member of %6 to compare member %2| to compare base class %2}1'
 HA2763C071EBA: '默认的 %0 因隐式删除，因为它会调用 %select{private|protected}3 %4%select{ 的 %6 成员|的 %6 成员来比较成员 %2|来比较基类 %2}1'
 # 'defaulted %0 is implicitly deleted because it would invoke a deleted comparison function%select{| for member %2| for base class %2}1'
-H73AE2279ECF2: '默认的 %0 被隐式删除，因为它会调用已删除的比较函数%select{|的成员 %2|的基类 %2}1'
+H73AE2279ECF2: '默认的 %0 被隐式删除，因为它会调用已删除的比较函数 %select{|的成员 %2|的基类 %2}1'
 # "defaulted %0 is implicitly deleted because there is no viable %select{three-way comparison function|'operator=='}1 for %select{|member |base class }2%3"
-HC9957DD8DD53: "默认的 %0 因隐式删除，因为%select{|成员 |基类 }2%3 没有可用的%select{三向比较函数|'operator=='}1"
+HC9957DD8DD53: "默认的 %0 因隐式删除，因为 %select{|成员 |基类 }2%3 没有可用的%select{三向比较函数|'operator=='}1"
 # 'defaulted %0 is implicitly deleted because this non-rewritten comparison function would be the best match for the comparison'
 H5A66B2776E93: '默认的 %0 因隐式删除，因为此未重写的比较函数会成为比较的最佳匹配'
 # 'defaulted comparison function must not be volatile'
@@ -20073,11 +20073,11 @@ H17EA10D2ACC2: '默认比较运算符是C++20扩展'
 # 'defaulted comparison operators are incompatible with C++ standards before C++20'
 H38C2AF56B86F: '默认比较运算符与C++20之前的C++标准不兼容'
 # "defaulted definition of %select{%select{<ERROR>|equality|three-way|equality|relational}1 comparison operator|three-way comparison operator}0 cannot be declared %select{constexpr|consteval}2 because %select{it|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function"
-HDA596C603C53: '默认的%select{%select{<ERROR>|相等性|三向|相等性|关系性}1比较运算符|三向比较运算符}0不能声明为 %select{constexpr|consteval}2，因为%select{它|对应隐式operator==的}0调用了非constexpr比较函数'
+HDA596C603C53: '默认的 %select{%select{<ERROR>|相等性|三向|相等性|关系性}1比较运算符|三向比较运算符}0不能声明为 %select{constexpr|consteval}2，因为%select{它|对应隐式operator==的}0调用了非constexpr比较函数'
 # 'defaulted definition of %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}0 cannot be marked %select{constexpr|consteval}1 before C++23'
 H5C1B0C179374: '默认的%select{默认构造函数|拷贝构造函数|移动构造函数|拷贝赋值运算符|移动赋值运算符|析构函数}0在C++23之前不能标记为 %select{constexpr|consteval}1'
 # 'defaulted member %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator must be const-qualified'
-H8A22F945F946: '默认的%select{<ERROR>|相等性|三向|相等性|关系性}0比较运算符必须有const限定符'
+H8A22F945F946: '默认的 %select{<ERROR>|相等性|三向|相等性|关系性}0比较运算符必须有const限定符'
 # 'defaulted move assignment operator of %0 will move assign virtual base class %1 multiple times'
 HC302B71D801C: '类型 %0 的默认移动赋值运算符将多次移动赋值虚基类 %1'
 # "defaulting %select{this %select{<ERROR>|equality|three-way|equality|relational}1 comparison operator|the corresponding implicit 'operator==' for this defaulted 'operator<=>'}0 would delete it after its first declaration"
@@ -20099,7 +20099,7 @@ HD03996A6AE5C: "模块 '%0' 中的定义在此处"
 # "definition of %0 is not complete until the closing '}'"
 H6A431AA48FA1: "%0 的定义在闭合的 '}' 之前未完成"
 # 'definition of a %select{static|thread_local}1 variable in a constexpr %select{function|constructor}0 is a C++23 extension'
-H398F375C6A6A: '在constexpr %select{函数|构造函数}0中定义一个%select{静态|thread_local}1变量是C++23扩展'
+H398F375C6A6A: '在constexpr %select{函数|构造函数}0中定义一个%select{静态|thread_local}1 变量是C++23扩展'
 # 'definition of a %select{static|thread_local}1 variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23'
 HE9C5585842AA: '在constexpr %select{function|constructor}0 中定义一个 %select{static|thread_local}1 变量与C++23之前的C++标准不兼容'
 # 'definition of a variable of non-literal type in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23'
@@ -20133,7 +20133,7 @@ H40BB23B29C3F: "宏 '%0' 在AST文件 '%3'（'%1'）和命令行（'%2'）中的
 # "definition of module '%0' is not available; use -fmodule-file= to specify path to precompiled module interface"
 H1ED33479DE5D: "模块 '%0' 的定义不可用；请使用-fmodule-file=指定预编译模块接口的路径"
 # 'definition of type %0 conflicts with %select{typedef|type alias}1 of the same name'
-H5C3C4CCA94AB: '类型 %0 的定义与同名的%select{typedef|类型别名}1冲突'
+H5C3C4CCA94AB: '类型 %0 的定义与同名的 %select{typedef|类型别名}1冲突'
 # 'definition of variable with array type needs an explicit size or an initializer'
 H79E09A4784DB: '具有数组类型的变量定义需要显式指定大小或初始化器'
 # 'definition or redeclaration of %0 cannot name the global scope'
@@ -20157,7 +20157,7 @@ H8B4F3ED0F000: "删除指向非堆分配对象的指针 '%0'"
 # 'delete of pointer that has already been deleted'
 H42BC8DFBCECC: '删除已被释放的指针'
 # "delete of pointer%select{ to subobject|}1 '%0' %select{|that does not point to complete object}1"
-H4DFF941C0746: '删除%select{子对象|}1的指针%select{|不指向完整对象}1的指针 %0'
+H4DFF941C0746: '删除%select{子对象|}1 的指针 %select{|不指向完整对象}1的指针 %0'
 # 'deleted definition must be first declaration'
 H0F602982588E: '被删除的定义必须是首次声明'
 # 'deleted function %0 cannot override a non-deleted function'
@@ -20183,7 +20183,7 @@ HA97D8413D319: '密集的YAML表示形式'
 # "depend modifier cannot be used with 'sink' or 'source' depend type"
 H92A125FCC1F2: "depend修饰符不能与 'sink' 或 'source' depend类型一起使用"
 # 'dependent %select{__if_not_exists|__if_exists}0 declarations are ignored'
-H7E0205C30EB0: '依赖的%select{__if_not_exists|__if_exists}0声明被忽略'
+H7E0205C30EB0: '依赖的 %select{__if_not_exists|__if_exists}0 声明被忽略'
 # 'dependent nested name specifier %0 for friend class declaration is not supported; turning off access control for %1'
 H6C7EBDCCA541: '依赖的嵌套名称指定符 %0 用于友元类声明不受支持；禁用 %1 的访问控制'
 # 'dependent nested name specifier %0 for friend template declaration is not supported; ignoring this friend declaration'
@@ -20195,7 +20195,7 @@ H2DF43C211998: '解引用指向不完整类型 %0 的指针'
 # 'dereference of type %1 that was reinterpret_cast from type %0 has undefined behavior'
 H90FCF362143A: '对类型 %0 经reinterpret_cast转换为类型 %1 后的解引用会导致未定义行为'
 # 'dereferenced pointer past the end of %select{|subobject of }0%select{temporary|%2}1 is not a constant expression'
-H22AD60D3A378: '解引用超出%select{|子对象的 }0%select{临时对象|%2}1末尾的指针不是一个常量表达式'
+H22AD60D3A378: '解引用超出 %select{|子对象的 }0%select{临时对象|%2}1 末尾的指针不是一个常量表达式'
 # "dereferencing %0; was declared with a 'noderef' type"
 H77B30DE9BC36: "解引用 %0；该类型被声明为 'noderef'"
 # 'dereferencing a __weak pointer is not allowed due to possible null value caused by race condition, assign it to strong variable first'
@@ -20231,15 +20231,15 @@ H6533BAA0653D: '复数的单个组件的销毁在常量表达式中尚未得到�
 # 'destruction of object that is already being destroyed'
 HBC86CD58BD53: '正在销毁已被销毁的对象'
 # 'destructor cannot be declared %select{<ERROR>|constexpr|consteval|constinit}0'
-H39B25D41B01F: '析构函数不能声明为%select{<ERROR>|constexpr|consteval|constinit}0'
+H39B25D41B01F: '析构函数不能声明为 %select{<ERROR>|constexpr|consteval|constinit}0'
 # 'destructor cannot be declared %select{<ERROR>|constexpr|consteval|constinit}0 because %select{data member %2|base class %3}1 does not have a constexpr destructor'
-HEA62090F1654: '析构函数不能声明为%select{<ERROR>|constexpr|consteval|constinit}0，因为%select{数据成员 %2|基类 %3}1没有constexpr析构函数'
+HEA62090F1654: '析构函数不能声明为 %select{<ERROR>|constexpr|consteval|constinit}0，因为%select{数据成员 %2|基类 %3}1 没有constexpr析构函数'
 # "destructor cannot be declared '%0'"
 H18788E54B072: "析构函数不能声明为 '%0'"
 # 'destructor cannot be declared as a template'
 H2A9016676C0B: '析构函数不能声明为模板'
 # 'destructor cannot be declared using a %select{typedef|type alias}1 %0 of the class name'
-HD2E86EDB043A: '不能使用类名的%select{typedef|类型别名}1 %0 来声明析构函数'
+HD2E86EDB043A: '不能使用类名的 %select{typedef|类型别名}1 %0 来声明析构函数'
 # 'destructor cannot be redeclared'
 H7C102E557BD9: '析构函数不能被重新声明'
 # 'destructor cannot be variadic'
@@ -20271,7 +20271,7 @@ H55938C1F7AEA: '确定是否在从输入日志符号化函数ID时解码函数�
 # 'determines whether to sort input log records by timestamp'
 HF854EBCB0FF7: '确定是否按时间戳对输入日志记录进行排序'
 # "device clause with ancestor device-modifier used without specifying 'requires reverse_offload'"
-H7C03F0398F87: '在未指定"requires reverse_offload"的情况下使用带有祖先设备修饰符的设备子句'
+H7C03F0398F87: '在未指定 "requires reverse_offload" 的情况下使用带有祖先设备修饰符的设备子句'
 # 'diagnostic formatting in SARIF mode is currently unstable'
 HADEECC0D1814: 'SARIF模式下的诊断信息格式目前还不稳定'
 # 'diagnostic msg: %0'
@@ -20283,9 +20283,9 @@ H41E6876DEC05: "未期望 %0 '%2' 由 '%1' 管理"
 # "did not find header '%0' in framework '%1' (loaded from '%2')"
 H33EA4C9E31A5: '在框架 "%1"（从 "%2" 加载）中未找到头文件 "%0"'
 # "did you forget ';'?"
-H5762CA5BE293: '是否漏掉了";"？'
+H5762CA5BE293: '是否漏掉了 ";"？'
 # "did you intend to use '#pragma pack (pop)' instead of '#pragma pack()'?"
-H38F2C3CF1911: '是否应使用"#pragma pack(pop)"而不是"#pragma pack()"？'
+H38F2C3CF1911: '是否应使用 "#pragma pack(pop)" 而不是 "#pragma pack()"？'
 # "did you mean %0 ('%2' U+%1)?"
 H034E19BAF4DB: '是否是指 %0（"%2" U+%1）？'
 # 'did you mean %0?'
@@ -20295,9 +20295,9 @@ H2F94B54CE3AD: '此处是否是指 %select{struct|interface|class}0？'
 # "did you mean '%0'?"
 HC2D29273BC0C: '是否是指 "%0"？'
 # "did you mean 'using namespace'?"
-H7384271A4FC4: '是否是指"using namespace"？'
+H7384271A4FC4: '是否是指 "using namespace"？'
 # "did you mean to %select{dereference the argument to 'sizeof' (and multiply it by the number of elements)|remove the addressof in the argument to 'sizeof' (and multiply it by the number of elements)|provide an explicit length}0?"
-H206E38ACCE90: '是否应%select{对"sizeof"的参数进行解引用（并乘以元素数量）|移除"sizeof"参数中的取地址运算符（并乘以元素数量）|提供显式的长度}0？'
+H206E38ACCE90: '是否应%select{对 "sizeof" 的参数进行解引用（并乘以元素数量）|移除 "sizeof" 参数中的取地址运算符（并乘以元素数量）|提供显式的长度}0？'
 # 'did you mean to call the %0 method?'
 H0FF3D4ADDC94: '是否应调用 %0 方法？'
 # 'did you mean to compare the result of %0 instead?'
@@ -20305,7 +20305,7 @@ HA27A0B6056FB: '是否应比较 %0 的结果？'
 # "did you mean to use '%0'?"
 H18F66684E290: '是否应使用 "%0"？'
 # "did you mean to use '.' instead?"
-HE2F23CD42B59: '是否应使用"."？'
+HE2F23CD42B59: '是否应使用 "."？'
 # "did you mean to use '\\u'?"
 H8EB1B38F64B3: '您是否想使用‘\\u’？'
 # "did you mean to use 'typename'?"
@@ -20329,7 +20329,7 @@ H4EFEDE46DF56: '属性 %0 的direct属性被忽略（此Objective-C运行时未�
 # 'direct base %0 is inaccessible due to ambiguity:%1'
 HB8D80890A48E: '直接基类 %0 由于以下歧义不可访问：%1'
 # 'direct comparison of %select{an array literal|a dictionary literal|a numeric literal|a boxed expression|}0 has undefined behavior'
-HB492D0D3EB6E: '直接比较%select{数组字面量|字典字面量|数值字面量|包装表达式|}0会导致未定义行为'
+HB492D0D3EB6E: '直接比较%select{数组字面量|字典字面量|数值字面量|包装表达式|}0 会导致未定义行为'
 # 'direct comparison of a string literal has undefined behavior'
 H32F54A871B25: '直接比较字符串字面量会导致未定义行为'
 # 'direct member declared here'
@@ -20343,9 +20343,9 @@ HE6AB93C50673: '在%select{主接口|扩展|分类}0中声明而在%select{主�
 # 'direct property cannot be @dynamic'
 HE7907E55F6FD: '直接属性不能为@dynamic'
 # "directive '#pragma omp %0' cannot contain more than one '%1' clause%select{| with '%3' name modifier| with 'source' dependence}2"
-H4FF8713761CF: "指令'#pragma omp %0'不能包含超过一个 '%1' 子句%select{|带有 '%3' 名称修饰符|带有 'source' 依赖}2"
+H4FF8713761CF: "指令 '#pragma omp %0' 不能包含超过一个 '%1' 子句 %select{|带有 '%3' 名称修饰符|带有 'source' 依赖}2"
 # "directive '#pragma omp %0' cannot contain more than one 'seq_cst',%select{ 'relaxed',|}1 'acq_rel', 'acquire' or 'release' clause"
-HAC63F783B13F: "指令'#pragma omp %0'不能包含超过一个 'seq_cst',%select{ 'relaxed',|}1 'acq_rel', 'acquire' 或 'release' 子句"
+HAC63F783B13F: "指令 '#pragma omp %0' 不能包含超过一个 'seq_cst',%select{ 'relaxed',|}1 'acq_rel', 'acquire' 或 'release' 子句"
 # "directive '#pragma omp %0' requires the '%1' clause"
 H54115AA95D6F: "指令 '#pragma omp %0' 需要 '%1' 子句"
 # "directive '#pragma omp atomic%select{ %0|}1' cannot be used with '%2' clause"
@@ -20645,7 +20645,7 @@ H33FDED0520CF: '复制跨越缓存行的无条件分支'
 # 'duplicate use of asm operand name "%0"'
 H3EAACD3C87CF: 'asm 操作数名称 "%0" 重复使用'
 # "duplicated command '%select{\\|@}0%1'"
-H76B78FD8FF48: "重复的命令'%select{\\|@}0%1'"
+H76B78FD8FF48: "重复的命令 '%select{\\|@}0%1'"
 # 'during field initialization in %select{this|the implicit default}0 constructor'
 H865BE3842864: '在 %select{this|the implicit default}0 构造函数的字段初始化期间'
 # 'during template argument deduction for %select{class|variable}0 template %select{partial specialization |}1%2 %3'
@@ -20795,7 +20795,7 @@ HC0011ACD5CEF: '用 %select{@available|__builtin_available}1 检查包裹 %0 以
 # 'encoding of %0 type is incomplete because %1 component has unknown encoding'
 HE63ED9F43B42: '%0 类型的编码不完整，因为 %1 成分的编码未知'
 # "encoding prefix '%0' on an unevaluated string literal has no effect%select{| and is incompatible with c++2c}1"
-HFB264777D8F6: "未求值的字符串字面量上的编码前缀 '%0' 没有效果%select{| 且与 c++2c 不兼容}1"
+HFB264777D8F6: "未求值的字符串字面量上的编码前缀 '%0' 没有效果 %select{| 且与 c++2c 不兼容}1"
 # 'end tag'
 HE76165194C35: '结束标签'
 # "entering module '%0' due to this pragma"
@@ -20807,9 +20807,9 @@ HACD4B99390E7: '枚举类型 %0 是不完整的'
 # 'enumeration cannot be a template'
 H0777CF5091AE: '枚举类型不能作为模板'
 # 'enumeration previously declared as %select{un|}0scoped'
-H979505490BD1: '枚举之前被声明为%select{非|}0作用域'
+H979505490BD1: '枚举之前被声明为%select{非|}0 作用域'
 # 'enumeration previously declared with %select{non|}0fixed underlying type'
-H8C078F2C2E0F: '枚举之前被声明为带有%select{非|}0固定底层类型'
+H8C078F2C2E0F: '枚举之前被声明为带有%select{非|}0 固定底层类型'
 # 'enumeration redeclared with different underlying type %0 (was %1)'
 H67E555152513: '枚举被重新声明为不同的底层类型 %0（原为 %1）'
 # 'enumeration type %0 is not allowed in a vector conditional'
@@ -20867,7 +20867,7 @@ HD1F59176156D: "打开 '%0' 时出错：该文件由跨翻译单元功能所需"
 # "error opening file '%0': %1"
 H36FA208EA1D0: "打开文件 '%0' 时出错：%1"
 # "error parsing index file: '%0' line: %1 '<USR-Length>:<USR> <File-Path>' format expected"
-HDAED7E913418: "索引文件解析错误：'%0' 第 %1 行应为'<USR-Length>:<USR> <File-Path>'格式"
+HDAED7E913418: "索引文件解析错误：'%0' 第 %1 行应为 '<USR-Length>:<USR> <File-Path>' 格式"
 # "error reading '%0': %1"
 HB78815388E3E: "读取 '%0' 时出错：%1"
 # 'error reading stdin: %0'
@@ -20901,13 +20901,13 @@ H64C22CA14EC7: '不完整类 %0 的成员需要异常规范'
 # 'exception specification of %0 uses itself'
 H8B7B4ED4974B: '%0 的异常规范使用自身'
 # "exception specification of '...' is a Microsoft extension"
-H50C368DB8633: "'...'的异常规范是Microsoft扩展"
+H50C368DB8633: "'...' 的异常规范是Microsoft扩展"
 # 'exception specification of overriding function is more lax than base version'
 HBB63D54D7089: '覆盖函数的异常规范比基类版本更宽松'
 # 'exception specifications are not allowed beyond a single level of indirection'
 HB84B4B7EA104: '异常规范不允许超过单层间接引用'
 # 'exception specifications are not allowed in %select{typedefs|type aliases}0'
-HBAC9EC08A3E9: '异常规范不允许在%select{typedefs|类型别名}0中使用'
+HBAC9EC08A3E9: '异常规范不允许在 %select{typedefs|类型别名}0中使用'
 # 'exception specifications of %select{return|argument}0 types differ'
 H04931F9B5864: '%select{返回|参数}0类型的异常规范不同'
 # 'excess elements in %select{array|vector|scalar|union|struct}0 initializer'
@@ -20917,7 +20917,7 @@ H65240A881DB2: '字符数组初始化器存在多余元素'
 # 'excess elements in initializer for indivisible sizeless type %0'
 HF6B0539A54ED: '不可分割无尺寸类型 %0 的初始化器存在多余元素'
 # 'excess precision is requested but the target does not support excess precision which may result in observable differences in complex division behavior%select{|, additional uses where the requested higher precision cannot be honored were found but not diagnosed}0'
-H46192DCC4FC7: '请求额外精度但目标架构不支持额外精度，可能导致复数除法行为差异%select{|, 在其他需要更高精度的位置未诊断出无法满足的情况}0'
+H46192DCC4FC7: '请求额外精度但目标架构不支持额外精度，可能导致复数除法行为差异 %select{|, 在其他需要更高精度的位置未诊断出无法满足的情况}0'
 # 'exe called with module IR after each pass that changes it'
 H9DCF33C92D4F: '在每次修改模块的pass后，执行带有该模块IR的exe'
 # 'execute only is not supported for the %0 sub-architecture'
@@ -20927,7 +20927,7 @@ HBE1A4247ED95: '__weak属性 %0 的现有实例变量 %1 必须为__weak'
 # 'existing instance variable %1 for property %0 with %select{unsafe_unretained|assign}2 attribute must be __unsafe_unretained'
 H45768C1508E1: '属性 %0 的 %select{unsafe_unretained|assign}2 属性对应的实例变量 %1 必须为__unsafe_unretained'
 # 'existing instance variable %1 for strong property %0 may not be %select{|__unsafe_unretained||__weak}2'
-H98A6ABD1A54E: '强属性 %0 的现有实例变量 %1 不能为%select{|__unsafe_unretained||__weak}2'
+H98A6ABD1A54E: '强属性 %0 的现有实例变量 %1 不能为 %select{|__unsafe_unretained||__weak}2'
 # 'existing instance variable %1 for strong property %0 may not be __weak'
 HD554DEC7881B: '强属性 %0 的现有实例变量 %1 可能不能是 __weak'
 # 'exit after writing aggregated data file'
@@ -20957,15 +20957,15 @@ H62A445966708: '期望 %0; %1 是Objective-C++中的关键字'
 # 'expected %1 after %0'
 H5879CE8F4818: '在 %0 之后期望 %1'
 # "expected %select{'enable', 'disable', 'begin' or 'end'|'disable'}0 - ignoring"
-H1B18CF6CA096: "期望%select{'enable', 'disable', 'begin' 或 'end'|'disable'}0 - 忽略"
+H1B18CF6CA096: "期望 %select{'enable', 'disable', 'begin' 或 'end'|'disable'}0 - 忽略"
 # "expected %select{'match'|'match', 'adjust_args', or 'append_args'}0 clause on 'omp declare variant' directive"
-HED7B3D66D419: "期望%select{'match'|'match', 'adjust_args' 或 'append_args'}0子句在'omp declare variant'指令上"
+HED7B3D66D419: "期望 %select{'match'|'match', 'adjust_args' 或 'append_args'}0 子句在 'omp declare variant' 指令上"
 # "expected %select{'val' modifier|one of 'ref', val' or 'uval' modifiers}0"
-HCC26F8F297FB: "期望%select{'val' 修饰符|'ref', 'val' 或 'uval' 修饰符之一}0"
+HCC26F8F297FB: "期望 %select{'val' 修饰符|'ref', 'val' 或 'uval' 修饰符之一}0"
 # 'expected %select{assignment|assignment, compound assignment, increment, or decrement}0 expression'
 H2BC7EE32B904: '期望%select{赋值|赋值、复合赋值、递增或递减}0表达式'
 # "expected %select{identifier after '.' in |}0module name"
-HF095089F6D4D: '期望模块名称%select{中 '.' 后应为标识符|}0'
+HF095089F6D4D: '期望 %select{.后的标识符|}0 模块名称'
 # 'expected %select{identifier|unqualified-id}0'
 HC1969BE019B7: '期望%select{标识符|未限定的标识符}0'
 # 'expected %select{library|framework}0 name as a string'
@@ -20973,83 +20973,83 @@ H5FD987168935: '期望%select{库|框架}0名称作为字符串'
 # "expected %select{module exclusion with 'exclude'|'export *'}0"
 H4175E9BAE37D: "期望%select{带有 'exclude' 的模块排除|'export *'}0"
 # "expected '#pragma omp end declare %select{target|variant}0'"
-H7B3C6216417A: "期望'#pragma omp end declare %select{target|variant}0'"
+H7B3C6216417A: "期望 '#pragma omp end declare %select{target|variant}0'"
 # "expected '#pragma omp end declare target' at end of file to match '#pragma omp %0'"
-H25BEC71CAA92: "期望在文件末尾有'#pragma omp end declare target'来匹配'#pragma omp %0'"
+H25BEC71CAA92: "期望在文件末尾有 '#pragma omp end declare target' 来匹配 '#pragma omp %0'"
 # "expected '#pragma unused' argument to be a variable name"
-HE4429A749432: "'#pragma unused'参数应为变量名"
+HE4429A749432: "'#pragma unused' 参数应为变量名"
 # "expected '%0' after the %1; '%0' assumed"
 HB08F71D9B939: "在 %1 之后期望 '%0'；假设了 '%0'"
 # "expected '%0' clause with an argument on '#pragma omp %1' construct"
-HA803E7993B4F: "在'#pragma omp %1'结构中期望带参数的 '%0' 子句"
+HA803E7993B4F: "在 '#pragma omp %1' 结构中期望带参数的 '%0' 子句"
 # "expected '(' after '%0'"
-HA365863454FD: "在 '%0' 后期望'('"
+HA365863454FD: "在 '%0' 后期望 '('"
 # "expected '(' for function-style cast or type construction"
-H95D0E6661AB2: "期望'('用于函数式类型转换或类型构造"
+H95D0E6661AB2: "期望 '(' 用于函数式类型转换或类型构造"
 # "expected ')' after '%0'"
-H068274655B04: "在 '%0' 后期望')'"
+H068274655B04: "在 '%0' 后期望 ')'"
 # "expected ')' in preprocessor expression"
-H9FA29BAED1EF: "预处理表达式中期望')'"
+H9FA29BAED1EF: "预处理表达式中期望 ')'"
 # "expected ')' or ',' after '%0'"
-HD115318388CA: "在 '%0' 后期望')'或','"
+HD115318388CA: "在 '%0' 后期望 ')' 或 ','"
 # "expected ')' or ',' in '#pragma %0'"
-H97FBD869E75F: "在'#pragma %0'中期望')'或','"
+H97FBD869E75F: "在 '#pragma %0' 中期望 ')' 或 ','"
 # "expected '+' or '-' operation"
-H193C159A95C7: "期望'+'或'-'操作"
+H193C159A95C7: "期望 '+' 或 '-' 操作"
 # "expected ',' after conflicting module name"
-H307B5FE6EEA1: "在冲突模块名后期望','"
+H307B5FE6EEA1: "在冲突模块名后期望 ','"
 # "expected ',' after interop modifier"
-HBE15766F267C: "在互操作修饰符后期望','"
+HBE15766F267C: "在互操作修饰符后期望 ','"
 # "expected ',' in '#pragma %0'"
-H80B3D004C35A: "在'#pragma %0'中期望','"
+H80B3D004C35A: "在 '#pragma %0' 中期望 ','"
 # "expected ',' or ')' after iterator specifier"
-H5B885E53A966: "在迭代器说明符后期望','或')'"
+H5B885E53A966: "在迭代器说明符后期望 ',' 或 ')'"
 # "expected ',' or ')' at end of property accessor list"
-H90761748BDB7: "在属性存取器列表末尾期望','或')'"
+H90761748BDB7: "在属性存取器列表末尾期望 ',' 或 ')'"
 # "expected ',' or ')' in '%0' %select{clause|directive}1"
-H27E43F9D4E4C: "在 '%0' %select{子句|指令}1中期望','或')'"
+H27E43F9D4E4C: "在 '%0' %select{子句|指令}1中期望 ',' 或 ')'"
 # "expected ',' or '>' in template-parameter-list"
-HE6FA48C9A81A: "在模板参数列表中期望','或'>'"
+HE6FA48C9A81A: "在模板参数列表中期望 ',' 或 '>'"
 # "expected ',' or ']' in lambda capture list"
-H01C14BB9E6E5: 'lambda捕获列表中期望","或"]"'
+H01C14BB9E6E5: 'lambda捕获列表中期望 "," 或 "]"'
 # "expected '->' before expression type requirement"
-H25053402E92B: '在表达式类型要求前期望"->"'
+H25053402E92B: '在表达式类型要求前期望 "->"'
 # "expected '.' after pragma attribute namespace %0"
-H6D0DBF9112AD: '在pragma属性命名空间 %0 后期望"."'
+H6D0DBF9112AD: '在pragma属性命名空间 %0 后期望 "."'
 # "expected '::' after '__super'"
-HFBD8EE4CC424: '在"__super"后期望"::"'
+HFBD8EE4CC424: '在 "__super" 后期望 "::"'
 # "expected ';' after %0 statement"
-H26F61B7787AD: '"%0 语句后期望";"'
+H26F61B7787AD: '"%0 语句后期望 ";"'
 # "expected ';' after '%0'"
-HC22BB7A01636: "期望在 '%0' 后有';'"
+HC22BB7A01636: "期望在 '%0' 后有 ';'"
 # "expected ';' after attribute list"
-HC367299E9BFD: "期望在属性列表后有';'"
+HC367299E9BFD: "期望在属性列表后有 ';'"
 # "expected ';' after expression"
-H26209FD52998: "期望在表达式后有';'"
+H26209FD52998: "期望在表达式后有 ';'"
 # "expected ';' after method prototype"
-H4DCD5C7E2BCB: "期望在方法原型后有';'"
+H4DCD5C7E2BCB: "期望在方法原型后有 ';'"
 # "expected ';' after module name"
-H20B27913626E: "期望在模块名后有';'"
+H20B27913626E: "期望在模块名后有 ';'"
 # "expected ';' after namespace name"
-HAAD5C65924B6: "期望在命名空间名后有';'"
+HAAD5C65924B6: "期望在命名空间名后有 ';'"
 # "expected ';' after private module fragment declaration"
-H868380AB5A37: "期望在私有模块片段声明后有';'"
+H868380AB5A37: "期望在私有模块片段声明后有 ';'"
 # "expected ';' after top level declarator"
-H3A247DA7CE56: "期望在顶层声明符后有';'"
+H3A247DA7CE56: "期望在顶层声明符后有 ';'"
 # "expected ';' at end of declaration"
-HA8E976B320DC: "期望在声明结尾处有';'"
+HA8E976B320DC: "期望在声明结尾处有 ';'"
 # "expected ';' at end of declaration list"
-HA684210D419F: "期望在声明列表结尾处有';'"
+HA684210D419F: "期望在声明列表结尾处有 ';'"
 # "expected ';' at end of requirement"
-HDCCCFEC70AB1: "期望在约束条件结尾处有';'"
+HDCCCFEC70AB1: "期望在约束条件结尾处有 ';'"
 # "expected ';' in 'for' statement specifier"
-H2C47358FD75D: "期望在 'for' 语句说明符中有';'"
+H2C47358FD75D: "期望在 'for' 语句说明符中有 ';'"
 # "expected '<' after '%0'"
-H1010291C9C7B: "期望在 '%0' 后有'<'"
+H1010291C9C7B: "期望在 '%0' 后有 '<'"
 # "expected '= constant-expression' or end of enumerator definition"
 H01AC9A3D13F6: "期望'= 常量表达式'或枚举器定义结束"
 # "expected '=' after '%0'"
-H46EA9025A033: "期望在 '%0' 后有'='"
+H46EA9025A033: "期望在 '%0' 后有 '='"
 # "expected '=' after diagnostic option"
 HEF7733E47109: "在诊断选项后期望 '=' 符号"
 # "expected '=' following '#pragma %select{align|options align}0' - ignored"
@@ -21133,7 +21133,7 @@ H0B5DBF4FC4A5: "在 '~' 后期望类名以命名析构函数"
 # 'expected a feature name'
 H83F9EEF32768: '需要一个功能名称'
 # "expected a field designator, such as '.field = 4'"
-HE811DCDC9E5C: "期望一个字段指定符，例如'.field = 4'"
+HE811DCDC9E5C: "期望一个字段指定符，例如 '.field = 4'"
 # 'expected a foldable binary operator in fold expression'
 H442801240371: '折叠表达式中需要一个可折叠的二元操作符'
 # "expected a for, while, or do-while loop to follow '%0'"
@@ -21149,17 +21149,17 @@ H3712B62CAC8D: "需要描述与 '%0' 冲突的说明信息"
 # 'expected a module map file name'
 H34A1748EFBBA: '需要一个模块映射文件名称'
 # "expected a module name after '%select{module|import}0'"
-H60B4E74C4DAA: "在'%select{module|import}0'之后期望一个模块名称"
+H60B4E74C4DAA: "在 '%select{module|import}0' 之后期望一个模块名称"
 # "expected a module name in '__building_module' expression"
 H3E7D4309A80A: "在 '__building_module' 表达式中需要一个模块名称"
 # "expected a module name or '*'"
-HA872E74CF2C8: "需要一个模块名称或'*'"
+HA872E74CF2C8: "需要一个模块名称或 '*'"
 # 'expected a platform name here'
 HB3E385166F04: '此处需要一个平台名称'
 # "expected a platform name, e.g., 'macos'"
 H451496142CA8: "期望一个平台名称，例如 'macos'"
 # 'expected a property name in @synthesize'
-HFCD01091BCD1: "'@synthesize'中需要指定属性名称"
+HFCD01091BCD1: "'@synthesize' 中需要指定属性名称"
 # "expected a qualified name after 'typename'"
 H3D60DB7C4A2E: "在 'typename' 之后需要一个限定名称"
 # "expected a reference to a parameter specified in a 'uniform' clause"
@@ -21169,7 +21169,7 @@ HD574D7423FC7: '需要一个指向整型参数的引用'
 # "expected a related Objective-C class name, e.g., 'NSColor'"
 H1B15D42F8530: "期望一个相关的Objective-C类名，例如 'NSColor'"
 # "expected a stack label or a string literal for the section name in '#pragma %0' - ignored"
-HC98188AB663C: "在'#pragma %0'中期望一个栈标签或字符串字面量作为段名称 - 已忽略"
+HC98188AB663C: "在 '#pragma %0' 中期望一个栈标签或字符串字面量作为段名称 - 已忽略"
 # "expected a string literal for the section name in '#pragma %0' - ignored"
 HE785ABE9BD3E: "在 '#pragma %0' 中期望段名称的字符串字面量 - 已忽略"
 # 'expected a type'
@@ -21211,19 +21211,19 @@ H9C057C572CE2: "期望与属性对象匹配子规则对应的标识符；'%0' �
 # 'expected an identifier that corresponds to an attribute subject rule'
 H294E4D252009: '期望与属性对象规则对应的标识符'
 # "expected an integer argument in '#pragma %0'"
-H8B88B2FBB6B4: "在'#pragma %0'中期望整数参数"
+H8B88B2FBB6B4: "在 '#pragma %0' 中期望整数参数"
 # "expected an integer or a pointer type of the outer loop counter '%0' for non-rectangular nests"
 H7B769AB4785B: "在非矩形嵌套中，外层循环计数器 '%0' 的类型应为整数或指针类型"
 # "expected at least one %0 clause for '#pragma omp %1'"
-H7235197EF029: "在'#pragma omp %1'中期望至少一个 %0 子句"
+H7235197EF029: "在 '#pragma omp %1' 中期望至少一个 %0 子句"
 # "expected at least one %select{'enter' or 'link'|'enter', 'link' or 'indirect'}0 clause"
-H068B5F15FD0D: "期望至少一个%select{'enter' 或 'link'|'enter', 'link' 或 'indirect'}0子句"
+H068B5F15FD0D: "期望至少一个 %select{'enter' 或 'link'|'enter', 'link' 或 'indirect'}0 子句"
 # "expected at least one %select{'to' or 'link'|'to', 'link' or 'indirect'}0 clause"
-HCCB831884601: "期望至少一个%select{'to' 或 'link'|'to', 'link' 或 'indirect'}0子句"
+HCCB831884601: "期望至少一个 %select{'to' 或 'link'|'to', 'link' 或 'indirect'}0 子句"
 # "expected at least one 'to' clause or 'from' clause specified to '#pragma omp target update'"
-HD1F834BB93F7: "在'#pragma omp target update'中需要指定至少一个 'to' 子句或 'from' 子句"
+HD1F834BB93F7: "在 '#pragma omp target update' 中需要指定至少一个 'to' 子句或 'from' 子句"
 # "expected at least one clause on '#pragma omp %0' directive"
-HF2F95AA7B57B: "在'#pragma omp %0'指令中需要至少一个子句"
+HF2F95AA7B57B: "在 '#pragma omp %0' 指令中需要至少一个子句"
 # "expected attribute subject set specifier 'apply_to'"
 H235FBF52B9D6: "期望属性对象设置说明符 'apply_to'"
 # 'expected binary operation on right hand side of assignment operator'
@@ -21249,7 +21249,7 @@ HAB95DA27DF2F: '期望逗号后的配置宏名称'
 # "expected constant sized array of 'omp_alloctrait_t' elements, not %0"
 H05FAEDD71E4D: "期望 'omp_alloctrait_t' 元素的固定大小数组，而非 %0"
 # "expected declarator on 'omp declare mapper' directive"
-HB22F9750894D: "期望'omp declare mapper'指令中的说明符"
+HB22F9750894D: "期望 'omp declare mapper' 指令中的说明符"
 # 'expected depobj expression'
 HE3D01E0D4DF5: '期望依赖对象表达式'
 # 'expected end of directive in pragma'
@@ -21271,7 +21271,7 @@ HF961A21CDC61: '函数说明符后需跟函数主体'
 # "expected function or lambda declaration for 'routine' construct"
 H6E72FAB495F6: "期望为 'routine' 结构声明函数或lambda表达式"
 # "expected identifier in '#pragma %0' - ignored"
-H05B1FBF9EBC9: '在"#pragma %0"中期望标识符 - 被忽略'
+H05B1FBF9EBC9: '在 "#pragma %0" 中期望标识符 - 被忽略'
 # 'expected identifier in macro parameter list'
 H94E463CD5EE5: '宏参数列表中期望标识符'
 # "expected identifier or one of the following operators: '+', '-', '*', '&', '|', '^', '&&', or '||'"
@@ -21287,11 +21287,11 @@ H4FF5B028471D: '期望表示属性名称的标识符'
 # 'expected initializer'
 HC06E564F6549: '期望初始化器'
 # "expected integer between %0 and %1 inclusive in '#pragma %2' - ignored"
-HD3B45551DCCD: '在"#pragma %2"中期望 %0 到 %1 之间的整数（含边界） - 被忽略'
+HD3B45551DCCD: '在 "#pragma %2" 中期望 %0 到 %1 之间的整数（含边界） - 被忽略'
 # "expected integer literal as value for header attribute '%0'"
 H664A6DF4E15C: "期望头属性 '%0' 的值为整数字面量"
 # "expected integer or identifier in '#pragma pack' - ignored"
-H76DF3F452A3B: '在"#pragma pack"中期望整数或标识符 - 被忽略'
+H76DF3F452A3B: '在 "#pragma pack" 中期望整数或标识符 - 被忽略'
 # 'expected integral or pointer type as the iterator-type, not %0'
 H630D7FF60D9F: '期望迭代器类型为整型或指针类型，而非 %0'
 # "expected interop type: 'target' and/or 'targetsync'"
@@ -21341,7 +21341,7 @@ HE400FE627646: '期望参数声明符'
 # 'expected parentheses around type name in %0 expression'
 H29C3C3BEE053: '在 %0 表达式中期望类型名称周围的括号'
 # "expected parenthesized parameter pack name in 'sizeof...' expression"
-H872448706A49: "在'sizeof...'表达式中期望括号括起的参数包名称"
+H872448706A49: "在 'sizeof...' 表达式中期望括号括起的参数包名称"
 # "expected pointer in '%0' clause, type is %1"
 HA28C1D2864FB: "在 '%0' 子句中期望指针，类型为 %1"
 # "expected pointer or reference to pointer in 'use_device_ptr' clause"
@@ -21353,11 +21353,11 @@ H529E9DB350DF: "在'is_device_ptr子句中期望指针、数组、指向指针�
 # 'expected property name'
 H849B19CD5A49: '期望属性名称'
 # "expected push, pop or a string literal for the section name in '#pragma %0' - ignored"
-H4F1921BA3641: "在'#pragma %0'中期望push、pop或段名字符串字面量 - 忽略"
+H4F1921BA3641: "在 '#pragma %0' 中期望push、pop或段名字符串字面量 - 忽略"
 # 'expected quoted string after equals sign'
 H2D60229D01D0: '在等号后面期望字符串字面量'
 # "expected reference to one of the parameters of function %0%select{| or 'this'}1"
-HD78611AD5D12: "期望函数 %0%select{|或 'this'}1的参数之一的引用"
+HD78611AD5D12: "期望函数 %0%select{|或 'this'}1 的参数之一的引用"
 # 'expected selector for Objective-C %select{setter|getter}0'
 HFB2F00048645: 'Objective-C %select{设置器|获取器}0期望选择器'
 # 'expected selector for Objective-C method'
@@ -21365,13 +21365,13 @@ HC4CCDD47D676: 'Objective-C方法期望选择器'
 # 'expected statement'
 HFEEF58AA5565: '期望语句'
 # "expected string literal %select{in %1|for diagnostic message in static_assert|for optional message in 'availability' attribute|for %select{language name|source container name|USR}1 in 'external_source_symbol' attribute|as argument of '%1' attribute}0"
-HD61709E5D47F: "期望字符串字面量 %select{在 %1 中|在static_assert的诊断消息中|在 'availability' 属性的可选消息中|在 'external_source_symbol' 属性的%select{语言名称|源容器名称|USR}1中|作为 '%1' 属性的参数}0"
+HD61709E5D47F: "期望字符串字面量 %select{在 %1 中|在static_assert的诊断消息中|在 'availability' 属性的可选消息中|在 'external_source_symbol' 属性的%select{语言名称|源容器名称|USR}1 中|作为 '%1' 属性的参数}0"
 # "expected string literal %select{or parenthesized constant expression |}0in 'asm'"
 H87FD9C867F0C: "在 'asm' 中期望字符串字面量 %select{或括号内的常量表达式 |}0"
 # "expected string literal in '#pragma %0' - ignoring"
-H0A31A7BE2E40: "在'#pragma %0'中期望字符串字面量 - 忽略"
+H0A31A7BE2E40: "在 '#pragma %0' 中期望字符串字面量 - 忽略"
 # "expected string literal in 'clause %0' - ignoring"
-H25BCA649E0CB: "在'clause %0'子句中期望字符串字面量 - 忽略"
+H25BCA649E0CB: "在 'clause %0' 子句中期望字符串字面量 - 忽略"
 # 'expected template'
 H15B15916EEBA: '期望模板'
 # "expected template name after 'template' keyword in nested name specifier"
@@ -21379,7 +21379,7 @@ H49E8E5AAE6BB: "在嵌套名称限定符中的 'template' 关键字后期望模�
 # 'expected template parameter'
 H112129FF4EB6: '期望模板参数'
 # "expected the class name after '~' to name the enclosing class"
-HD0B1F9262E8D: "期望在'~'之后给出封闭类的类名"
+HD0B1F9262E8D: "期望在 '~' 之后给出封闭类的类名"
 # 'expected the name of a parameter pack'
 H259207509382: '期望参数包的名称'
 # 'expected type parameter name'
@@ -21391,31 +21391,31 @@ HF9402AD88CE1: '在 %0 中期望有效的上下文选择器'
 # 'expected value in expression'
 HC052EF0BAA44: "期望变量名或 'this' 在lambda捕获列表中"
 # 'expected variable name as a base of the array %select{subscript|section}0'
-HBE410C345F41: '期望变量名%select{|或当前类的数据成员}0'
+HBE410C345F41: '期望变量名 %select{|或当前类的数据成员}0'
 # "expected variable name or 'this' in lambda capture list"
 H9A94F049DF94: "在lambda捕获列表中期望变量名称或 'this'"
 # 'expected variable name%select{| or data member of current class}0'
-H829F4F463842: '期望变量名%select{|或当前类的数据成员}0'
+H829F4F463842: '期望变量名 %select{|或当前类的数据成员}0'
 # 'expected variable name%select{|, data member of current class}0, array element or array section'
-HEAE159C816D1: '期望变量名%select{|、当前类的数据成员}0、数组元素或数组切片'
+HEAE159C816D1: '期望变量名 %select{|、当前类的数据成员}0、数组元素或数组切片'
 # 'expected variable of pointer type'
 H396A94544855: '期望指针类型的变量'
 # "expected variable of the '%0' type%select{|, not %2}1"
-H3293A68C1535: "期望类型为 '%0' 的变量%select{|，而非 %2}1"
+H3293A68C1535: "期望类型为 '%0' 的变量 %select{|，而非 %2}1"
 # "expected variable%select{| or static data member|, static data member, or non-static data member of current class}0 of type '%1'"
-H54FC8A6038F8: "期望类型为 '%1' 的变量%select{|或静态数据成员|、静态数据成员或当前类的非静态数据成员}0"
+H54FC8A6038F8: "期望类型为 '%1' 的变量 %select{|或静态数据成员|、静态数据成员或当前类的非静态数据成员}0"
 # 'expected%select{| %1}0 loop iteration variable'
-H9F489F0C181E: '期望%select{| %1}0 循环迭代变量'
+H9F489F0C181E: '期望 %select{| %1}0 循环迭代变量'
 # "expected%select{| non-const}0 variable of type 'omp_interop_t'"
-H7FA31289BDF2: '期望%select{|非const}0 类型为 omp_interop_t 的变量'
+H7FA31289BDF2: '期望 %select{|非const}0 类型为 omp_interop_t 的变量'
 # 'expected%select{| one of}0 %1 directive name modifier%select{|s}0'
-HF9EF92E2746A: '期望%select{|一个}0 %1 指令名称修饰符%select{|s}0'
+HF9EF92E2746A: '期望 %select{|一个}0 %1 指令名称修饰符 %select{|s}0'
 # "expecting %0 '%1' to be held at start of each loop"
 HFDC07BD9FDE6: "期望在每个循环的开头保持 %0 '%1'"
 # "expecting %0 '%1' to be held at the end of function"
 H696ED076811B: "期望在函数结尾保持 %0 '%1'"
 # 'explicit %select{constructor|conversion function|deduction guide}0 is not a candidate%select{| (explicit specifier evaluates to true)}1'
-H1B61513FD8B6: '显式 %select{构造函数|转换函数|推导指引}0 不是候选%select{|（显式说明符计算为true）}1'
+H1B61513FD8B6: '显式 %select{构造函数|转换函数|推导指引}0 不是候选 %select{|（显式说明符计算为true）}1'
 # 'explicit %select{constructor|deduction guide}0 declared here'
 H110462FEE829: '显式 %select{构造函数|推导指引}0 在此处声明'
 # 'explicit %select{specialization|instantiation}0 of %select{non-|undeclared }3template %1 %2'
@@ -21505,7 +21505,7 @@ HDBBF37665EBE: '在实例化之后对 %0 的显式特例化'
 # 'explicit specialization of %0 in function scope'
 H4AB8E368275F: '在函数作用域内对 %0 的显式特例化'
 # "explicit template instantiation cannot have a definition; if this definition is meant to be an explicit specialization, add '<>' after the 'template' keyword"
-H88A1F449C08B: "显式模板实例化不能有定义；如果此定义本意是显式特例化，请在 'template' 关键字后添加'<>'"
+H88A1F449C08B: "显式模板实例化不能有定义；如果此定义本意是显式特例化，请在 'template' 关键字后添加 '<>'"
 # 'explicit template parameter list for lambdas is a C++20 extension'
 HF9AE6F1B9252: 'lambda表达式中的显式模板参数列表是C++20扩展'
 # 'explicit template parameter list for lambdas is incompatible with C++ standards before C++20'
@@ -21515,7 +21515,7 @@ H07C70F747BCD: 'explicit(bool)是C++20扩展'
 # 'explicit(bool) is incompatible with C++ standards before C++20'
 H2A0E673F4AE0: 'explicit(bool)与C++20之前的C++标准不兼容'
 # 'explicitly assigning value of variable of type %0 to itself%select{|; did you mean to assign to member %2?}1'
-HB1C6DD04C662: '显式地将类型 %0 变量的值赋给自己%select{|; 是否应将成员 %2 赋值？}1'
+HB1C6DD04C662: '显式地将类型 %0 变量的值赋给自己 %select{|; 是否应将成员 %2 赋值？}1'
 # "explicitly capture 'this'"
 HCF140BF35536: "显式捕获 'this'"
 # 'explicitly cast the argument to size_t to silence this warning'
@@ -21525,7 +21525,7 @@ H8E24FB4D1062: '将指针显式转换以消除此警告'
 # "explicitly declare getter %objcinstance0 with '%1' to return an 'unowned' object"
 H4E2F7B8127D2: "使用 '%1' 显式声明返回 'unowned' 对象的getter %objcinstance0"
 # 'explicitly defaulted %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator is implicitly deleted'
-H811330B8F313: '显式默认的%select{<ERROR>|相等|三向|相等|关系}0比较运算符被隐式删除'
+H811330B8F313: '显式默认的 %select{<ERROR>|相等|三向|相等|关系}0比较运算符被隐式删除'
 # 'explicitly defaulted %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}0 is implicitly deleted'
 H4A686915F9DC: '显式默认的%select{默认构造函数|拷贝构造函数|移动构造函数|拷贝赋值运算符|移动赋值运算符|析构函数}0被隐式删除'
 # 'explicitly defaulted function was implicitly deleted here'
@@ -21533,7 +21533,7 @@ HF8EF8D3E0A6F: '显式默认的函数在此处被隐式删除'
 # 'explicitly defaulting this %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}0 with a type different from the implicit type is incompatible with C++ standards before C++20'
 H5E5EF3FDD4E3: '使用与隐式类型不同的类型显式默认%select{默认构造函数|拷贝构造函数|移动构造函数|拷贝赋值运算符|移动赋值运算符|析构函数}0与C++20之前的C++标准不兼容'
 # 'explicitly moving variable of type %0 to itself%select{|; did you mean to move to member %2?}1'
-H35CC5A2B002D: '显式将类型 %0 的变量移动到自身%select{|; 是否应移动到成员 %2？}1'
+H35CC5A2B002D: '显式将类型 %0 的变量移动到自身 %select{|; 是否应移动到成员 %2？}1'
 # 'explicitly specialized declaration is here'
 H0E01C428C014: '显式特化声明在此处'
 # 'explicitly-defaulted %select{copy|move}0 assignment operator must return %1'
@@ -21563,7 +21563,7 @@ HBEECC801546A: '表达式不能后跟后缀 %0 操作符；请添加括号'
 # 'expression does not compute the number of elements in this array; element type is %0, not %1'
 H23C233069DBB: '表达式未计算该数组的元素数量；元素类型为 %0 而非 %1'
 # "expression evaluates to '%0 %1 %2'"
-H64BCD859D7BF: "表达式计算为'%0 %1 %2'"
+H64BCD859D7BF: "表达式计算为 '%0 %1 %2'"
 # 'expression has incomplete class type %0'
 H58E1F9927C3B: '表达式具有不完整的类类型 %0'
 # 'expression is not a string literal'
@@ -21595,7 +21595,7 @@ H9C60337CD3B8: "用于 'typeid' 操作数的具有副作用的表达式仍会被
 # 'extension used'
 HD363255C0A95: '使用了扩展功能'
 # 'extern "C" language linkage specification begins here'
-H7A156727F19D: 'extern "C"语言链接规范从此处开始'
+H7A156727F19D: 'extern "C" 语言链接规范从此处开始'
 # 'extern declaration of %0 follows non-extern declaration'
 HD31A31C8A91F: '%0 的extern声明在非extern声明之后'
 # 'extern templates are a C++11 extension'
@@ -21609,7 +21609,7 @@ H15B2E1B8C6FC: '外部变量 %0 在不同翻译单元中声明的类型不兼容
 # 'external variable %0 defined in multiple translation units'
 H1F8D107DE885: '外部变量 %0 在多个翻译单元中定义'
 # "extra '&' taking address of overloaded function"
-H9A83B3B4D92C: "额外的'&'操作符用于取重载函数的地址"
+H9A83B3B4D92C: "额外的 '&' 操作符用于取重载函数的地址"
 # "extra ';' %select{outside of a function|inside a %1|inside instance variable list|after member function definition}0"
 HE280E1BDB8CF: "多余的 ';' %select{函数外|在 %1 内|在实例变量列表内|成员函数定义后}0"
 # "extra ';' after member function definition"
@@ -21735,7 +21735,7 @@ H8FECB3E29FF3: '字段不能用地址空间进行限定'
 # 'field of illegal %select{type|pointer type}0 %1 declared here'
 H7B96A2670B39: '非法的%select{类型|指针类型}0 %1 在此处声明'
 # 'field of type %0 has %select{private|protected}2 %select{default |copy |move |*ERROR* |*ERROR* |*ERROR* |}1constructor'
-H3E9701CFFDEE: '类型 %0 的字段具有%select{私有|保护}2 %select{默认|拷贝|移动|*ERROR*|*ERROR*|*ERROR*|}1构造函数'
+H3E9701CFFDEE: '类型 %0 的字段具有%select{私有|保护}2 %select{默认|拷贝|移动|*ERROR*|*ERROR*|*ERROR*|}1 构造函数'
 # 'field of type %1 has %select{private|protected}2 destructor'
 H40B677C32C44: '类型 %1 的字段具有%select{私有|保护}2 析构函数'
 # "fields must have a constant size: 'variable length array in structure' extension will never be supported"
@@ -21745,7 +21745,7 @@ H3AFCF68EDB4D: "在期望的 %1 中无法找到文件 '%0'"
 # "file '%0' from the precompiled header has been overridden"
 H0CD8B8C2C117: '来自预编译头的文件 "%0" 已被覆盖'
 # "file '%0' has been modified since the %select{precompiled header|module file|AST file}1 '%2' was built: %select{size|mtime|content}3 changed%select{| (was %5, now %6)}4"
-H031EEE30BF07: '自%select{预编译头|模块文件|AST文件}1 "%2" 构建以来，文件 "%0" 已被修改：%select{大小|修改时间|内容}3发生更改%select{|（原为 %5，现为 %6）}4'
+H031EEE30BF07: '自%select{预编译头|模块文件|AST文件}1 "%2" 构建以来，文件 "%0" 已被修改：%select{大小|修改时间|内容}3发生更改 %select{|（原为 %5，现为 %6）}4'
 # "file '%0' is not a module file"
 H5DD90DFEF976: '文件 "%0" 不是模块文件'
 # "file '%0' is too large for Clang to process"
@@ -21753,15 +21753,15 @@ H9AA7CD92D17E: '文件 "%0" 过大，Clang无法处理'
 # "file '%0' modified since it was first processed"
 H1DA05AEA2D52: '文件 "%0" 自首次处理后已被修改'
 # "file '%0' specified by '--extract-api-ignores=' not found"
-HC79263152CF4: '通过"--extract-api-ignores="指定的文件 "%0" 未找到'
+HC79263152CF4: '通过 "--extract-api-ignores=" 指定的文件 "%0" 未找到'
 # "file '%0' specified by '-fmodules-embed-file=' not found"
-HE609B0415A4D: '通过"-fmodules-embed-file="指定的文件 "%0" 未找到'
+HE609B0415A4D: '通过 "-fmodules-embed-file=" 指定的文件 "%0" 未找到'
 # "file '%1' is not a valid precompiled %select{PCH|module|AST}0 file: %2"
 H208E3D0A2BB0: '文件 "%1" 不是有效的预编译 %select{PCH|模块|AST}0 文件：%2'
 # 'file containing an ordered list of functions to use for function reordering'
 HAA6E189FC7DA: '包含用于函数重排的有序函数列表的文件'
 # 'file entered %0 time%s0 using %1B (%human1B) of space%plural{0:|: plus %2B (%human2B) for macro expansions}2'
-H6D5FEB2AA58C: '文件被输入 %0 time%s0，使用 %1B (%human1B) 的空间%plural{0:|: 加上 %2B (%human2B) 用于宏展开}2'
+H6D5FEB2AA58C: '文件被输入 %0 time%s0，使用 %1B (%human1B) 的空间 %plural{0:|: 加上 %2B (%human2B) 用于宏展开}2'
 # 'file name for generated dot file'
 H3426DAEC804D: '生成的dot文件的文件名'
 # 'file name where instrumented profile will be saved (default: /tmp/prof.fdata)'
@@ -21889,7 +21889,7 @@ H4D29848904BC: "格式说明符 '%0' 与 '%1' 不兼容"
 # 'format specifies type %0 but the argument has %select{type|underlying type}2 %1'
 H2B1918042742: '格式指定类型 %0，但参数具有%select{类型|底层类型}2 %1'
 # "format string contains '\\0' within the string body"
-H262604652293: "格式字符串在字符串正文中包含'\\0'"
+H262604652293: "格式字符串在字符串正文中包含 '\\0'"
 # 'format string is defined here'
 H2D8041B9330A: '格式字符串在此处定义'
 # 'format string is empty'
@@ -21919,7 +21919,7 @@ H61734FDBAB98: '模板实体的前向声明在此处'
 # "forward references to 'enum' types are a Microsoft extension"
 H747D15D3C5A0: '枚举类型的前向引用是Microsoft扩展'
 # "found '<::' after a %select{template name|addrspace_cast|const_cast|dynamic_cast|reinterpret_cast|static_cast}0 which forms the digraph '<:' (aka '[') and a ':', did you mean '< ::'?"
-HFDE68D3C1582: "在%select{模板名称|addrspace_cast|const_cast|dynamic_cast|reinterpret_cast|static_cast}0之后发现了'<::'，这形成了双字符符号'<:'（即'['）和一个':'，是否应为'<::'？"
+HFDE68D3C1582: "在%select{模板名称|addrspace_cast|const_cast|dynamic_cast|reinterpret_cast|static_cast}0 之后发现了 '<::'，这形成了双字符符号 '<:'（即 '['）和一个 ':'，是否应为 '<::'？"
 # "found near match '%0'"
 HE96C9DD0F351: "找到近似匹配项 '%0'"
 # 'fp convert instructions on integers with more than <N> bits are expanded.'
@@ -21961,7 +21961,7 @@ HABE505726BE2: '友元只能是类或函数'
 # 'friends cannot be members of the declaring class'
 H0C1CF26733ED: '友元不能是声明类的成员'
 # "from 'diagnose_if' attribute on %0:"
-HB7602983E09F: '来自 %0 上的"diagnose_if"属性：'
+HB7602983E09F: '来自 %0 上的 "diagnose_if" 属性：'
 # 'func1,func2,func3,...'
 H6E12F3399F53: 'func1,func2,func3,...'
 # "function %0 declared 'noreturn' should not return"
@@ -21987,11 +21987,11 @@ HC763DB755E39: '函数声明不能具有可变修改后的类型'
 # "function declaration is expected after 'declare %select{simd|variant}0' directive"
 HCE4F7AEAC2D0: '在声明 %select{simd|variant}0 指令后应有函数声明'
 # "function declaration is missing %select{'target'|'cpu_specific' or 'cpu_dispatch'|'target_version'}0 attribute in a multiversioned function"
-H3FE487F1B347: "在多版本函数中，函数声明缺少%select{'target'|'cpu_specific' 或 'cpu_dispatch'|'target_version'}0属性"
+H3FE487F1B347: "在多版本函数中，函数声明缺少 %select{'target'|'cpu_specific' 或 'cpu_dispatch'|'target_version'}0 属性"
 # 'function declared %0 was previously declared %1, which has different SME function attributes'
 HF900531E932D: '函数声明 %0 之前被声明为 %1，其具有不同的SME函数属性'
 # "function declared '%0' here was previously declared %select{'%2'|without calling convention}1"
-H2073EFB350A2: "在此处声明的函数 '%0' 之前被声明为%select{'%2'|无调用约定}1"
+H2073EFB350A2: "在此处声明的函数 '%0' 之前被声明为 %select{'%2'|无调用约定}1"
 # "function declared in block scope cannot have 'static' storage class"
 H60B5EC75E0B8: "块作用域内的函数声明不能具有 'static' 存储类"
 # 'function declared non-throwing here'
@@ -21999,7 +21999,7 @@ H03F3D9700027: '函数在此处声明为不抛出异常'
 # 'function declared with %0 attribute was previously declared without the %0 attribute'
 H5B84619C2423: '带有 %0 属性的函数声明之前被声明为没有该 %0 属性'
 # 'function declared with regparm(%0) attribute was previously declared %plural{0:without the regparm|:with the regparm(%1)}1 attribute'
-HF6A7160FBDE6: '声明带有regparm(%0)属性的函数之前被声明为%plural{0:无regparm|:带有regparm(%1)}1属性'
+HF6A7160FBDE6: '声明带有regparm(%0)属性的函数之前被声明为 %plural{0:无regparm|:带有regparm(%1)}1属性'
 # "function definition declared 'typedef'"
 H4E2B82F177E3: "此处的函数定义声明了 'typedef'"
 # 'function definition does not declare parameters'
@@ -22029,7 +22029,7 @@ H16DA1069458D: '函数多版本化目前仅在Linux系统上支持'
 # 'function multiversioning is not supported on the current target'
 H7E39D7302E01: '当前目标平台不支持函数多版本化'
 # "function name is not allowed in 'link' clause"
-H0E47E3134914: '函数名不允许出现在"link"子句中'
+H0E47E3134914: '函数名不允许出现在 "link" 子句中'
 # 'function names'
 HDC0A95620EA5: '函数名称'
 # 'function parameter %0 with unknown value cannot be used in a constant expression'
@@ -22041,17 +22041,17 @@ H6390B743719E: '函数返回带有[[clang::coro_return_type]]标记的类型 %0�
 # 'function scope depth exceeded maximum of %0'
 H7DB5DD972DEA: '函数作用域深度超过最大值 %0'
 # "function static variables are not permitted in functions to which an OpenACC 'routine' directive applies"
-HE3AED765A103: '应用OpenACC "routine"指令的函数中不允许使用静态变量'
+HE3AED765A103: '应用OpenACC "routine" 指令的函数中不允许使用静态变量'
 # 'function template %q0 matches specialization %1'
 HA3A32C570475: '函数模板%q0与特化模板 %1 匹配'
 # 'function template partial specialization is not allowed'
 HA3F0ADD5EDBB: '不允许函数模板的部分特化'
 # 'function template specialization %0 ambiguously refers to more than one function template; explicitly specify%select{| additional}1 template arguments to identify a particular function template'
-H64BC13156614: '函数模板特化 %0 模棱两可地指向多个函数模板；请显式指定%select{|附加}1模板参数以指定特定的函数模板'
+H64BC13156614: '函数模板特化 %0 模棱两可地指向多个函数模板；请显式指定 %select{|附加}1模板参数以指定特定的函数模板'
 # "function template with 'sycl_kernel' attribute must have a 'void' return type"
-HE8E9EA85C4E9: '带有"sycl_kernel"属性的函数模板必须具有"void"返回类型'
+HE8E9EA85C4E9: '带有 "sycl_kernel" 属性的函数模板必须具有 "void" 返回类型'
 # "function template with 'sycl_kernel' attribute must have a single parameter"
-H852CD6495192: '带有"sycl_kernel"属性的函数模板必须具有单一参数'
+H852CD6495192: '带有 "sycl_kernel" 属性的函数模板必须具有单一参数'
 # 'function try block in constexpr %select{function|constructor}0 is a C++20 extension'
 H5EFE05C3D7E9: '函数constexpr %select{函数|构造函数}0中的try块是C++20扩展'
 # 'function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20'
@@ -22155,7 +22155,7 @@ H37A919BEDE1E: '十六进制浮点字面量是C++17特性'
 # 'hexadecimal floating literals are incompatible with C++ standards before C++17'
 HDD6000DF6583: '十六进制浮点字面量与C++17之前的C++标准不兼容'
 # 'hidden overloaded virtual function %q0 declared here%select{|: different classes%diff{ ($ vs $)|}2,3|: different number of parameters (%2 vs %3)|: type mismatch at %ordinal2 parameter%diff{ ($ vs $)|}3,4|: different return type%diff{ ($ vs $)|}2,3|: different qualifiers (%2 vs %3)|: different exception specifications}1'
-HAF71C2F007E8: '被隐藏的重载虚函数 %q0 声明于此处%select{|: 不同的类%diff{ ($ vs $)|}2,3|: 参数数量不同（%2 vs %3）|: 第%ordinal2参数类型不匹配%diff{ ($ vs $)|}3,4|: 返回类型不同%diff{ ($ vs $)|}2,3|: 限定符不同（%2 vs %3）|: 异常规格不同}1'
+HAF71C2F007E8: '被隐藏的重载虚函数 %q0 声明于此处 %select{|: 不同的类%diff{ ($ vs $)|}2,3|: 参数数量不同（%2 vs %3）|: 第%ordinal2参数类型不匹配%diff{ ($ vs $)|}3,4|: 返回类型不同%diff{ ($ vs $)|}2,3|: 限定符不同（%2 vs %3）|: 异常规格不同}1'
 # "hidden visibility cannot be applied to 'dllexport' declaration"
 HF663B246106D: "隐藏可见性不能应用于 'dllexport' 声明"
 # 'higher order bits are zeroes after implicit conversion'
@@ -22173,7 +22173,7 @@ H4C1045D46DF7: 'hugify'
 # 'human-readable YAML format'
 HE74AE57FF6C4: '可读的YAML格式'
 # "identifier %0 after '~' in destructor name does not name a type"
-H83FECEE0EB8D: "析构函数名称中'~'后的标识符 %0 不是一个类型"
+H83FECEE0EB8D: "析构函数名称中 '~' 后的标识符 %0 不是一个类型"
 # 'identifier %0 in object destruction expression does not name a type'
 H9BF7AFAC2ABF: '对象销毁表达式中的标识符 %0 未命名一个类型'
 # 'identifier %0 in object destruction expression does not name the type %1 of the object being destroyed'
@@ -22239,23 +22239,23 @@ H4AA39F54EF26: "忽略 '%0' 选项，因为它当前不支持目标 '%1'"
 # "ignoring '%0' option for offload arch '%1' as it is not currently supported there. Use it with an offload arch containing '%2' instead"
 H788152E08844: "忽略为offload架构 '%1' 指定的 '%0' 选项，因为当前不支持该选项。请改用包含 '%2' 的offload架构"
 # "ignoring '%select{static|inline}0' keyword on explicit template instantiation"
-H8A80FA7727CA: "忽略显式模板实例化中的'%select{static|inline}0'关键字"
+H8A80FA7727CA: "忽略显式模板实例化中的 '%select{static|inline}0' 关键字"
 # "ignoring '-f%select{no-|}0raw-string-literals', which is only valid for C and C++ standards before C++11"
-H135D75731B01: "忽略'-f%select{no-|}0raw-string-literals'选项，该选项仅适用于C和C++11之前的版本"
+H135D75731B01: "忽略 '-f%select{no-|}0raw-string-literals' 选项，该选项仅适用于C和C++11之前的版本"
 # "ignoring '-mabs=2008' option because the '%0' architecture does not support it"
-H5F88EE5F0A3D: "忽略'-mabs=2008'选项，因为 '%0' 架构不支持该选项"
+H5F88EE5F0A3D: "忽略 '-mabs=2008' 选项，因为 '%0' 架构不支持该选项"
 # "ignoring '-mabs=legacy' option because the '%0' architecture does not support it"
-HE0FE9F3B46CA: "忽略'-mabs=legacy'选项，因为 '%0' 架构不支持该选项"
+HE0FE9F3B46CA: "忽略 '-mabs=legacy' 选项，因为 '%0' 架构不支持该选项"
 # "ignoring '-mcompact-branches=' option because the '%0' architecture does not support it"
-H60C9F0D89DB6: "忽略'-mcompact-branches='选项，因为 '%0' 架构不支持该选项"
+H60C9F0D89DB6: "忽略 '-mcompact-branches=' 选项，因为 '%0' 架构不支持该选项"
 # "ignoring '-mgpopt' option as it cannot be used with %select{|the implicit usage of }0-mabicalls"
-H2A6F793FDFBC: "忽略'-mgpopt'选项，因为其不能与%select{|the implicit usage of }0-mabicalls同时使用"
+H2A6F793FDFBC: "忽略 '-mgpopt' 选项，因为其不能与 %select{|the implicit usage of }0-mabicalls同时使用"
 # "ignoring '-mlong-calls' option as it is not currently supported with %select{|the implicit usage of }0-mabicalls"
-HD076A9DC69A3: "忽略'-mlong-calls'选项，因为当前不支持与%select{|the implicit usage of }0-mabicalls同时使用"
+HD076A9DC69A3: "忽略 '-mlong-calls' 选项，因为当前不支持与 %select{|the implicit usage of }0-mabicalls同时使用"
 # "ignoring '-mnan=2008' option because the '%0' architecture does not support it"
-H29C27F0049E3: "忽略'-mnan=2008'选项，因为 '%0' 架构不支持该选项"
+H29C27F0049E3: "忽略 '-mnan=2008' 选项，因为 '%0' 架构不支持该选项"
 # "ignoring '-mnan=legacy' option because the '%0' architecture does not support it"
-HADAF322768AC: "忽略'-mnan=legacy'选项，因为 '%0' 架构不支持该选项"
+HADAF322768AC: "忽略 '-mnan=legacy' 选项，因为 '%0' 架构不支持该选项"
 # 'ignoring -fapple-kext which is valid for C++ and Objective-C++ only'
 H88A745D4B73F: '忽略仅适用于C++和Objective-C++的-fapple-kext选项'
 # 'ignoring -fdiscard-value-names for LLVM Bitcode'
@@ -22265,7 +22265,7 @@ H36FCA7FF86DB: '忽略-fverify-debuginfo-preserve-export=%0 选项，因为未�
 # 'ignoring __declspec(allocator) because the function return type %0 is not a pointer or reference type'
 H6AAEF2701683: '忽略__declspec(allocator)，因为函数返回类型 %0 不是指针或引用类型'
 # "ignoring availability attribute %select{on '+load' method|with constructor attribute|with destructor attribute}0"
-H24871179ED63: "忽略%select{在'+load'方法上的|带有构造函数属性的|带有析构函数属性的}0可用性属性"
+H24871179ED63: "忽略%select{在 '+load' 方法上的|带有构造函数属性的|带有析构函数属性的}0可用性属性"
 # "ignoring extension '%0' because the '%1' architecture does not support it"
 HD131D7C5772F: "忽略扩展 '%0'，因为 '%1' 架构不支持该扩展"
 # "ignoring invalid -ftabstop value '%0', using default value %1"
@@ -22277,11 +22277,11 @@ HE01ADCD1C19E: '忽略Objective-C限定符宏的重复定义'
 # 'ignoring return value of function declared with %0 attribute'
 H0B36C4D66510: '忽略使用 %0 属性声明的函数的返回值'
 # 'ignoring return value of function declared with %0 attribute%select{|: %2}1'
-H9DECD2C6A7A4: '忽略声明带有 %0 属性的函数的返回值%select{|: %2}1'
+H9DECD2C6A7A4: '忽略声明带有 %0 属性的函数的返回值 %select{|: %2}1'
 # 'ignoring temporary created by a constructor declared with %0 attribute%select{|: %2}1'
-H0FFFAF84F31C: '忽略由声明带有 %0 属性的构造函数创建的临时对象%select{|: %2}1'
+H0FFFAF84F31C: '忽略由声明带有 %0 属性的构造函数创建的临时对象 %select{|: %2}1'
 # "ignoring the 'branch-protection' attribute because the '%0' architecture does not support it"
-HF5FC687425B2: "由于 '%0' 架构不支持该属性，忽略'branch-protection'属性"
+HF5FC687425B2: "由于 '%0' 架构不支持该属性，忽略 'branch-protection' 属性"
 # 'illegal OpenMP user-defined mapper identifier'
 H4FE25A4B348F: '非法的OpenMP用户定义映射器标识符'
 # 'illegal call to %0, expected %1 argument type'
@@ -22313,7 +22313,7 @@ H77F956612F13: "在类扩展 %0 中非法重新声明 'readwrite' 属性（也�
 # "illegal redeclaration of property in class extension %0 (attribute must be 'readwrite', while its primary must be 'readonly')"
 HA09E774D29B3: "在类扩展 %0 中非法重新声明属性（属性必须为 'readwrite'，而其主属性必须为 'readonly'）"
 # 'illegal scalar extension cast on argument %0 to %select{|in}1out paramemter'
-HF91E5CAEA96B: '参数 %0 到%select{|in}1out参数的非法标量扩展转换'
+HF91E5CAEA96B: '参数 %0 到 %select{|in}1out参数的非法标量扩展转换'
 # 'illegal storage class on file-scoped variable'
 H601564466459: '文件作用域变量上的非法存储类'
 # 'illegal storage class on function'
@@ -22339,11 +22339,11 @@ H9AA979884A67: '实现已弃用的%select{方法|类|分类}0'
 # 'implementing unavailable method'
 H0D7D4644123A: '实现不可用的方法'
 # 'implicit %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}0 inferred target collision: call to both %select{__device__|__global__|__host__|__host__ __device__}1 and %select{__device__|__global__|__host__|__host__ __device__}2 members'
-HDD95624FC57A: '隐式%select{默认构造函数|拷贝构造函数|移动构造函数|拷贝赋值运算符|移动赋值运算符|析构函数}0推断的目标冲突：同时调用了%select{__device__|__global__|__host__|__host__ __device__}1和%select{__device__|__global__|__host__|__host__ __device__}2成员'
+HDD95624FC57A: '隐式%select{默认构造函数|拷贝构造函数|移动构造函数|拷贝赋值运算符|移动赋值运算符|析构函数}0推断的目标冲突：同时调用了 %select{__device__|__global__|__host__|__host__ __device__}1 和 %select{__device__|__global__|__host__|__host__ __device__}2 成员'
 # 'implicit boolean conversion of Objective-C object literal always evaluates to true'
 HFAC6148E9355: 'Objective-C对象字面量的隐式布尔转换始终计算为true'
 # "implicit capture of 'this' with a capture default of '=' is deprecated"
-H7D01BFC1D4A1: '使用默认捕获方式"="隐式捕获"this"已弃用'
+H7D01BFC1D4A1: '使用默认捕获方式 "=" 隐式捕获 "this" 已弃用'
 # 'implicit capture of lambda object due to conversion to block pointer here'
 H9CBFA98934C5: '由于此处转换为块指针，隐式捕获了lambda对象'
 # 'implicit cast from type %0 to type %1 drops __unaligned qualifier'
@@ -22351,7 +22351,7 @@ HBCE299280FC0: '从类型 %0 到类型 %1 的隐式转换会丢失__unaligned限
 # 'implicit conversion between pointer-to-function and pointer-to-object is a Microsoft extension'
 HE1B9297E3DCF: '函数指针与对象指针之间的隐式转换是Microsoft扩展'
 # "implicit conversion between vector types ('%0' and '%1') is deprecated; in the future, the behavior implied by '-fno-lax-vector-conversions' will be the default"
-HD9008DAA3AF0: '向量类型（"%0" 和 "%1"）之间的隐式转换已弃用；未来，"-fno-lax-vector-conversions"选项指定的行为将成为默认'
+HD9008DAA3AF0: '向量类型（"%0" 和 "%1"）之间的隐式转换已弃用；未来，"-fno-lax-vector-conversions" 选项指定的行为将成为默认'
 # 'implicit conversion changes signedness: %0 to %1'
 H2AEC008E19C8: '隐式转换改变了符号性：%0 到 %1'
 # 'implicit conversion discards imaginary component: %0 to %1'
@@ -22451,7 +22451,7 @@ HBA6CF98B38A4: "通过%select{ |模块 '%2' 在}1'%0' 导入"
 # 'importing an implementation partition unit in a module interface is not recommended. Names from %0 may not be reachable'
 H4BCD18B5E018: '在模块接口中导入实现分区单元不被推荐。%0 中的名称可能无法访问'
 # "importing module '%0'%select{| into '%3'}2 from '%1'"
-HD074A7D9BA2D: "从 '%1'%select{ |到 '%3'}2导入模块 '%0'"
+HD074A7D9BA2D: "从 '%1'%select{ |到 '%3'}2 导入模块 '%0'"
 # 'imports must immediately follow the module declaration'
 H25C0CF982742: '导入必须紧跟模块声明之后'
 # 'impossible constraint in asm: cannot store value into a register'
@@ -22461,9 +22461,9 @@ H7F88B1ED021A: '在%select{隐式|默认}0 %select{默认构造函数|拷贝构�
 # "in call to '%0'"
 H5F44B6591F5A: "在转储结构体时，调用带有参数 '(%0)' 的打印函数"
 # "in call to printing function with arguments '(%0)' while dumping struct"
-H5B10BE57CF69: "在转储结构时调用参数为'(%0)'的打印函数"
+H5B10BE57CF69: "在转储结构时调用参数为 '(%0)' 的打印函数"
 # 'in defaulted %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator for %1 first required here'
-H41C2C013E2E2: '在 %1 的默认%select{<ERROR>|相等|三向|相等|关系}0比较运算符中首次需要此处'
+H41C2C013E2E2: '在 %1 的默认 %select{<ERROR>|相等|三向|相等|关系}0比较运算符中首次需要此处'
 # 'in evaluating default argument here'
 HA6EC671D8C49: '在此处评估默认参数'
 # 'in evaluation of exception specification for %q0 needed here'
@@ -22525,7 +22525,7 @@ H6D9691DC0D28: '在 %0 的默认初始化器中'
 # 'in value-initialization of type %0 here'
 H74E349C94BB1: '在此处 %0 类型的值初始化中'
 # 'in%select{| implicit}0 constructor here'
-H24F20A5C047E: '在%select{| 隐式}0构造函数中'
+H24F20A5C047E: '在 %select{| 隐式}0构造函数中'
 # 'in-class initializer for static data member is not a constant expression'
 H9B69A27F211E: '类内静态数据成员的初始值设定项不是常量表达式'
 # 'in-class initializer for static data member is not a constant expression; folding it to a constant is a GNU extension'
@@ -22551,7 +22551,7 @@ H45B1E0C04AB4: '未找到libstdc++头文件的包含路径；请通过命令行�
 # 'include search path'
 H43B868761DFC: '包含搜索路径'
 # "include the header <%0> or explicitly provide a declaration for '%1'"
-HBFC18315E2CB: '包含头文件<%0>或显式为 %1 提供声明'
+HBFC18315E2CB: '包含头文件 <%0> 或显式为 %1 提供声明'
 # 'incompatible block pointer types %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2'
 HA4D550DCCECE: '不兼容的块指针类型 %select{%diff{将$赋值给$|将不同类型赋值}0,1|%diff{将$传给类型$的参数|传给不同类型参数}0,1|%diff{从结果类型为$的函数返回$|从函数返回不同类型}1,0|%diff{将$转换为类型$|转换类型}0,1|%diff{用类型$的表达式初始化$|用不同类型的表达式初始化}0,1|%diff{将$发送给类型$的参数|发送给不同类型参数}0,1|%diff{将$转换为类型$|转换类型}0,1}2'
 # 'incompatible constant for this __builtin_neon function'
@@ -22573,7 +22573,7 @@ H85C3F4475A3D: '将类型 %0 的可保留参数传给期望类型 %1 的CF函数
 # 'incompatible redeclaration of library function %0'
 H4DCB8A7133E4: '库函数 %0 的不兼容重声明'
 # 'incompatible types casting %0 to %1 with a %select{__bridge|__bridge_transfer|__bridge_retained}2 cast'
-HA70D951974C7: '使用%select{__bridge|__bridge_transfer|__bridge_retained}2类型转换将 %0 转为 %1 时类型不兼容'
+HA70D951974C7: '使用 %select{__bridge|__bridge_transfer|__bridge_retained}2 类型转换将 %0 转为 %1 时类型不兼容'
 # 'incompatible vector types %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2'
 H349444057F6C: '向量类型不兼容 %select{%diff{将$赋给$|将不同类型赋值}0,1|%diff{将$传给类型为$的参数|传给不同类型的参数}0,1|%diff{从结果类型为$的函数返回$|函数返回类型不匹配}1,0|%diff{将$转换为类型$|类型间转换}0,1|%diff{用类型$的表达式初始化$|用不同类型的表达式初始化}0,1|%diff{将$传给类型为$的参数|传给不同类型的参数}0,1|%diff{将$转换为类型$|类型间转换}0,1}2'
 # 'incomplete definition of type %0'
@@ -22607,7 +22607,7 @@ HB57B0356D109: '调用类型 %0 的对象时使用了不完整类型'
 # 'incomplete universal character name'
 H0184822E59BB: '通用名称不完整'
 # "incomplete universal character name; treating as '\\' followed by identifier"
-H5B8C01DBAD90: "不完整的通用字符名；视为'\\'后跟标识符"
+H5B8C01DBAD90: "不完整的通用字符名；视为 '\\' 后跟标识符"
 # 'inconsistent number of instance variables specified'
 H7EB07F9DCA1E: '指定的实例变量数量不一致'
 # "incorrect adjust_args type, expected 'need_device_ptr' or 'nothing'"
@@ -22623,7 +22623,7 @@ H39F86512F6F1: '整数中的位数不正确（期望 %0 位，但实际为 %1 �
 # 'incorrect number of bits in vector operand (expected %select{|a multiple of}0 %1 bits, have %2)'
 HDF4134C84931: '向量操作数位数不正确（期望%select{ |的倍数}0%1 位，实际 %2 位）'
 # "incorrect reduction identifier, expected one of '+', '*', '&', '|', '^', '&&', '||', 'min' or 'max' or declare reduction for type %0"
-HD90D2B65D413: "错误的规约标识符，期望其中一个：'+'、'*'、'max'、'min'、'&'、'|'、'^'、'&&'、'||'或为类型 %0 声明规约"
+HD90D2B65D413: "错误的规约标识符，期望其中一个：'+'、'*'、'max'、'min'、'&'、'|'、'^'、'&&'、'||' 或为类型 %0 声明规约"
 # "incorrect reduction identifier, expected one of '+', '-', '*', '&', '|', '^', '&&', '||', 'min' or 'max' or declare reduction for type %0"
 HC80B58A26C84: "错误的规约标识符，期望其中一个：'+'、'-'、'*'、'&'、'|'、'^'、'&&'、'||'、'min' 或 'max' 或为类型 %0 声明规约"
 # 'incorrect use of #pragma clang force_cuda_host_device begin|end'
@@ -22643,7 +22643,7 @@ HB438D9D07956: 'bool类型的递增表达式已弃用，并与C++17不兼容'
 # 'increments 8-bit counter for every edge'
 H286B107846BC: '为每条边递增 8 位计数器'
 # "indeterminate value can only initialize an object of type 'unsigned char'%select{, 'char',|}1 or 'std::byte'; %0 is invalid"
-H26C79B7B3090: "不确定的值只能初始化类型为'unsigned char'%select{, 'char',|}1或'std::byte'的对象；%0 无效"
+H26C79B7B3090: "不确定的值只能初始化类型为 'unsigned char'%select{, 'char',|}1 或 'std::byte' 的对象；%0 无效"
 # 'index %0 must appear exactly once in the permutation clause'
 H907BCB3D7A64: '索引 %0 必须在排列子句中恰好出现一次'
 # 'index for __builtin_shufflevector must be a constant integer'
@@ -22705,7 +22705,7 @@ H36A01643C5A6: '__shared__变量的初始化不受支持'
 # 'initialization of %0 may run twice when built into a shared library: it has hidden visibility and external linkage'
 H8FC0CAE3AC23: '具有隐藏可见性和外部链接性的 %0 初始化在构建为共享库时可能执行两次'
 # "initialization of %select{|signed }0char array with UTF-8 string literal is not permitted by %select{'-fchar8_t'|C++20}1"
-H2A8B3176C3CF: "使用%select{'-fchar8_t'|C++20}1时不允许用UTF-8字符串字面量初始化%select{有符号 |}0char数组"
+H2A8B3176C3CF: "使用 %select{'-fchar8_t'|C++20}1 时不允许用UTF-8字符串字面量初始化%select{有符号 |}0char数组"
 # 'initialization of an array %diff{of type $ from a compound literal of type $|from a compound literal}0,1 is a GNU extension'
 HA729653B7153: '从复合字面量类型$初始化数组%diff{类型$到|来自}0,1的扩展是GNU扩展'
 # 'initialization of flexible array member is not allowed'
@@ -22739,7 +22739,7 @@ H7BA4847E4BDF: '初始化的lambda包捕获是C++20扩展特性'
 # 'initializer %0 does not name a non-static data member or base class; did you mean the %select{base class|member}1 %2?'
 HBFA8CB0E43F8: '初始化器 %0 未命名非静态数据成员或基类；是否指%select{基类|成员}1%2？'
 # 'initializer %select{partially |}0overrides prior initialization of this subobject'
-H5DE4CB24B2D2: '初始化器%select{部分|}0覆盖了此子对象的先前初始化'
+H5DE4CB24B2D2: '初始化器%select{部分|}0 覆盖了此子对象的先前初始化'
 # 'initializer element is not a compile-time constant'
 H132D68BCCE73: '初始化器元素不是编译时常量'
 # 'initializer for aggregate is not a compile-time constant'
@@ -22819,7 +22819,7 @@ H0812ED282234: '块作用域中不允许内联声明 %0'
 # 'inline function %q0 is not defined'
 HC9FA92373F42: '内联函数 %q0 未定义'
 # 'inline function not defined%select{| before the private module fragment}0'
-H195EBE25939A: '内联函数未定义%select{| 在私有模块片段之前}0'
+H195EBE25939A: '内联函数未定义 %select{| 在私有模块片段之前}0'
 # 'inline function performs a conversion which is forbidden in ARC'
 H46AB09EDECD4: '内联函数执行了ARC中禁止的转换'
 # 'inline functions based on how much of the function is a scop.'
@@ -22831,7 +22831,7 @@ H6C3FCE1081BE: '内联带有CFI程序的函数（可能导致异常处理失效�
 # 'inline leaf functions with CFI programs (can break unwinding)'
 H8B9275AE6FE3: '内联带有CFI程序的叶子函数（可能导致展开过程失效）'
 # "inline memcpy using 'rep movsb' instruction (X86-only)"
-H1E31B40E5C1D: "使用'rep movsb'指令内联memcpy（仅X86）"
+H1E31B40E5C1D: "使用 'rep movsb' 指令内联memcpy（仅X86）"
 # 'inline namespace reopened as a non-inline namespace'
 H46A1E728D683: '内联命名空间以非内联命名空间重新打开'
 # 'inline namespaces are a C++11 feature'
@@ -22891,7 +22891,7 @@ HBFCDBA937742: '实例变量 %0 在不同翻译单元中被声明为不兼容的
 # 'instance variable %0 has conflicting bit-field width'
 H2B77404519CC: '实例变量 %0 的位段宽度冲突'
 # 'instance variable %0 has conflicting type%diff{: $ vs $|}1,2'
-H9D5CF719769D: '实例变量 %0 的类型冲突%diff{: $ vs $|}1,2'
+H9D5CF719769D: '实例变量 %0 的类型冲突 %diff{: $ vs $|}1,2'
 # 'instance variable %0 is being directly accessed'
 H3F2D0ABA6990: '实例变量 %0 正在被直接访问'
 # 'instance variable %0 is private'
@@ -22955,7 +22955,7 @@ H38F9A13FA923: '整型常量超出枚举类型 %0 的取值范围'
 # 'integer literal is too large to be represented in a signed integer type, interpreting as unsigned'
 H510046C2B2ED: '整型字面量过大，无法用有符号整型表示，将解释为无符号类型'
 # 'integer literal is too large to be represented in any %select{signed |}0integer type'
-H586D057CD6B8: '整型字面量过大，无法用任何%select{有符号 |}0整型类型表示'
+H586D057CD6B8: '整型字面量过大，无法用任何%select{有符号 |}0 整型类型表示'
 # "integer literal is too large to be represented in type 'long' and is subject to undefined behavior under C++98, interpreting as 'unsigned long'; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards"
 H84C22AB83CDC: "整型字面量过大，无法用类型 'long' 表示，根据C++98的规范解释为 'unsigned long'；在C++11及以后，该字面量将%select{具有类型 'long long'|被视为非法}0"
 # "integer literal is too large to be represented in type 'long', interpreting as 'unsigned long' per C++98; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards"
@@ -23035,9 +23035,9 @@ H74A42ADBF419: "无效的OpenACC指令 %select{%1|'%1 %2'}0"
 # 'invalid PCS type'
 H696D824B4D2C: '无效的PCS类型'
 # "invalid RVV vector size '%0', expected size is '%1' based on LMUL of type and '-mrvv-vector-bits'"
-H96A03531A0AD: "无效的RVV向量大小 '%0'，基于类型LMUL和'-mrvv-vector-bits'参数，期望的大小应为 '%1'"
+H96A03531A0AD: "无效的RVV向量大小 '%0'，基于类型LMUL和 '-mrvv-vector-bits' 参数，期望的大小应为 '%1'"
 # "invalid SVE vector size '%0', must match value set by '-msve-vector-bits' ('%1')"
-HF993CA8A3093: "无效的SVE向量大小 '%0'，必须与'-msve-vector-bits'设置的值 '%1' 一致"
+HF993CA8A3093: "无效的SVE向量大小 '%0'，必须与 '-msve-vector-bits' 设置的值 '%1' 一致"
 # 'invalid UTF-8 in comment'
 H58EB41DE8F48: '注释中的无效UTF-8编码'
 # "invalid Xarch argument: '%0', not all driver options can be forwared via Xarch argument"
@@ -23049,7 +23049,7 @@ H9A97FF7B54BE: '无效的__hlsl_resource_t类型属性'
 # 'invalid address discrimination mode %0'
 H1D217687F248: '无效的地址区分模式 %0'
 # "invalid alignment option in '#pragma %select{align|options align}0' - ignored"
-H410475644E70: "在'#pragma %select{align|options align}0'中指定了无效的对齐选项 - 已忽略"
+H410475644E70: "在 '#pragma %select{align|options align}0' 中指定了无效的对齐选项 - 已忽略"
 # "invalid application of '%0' to %select{an incomplete|sizeless}1 type %2"
 H3984632B643A: "将 '%0' 应用于%select{不完整|无大小}1类型 %2 是无效的"
 # "invalid application of '%0' to WebAssembly table"
@@ -23059,7 +23059,7 @@ HFD1A077F0D84: "将 '%0' 应用于函数类型无效"
 # "invalid application of '%0' to a void type"
 H3290D1C688B6: "将 '%0' 应用于void类型无效"
 # "invalid application of '%select{sizeof|alignof|typeof|typeof_unqual}0' to bit-field"
-H4D97635BE644: "将'%select{sizeof|alignof|typeof|typeof_unqual}0'应用于位域无效"
+H4D97635BE644: "将 '%select{sizeof|alignof|typeof|typeof_unqual}0' 应用于位域无效"
 # "invalid application of '__builtin_omp_required_simd_align' to an expression, only type is allowed"
 H0F35C466B34C: '__builtin_omp_required_simd_align只能用于类型，不能应用于表达式'
 # "invalid application of 'alignof' to a field of a class still being defined"
@@ -23109,9 +23109,9 @@ H369903756AB7: "无效参数；期望 'enable'%select{|, 'full'}0%select{|, 'ass
 # 'invalid authentication key %0'
 H1380B8ED725A: '无效的认证密钥 %0'
 # 'invalid block pointer conversion %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2'
-H1E4447440EDF: '块指针转换无效%select{%diff{将$分配给$|不同类型的赋值}0,1|%diff{将$传递给类型$的参数|传递到不同类型参数}0,1|%diff{从返回类型$的函数返回$|函数返回类型不匹配}0,1|%diff{将$转换为类型$|不同类型的转换}0,1|%diff{用类型$的表达式初始化$|表达式类型与初始化类型不匹配}0,1|%diff{将$发送到类型$的参数|发送到不同类型参数}0,1|%diff{将$强制转换为类型$|不同类型的强制转换}0,1}2'
+H1E4447440EDF: '块指针转换无效 %select{%diff{将$分配给$|不同类型的赋值}0,1|%diff{将$传递给类型$的参数|传递到不同类型参数}0,1|%diff{从返回类型$的函数返回$|函数返回类型不匹配}0,1|%diff{将$转换为类型$|不同类型的转换}0,1|%diff{用类型$的表达式初始化$|表达式类型与初始化类型不匹配}0,1|%diff{将$发送到类型$的参数|发送到不同类型参数}0,1|%diff{将$强制转换为类型$|不同类型的强制转换}0,1}2'
 # 'invalid block variable declaration - must be %select{const qualified|initialized}0'
-HF892D907A5A7: '无效的块变量声明 - 必须是%select{const限定|已初始化}0'
+HF892D907A5A7: '无效的块变量声明 - 必须是 %select{const限定|已初始化}0'
 # "invalid block variable declaration - using 'extern' storage class is disallowed"
 H2029EAB9FA9A: "无效的块变量声明 - 不允许使用 'extern' 存储类"
 # 'invalid branch into OpenACC Compute/Combined Construct'
@@ -23135,7 +23135,7 @@ HAD5A2EB8C76E: '不同类型大小的向量类型 %0 和整型类型 %1 之间�
 # 'invalid conversion between vector type %0 and scalar type %1'
 H0E21BE8324C1: '向量类型 %0 和标量类型 %1 之间的无效转换'
 # 'invalid conversion between vector type%diff{ $ and $|}0,1 of different size'
-H62FB40425AFD: '不同大小的向量类型%diff{ $和$|}0,1之间的无效转换'
+H62FB40425AFD: '不同大小的向量类型%diff{ $和$|}0,1 之间的无效转换'
 # "invalid conversion specifier '%0'"
 H36DE3CE25255: "无效的格式说明符 '%0'"
 # 'invalid covariant return for virtual function: %1 is a %select{private|protected}2 base class of %0'
@@ -23151,7 +23151,7 @@ H75299BE36932: '在 %select{tbuffer|cbuffer}0 内部的无效声明'
 # 'invalid declaration specifier in template non-type parameter'
 HE0A0675789D7: '模板非类型参数中的无效声明说明符'
 # 'invalid diagnostic type for \'diagnose_if\'; use "error" or "warning" instead'
-HD2E5D476D869: '无效的诊断类型用于\'diagnose_if\'; 使用"error"或"warning"代替'
+HD2E5D476D869: '无效的诊断类型用于\'diagnose_if\'; 使用 "error" 或 "warning" 代替'
 # "invalid digit '%0' in %select{decimal|octal|binary}1 constant"
 H6F9BD80EC0BE: "无效的数字 '%0' 在%select{十进制|八进制|二进制}1常量中"
 # "invalid digit '%0' in escape sequence"
@@ -23159,7 +23159,7 @@ HF729B18CD0D2: "无效的数字 '%0' 在转义序列中"
 # "invalid escape sequence '%0' in an unevaluated string literal"
 HF58F976119B7: "无效的转义序列 '%0' 在未求值的字符串字面量中"
 # "invalid exception model '%select{none|sjlj|seh|dwarf|wasm}0' for target '%1'"
-H00FCEE8853CC: "目标 '%1' 的无效异常模型'%select{none|sjlj|seh|dwarf|wasm}0'"
+H00FCEE8853CC: "目标 '%1' 的无效异常模型 '%select{none|sjlj|seh|dwarf|wasm}0'"
 # 'invalid expected %0: %1'
 HE0DC8B702320: '无效的期望 %0：%1'
 # 'invalid explicit object parameter type %0 in lambda with capture; the type must be the same as, or derived from, the lambda'
@@ -23181,7 +23181,7 @@ H5CC65A10A5E0: '无效的标志行标记指令'
 # "invalid float ABI '%0'"
 H606FAE3A11E2: "无效的浮点ABI '%0'"
 # "invalid iOS deployment version '%0', iOS 10 is the maximum deployment target for 32-bit targets"
-HD422F25540A2: "无效的iOS部署版本 '%0', iOS 10是 32 位目标的最大部署目标"
+HD422F25540A2: "无效的iOS部署版本 '%0', iOS 10 是 32 位目标的最大部署目标"
 # 'invalid index %0 for pack %1 of size %2'
 H1627FB393F43: '大小为 %2 的参数包 %1 的无效索引 %0'
 # "invalid input constraint '%0' in asm"
@@ -23231,7 +23231,7 @@ HC5560B091967: '二进制表达式中的操作数类型无效 (%0 和 %1)'
 # "invalid option '%0' for %select{cpu_specific|cpu_dispatch}1"
 HEFAAB35E81AF: "选项 '%0' 无效，%select{cpu_specific|cpu_dispatch}1"
 # "invalid option '%0' not of the form <from-file>;<to-file>"
-HCB5BB85712F1: "无效的选项 '%0'，不符合<from-file>;<to-file>的格式"
+HCB5BB85712F1: "无效的选项 '%0'，不符合 <from-file>;<to-file> 的格式"
 # 'invalid option combination; LASX depends on LSX'
 H7E946D645C29: '无效的选项组合；LASX依赖于LSX'
 # "invalid or misplaced branch protection specification '%0'"
@@ -23249,15 +23249,15 @@ H1AE0ECD8B562: "与gcc工具一起使用时无效的输出类型 '%0'"
 # "invalid parameter name: '%0' is a keyword"
 HBA4C66D8A8AA: "无效的参数名称：'%0' 是一个关键字"
 # 'invalid parameter type for defaulted %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator; found %1, expected %2%select{| or %4}3'
-H1333988BA8FC: '默认的%select{<ERROR>|相等|三向|相等|关系}0比较运算符的参数类型无效；找到 %1，期望 %2%select{|或 %4}3'
+H1333988BA8FC: '默认的 %select{<ERROR>|相等|三向|相等|关系}0比较运算符的参数类型无效；找到 %1，期望 %2%select{|或 %4}3'
 # 'invalid parameter type for non-member defaulted %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator; found %1, expected class or reference to a constant class'
-HEB967961C960: '非成员默认的%select{<ERROR>|相等|三向|相等|关系}0比较运算符的参数类型无效；找到 %1，期望类或常量类的引用'
+HEB967961C960: '非成员默认的 %select{<ERROR>|相等|三向|相等|关系}0比较运算符的参数类型无效；找到 %1，期望类或常量类的引用'
 # 'invalid pipe access modifier (expecting %0)'
 HA4FFF117B821: '无效的管道访问修饰符（期望 %0）'
 # 'invalid position specified for %select{field width|field precision}0'
 H5DF564C1B18C: '为%select{字段宽度|字段精度}0指定的无效位置'
 # "invalid preprocessing directive%select{|, did you mean '#%1'?}0"
-H852ECDD7D2C3: '无效的预处理指令%select{|，您是指"#%1"?}0'
+H852ECDD7D2C3: '无效的预处理指令 %select{|，您是指 "#%1"?}0'
 # 'invalid profile : %0'
 H35AB0F2CB838: '无效的配置文件： %0'
 # 'invalid protocol qualifiers on non-ObjC type'
@@ -23265,11 +23265,11 @@ H3723A726B37F: '非ObjC类型上的无效协议限定符'
 # 'invalid prototype, variadic arguments are not allowed in OpenCL'
 H5E1888FFA26E: '无效的原型，在OpenCL中不允许使用可变参数'
 # "invalid range expression of type %0; did you mean to dereference it with '*'?"
-H1FCBEB4D2213: '类型为 %0 的无效区间表达式；您是否打算用"*"进行解引用？'
+H1FCBEB4D2213: '类型为 %0 的无效区间表达式；您是否打算用 "*" 进行解引用？'
 # "invalid range expression of type %0; no viable '%select{begin|end}1' function available"
-H76B630AFA57F: '类型为 %0 的无效区间表达式；没有可用的"%select{begin|end}1"函数'
+H76B630AFA57F: '类型为 %0 的无效区间表达式；没有可用的 "%select{begin|end}1" 函数'
 # "invalid range following '-' in expected %0"
-H99FD9B7E0352: "在期望的 %0 中'-'后的范围无效"
+H99FD9B7E0352: "在期望的 %0 中 '-' 后的范围无效"
 # "invalid reduction operator,  expected '+', '*', 'max', 'min', '&', '|', '^', '&&', or '||'"
 H3407BE2F5E5D: "无效的规约运算符，期望的运算符之一为 '+'、'*'、'max'、'min'、'&'、'|'、'^'、'&&' 或 '||'"
 # 'invalid reference to function %0: constraints not satisfied'
@@ -23291,7 +23291,7 @@ H26E533E2D360: '内建函数的无效特殊寄存器'
 # 'invalid storage class specifier in function declarator'
 HF2FD2E42B318: '函数说明符中的无效存储类说明符'
 # "invalid string literal, ignoring final '\\'"
-H550F921F116D: "无效的字符串文字，忽略末尾的'\\'"
+H550F921F116D: "无效的字符串文字，忽略末尾的 '\\'"
 # "invalid suffix '%0' on %select{integer|floating|fixed-point}1 constant"
 HFE61994BB7A3: "在%select{整型|浮点型|定点型}1常量上的无效后缀 '%0'"
 # 'invalid suffix on literal; C++11 requires a space between literal and identifier'
@@ -23299,7 +23299,7 @@ H3AC3DC712C63: '文字的无效后缀；C++11要求文字和标识符之间有�
 # "invalid tag %0 on '%1' %select{directive|clause}2"
 HB6EF4B837656: "在 '%1' 的%select{指令|子句}2上的无效标签 %0"
 # "invalid target ID '%0'; format is a processor name followed by an optional colon-delimited list of features followed by an enable/disable sign (e.g., 'gfx908:sramecc+:xnack-')"
-HF2F065F66FFD: "无效的目标ID'%0'；格式为处理器名称后可接用冒号分隔的功能列表，再接启用/禁用符号（例如'gfx908:sramecc+:xnack-'）"
+HF2F065F66FFD: "无效的目标ID'%0'；格式为处理器名称后可接用冒号分隔的功能列表，再接启用/禁用符号（例如 'gfx908:sramecc+:xnack-'）"
 # 'invalid target type %0 for dynamic_cast; target type must be a reference or pointer type to a defined class'
 HFE4D2B7D8E06: 'dynamic_cast的无效目标类型 %0；目标类型必须是对已定义类的引用或指针类型'
 # "invalid thread model '%0' in '%1' for this target"
@@ -23345,7 +23345,7 @@ H50EBCD910232: '在%select{静态|显式对象}1成员函数中对成员 %0 的�
 # 'invalid use of non-static data member %0'
 H59D616D352F1: '非静态数据成员 %0 的无效使用'
 # 'invalid use of pointer to member type after %select{.*|->*}0'
-H48A2AD1643D5: '%select{.*|->*}0之后的成员指针类型无效'
+H48A2AD1643D5: '%select{.*|->*}0 之后的成员指针类型无效'
 # 'invalid validator version : %0; format of validator version is "<major>.<minor>" (ex:"1.4")'
 H4B1AA82F67A0: '无效的验证程序版本：%0；验证程序版本格式应为"<主版本>.<次版本>"（例如："1.4"）'
 # 'invalid validator version : %0; if validator major version is 0, minor version must also be 0'
@@ -23371,9 +23371,9 @@ H561E007CCA86: "无效的虚拟文件系统覆盖文件 '%0'"
 # "invalid virtual filesystem overlay file '%0'"
 HBFF79FC3240A: "无效的虚文件系统覆盖文件 '%0'"
 # "invoking a pointer to a 'const &' member function on an rvalue is a C++20 extension"
-HDCED919CDE9E: "对右值调用指向'const &'成员函数的指针与C++20之前的C++标准不兼容"
+HDCED919CDE9E: "对右值调用指向 'const &' 成员函数的指针与C++20之前的C++标准不兼容"
 # "invoking a pointer to a 'const &' member function on an rvalue is incompatible with C++ standards before C++20"
-H06659E61779A: "在C++20之前，对rvalue调用'const &'成员函数指针与C++标准冲突"
+H06659E61779A: "在C++20之前，对rvalue调用 'const &' 成员函数指针与C++标准冲突"
 # "isa trait '%0' is not known to the current target; verify the spelling or consider restricting the context selector with the 'arch' selector further"
 H0ED9A7F36C30: "目标架构未识别特性 '%0'；请检查拼写或通过 'arch' 选择器限制上下文"
 # "it could also be property %select{of type %1|without attribute '%1'|with attribute '%1'|with getter %1|with setter %1}0 declared here"
@@ -23597,7 +23597,7 @@ HCE669C9CA888: 'lcov跟踪文件输出'
 # 'left hand operand of type %0 to compound assignment cannot be truncated when used with right hand operand of type %1'
 H00D9FE7F4F87: '类型为 %0 的左操作数在与类型 %1 的右操作数复合赋值时不能被截断'
 # 'left hand operand to %0 must be a %select{|pointer to }1class compatible with the right hand operand, but is %2'
-HE8A81161D486: '复合赋值运算符 %0 的左操作数必须与右操作数兼容的%select{|指向}1类类型，但实际类型为 %2'
+HE8A81161D486: '复合赋值运算符 %0 的左操作数必须与右操作数兼容的 %select{|指向}1类类型，但实际类型为 %2'
 # "left hand side of assignment operation('%0') must match one side of the sub-operation on the right hand side('%1' and '%2')"
 HA99FEEFA45D5: '赋值运算的左侧（‘%0’）必须与右侧的子运算（‘%1’和‘%2’）的一侧匹配'
 # 'left operand of comma operator has no effect'
@@ -23739,13 +23739,13 @@ H09900D49A0E3: '局部声明的 %0 会隐藏实例变量'
 # 'local type %0 as template argument is incompatible with C++98'
 H6116FD3EFF04: '将局部类型 %0 作为模板参数与C++98不兼容'
 # "local variable '%0' should not be used in 'declare target' directive;"
-HF2D2B034481C: "局部变量 '%0' 不应在'declare target'指令中使用;"
+HF2D2B034481C: "局部变量 '%0' 不应在 'declare target' 指令中使用;"
 # "local variable cannot be declared 'constinit'"
 HE35DCF249418: "局部变量不能声明为 'constinit'"
 # "locking '%0' to build module '%1'"
 H36ABFAB03219: "锁定 '%0' 以构建模块 '%1'"
 # 'logical expression with vector %select{type %1 and non-vector type %2|types %1 and %2}0 is only supported in C++'
-H1200F428FBB0: '向量%select{类型 %1 与非向量类型 %2|类型 %1 和类型 %2}0的逻辑表达式仅在C++中支持'
+H1200F428FBB0: '向量%select{类型 %1 与非向量类型 %2|类型 %1 和类型 %2}0 的逻辑表达式仅在C++中支持'
 # 'logical not is only applied to the left hand side of this %select{comparison|bitwise operator}0'
 H9E8ECD267F25: '逻辑非仅应用于此%select{比较运算符|位运算符}0的左操作数'
 # 'lookup from the current scope refers here'
@@ -23757,7 +23757,7 @@ H52F57D0BB44E: '成员访问表达式中的 %0 查找是模棱两可的'
 # 'lookup of %0 in member access expression is ambiguous; using member of %1'
 H632E112FD2AD: '成员访问表达式中的 %0 查找是模棱两可的；使用 %1 的成员'
 # "loop iteration variable in the associated loop of 'omp %1' directive may not be %0, predetermined as %2"
-H777624FA6F75: "与'omp %1'指令关联的循环迭代变量不能是 %0，已被预设为 %2"
+H777624FA6F75: "与 'omp %1' 指令关联的循环迭代变量不能是 %0，已被预设为 %2"
 # 'loop step is expected to be %select{negative|positive}0 due to this condition'
 HF9B9B19EF744: '由于此条件，循环步长应为%select{负|正}0'
 # 'loop to be fully unrolled must have a constant trip count'
@@ -23769,13 +23769,13 @@ HDD2F7E9780FE: '循环变量 %0 绑定到类型 %1 的范围生成的临时值'
 # 'loop variable %0 creates a copy from type %1'
 H0EB738A6DA64: '循环变量 %0 从类型 %1 创建副本'
 # "loop variable %0 may not be declared %select{'extern'|'static'|'__private_extern__'|'auto'|'register'|'constexpr'|'thread_local'}1"
-HD1C2B82FE9FA: "循环变量 %0 不能被声明为%select{'extern'|'static'|'__private_extern__'|'auto'|'register'|'constexpr'|'thread_local'}1"
+HD1C2B82FE9FA: "循环变量 %0 不能被声明为 %select{'extern'|'static'|'__private_extern__'|'auto'|'register'|'constexpr'|'thread_local'}1"
 # "loop variable of loop associated with an OpenACC '%0' construct must be of integer, pointer, or random-access-iterator type (is %1)"
 HDE685F11E1FA: "与OpenACC '%0' 结构关联的循环变量必须是整型、指针或随机访问迭代器类型（当前为 %1）"
 # 'loop will run at most once (loop increment never executed)'
 H41A7771F3080: '该循环最多执行一次（循环增量从未被执行）'
 # "loop with a '%0' clause may not exist in the region of a '%1' clause%select{| on a '%3' construct}2"
-H31D69B81DD7A: "带有 '%0' 子句的循环不能存在于 '%1' 子句%select{|的 '%3' 结构}2区域中"
+H31D69B81DD7A: "带有 '%0' 子句的循环不能存在于 '%1' 子句 %select{|的 '%3' 结构}2区域中"
 # 'lower transpose without using a runtime call'
 H1DC7FFF629C0: '在不使用运行时调用的情况下转换转置'
 # 'mac68k alignment pragma is not supported on this target'
@@ -23783,11 +23783,11 @@ H13A22B895D9E: '此目标不支持mac68k对齐#pragma'
 # 'macro %0 defined here'
 H224BD0DEAAD4: '宏 %0 在此处定义'
 # 'macro %0 has been marked as deprecated%select{|: %2}1'
-HB9E9BBB38434: '宏 %0 已被标记为已弃用%select{|: %2}1'
+HB9E9BBB38434: '宏 %0 已被标记为已弃用 %select{|: %2}1'
 # 'macro %0 has been marked as final and should not be %select{undefined|redefined}1'
 H416ADCAF4BDC: '宏 %0 已被标记为最终且不应%select{未定义|重新定义}1'
 # 'macro %0 has been marked as unsafe for use in headers%select{|: %2}1'
-H0BD2BA6647E5: '宏 %0 已被标记为在头文件中不安全%select{|: %2}1'
+H0BD2BA6647E5: '宏 %0 已被标记为在头文件中不安全 %select{|: %2}1'
 # "macro '%0' contains embedded newline; text after the newline is ignored"
 HCA29C3134207: "宏 '%0' 包含嵌入的换行符；换行符后的文本将被忽略"
 # "macro '%0' was %select{defined|undef'd}1 in the AST file '%2' but %select{undef'd|defined}1 on the command line"
@@ -23837,23 +23837,23 @@ H3204C79CA043: '映射类型 "%0" 在此处之前已指定'
 # 'map type is already specified'
 HF4D36EA9229E: '映射类型已指定'
 # "map type modifier '%0' is not allowed for '#pragma omp %1'"
-H5A1E07271479: "映射类型修饰符 '%0' 不允许用于'#pragma omp %1'"
+H5A1E07271479: "映射类型修饰符 '%0' 不允许用于 '#pragma omp %1'"
 # 'mapper type must be of struct, union or class type'
 H3D3958379C94: '映射器类型必须为结构体、联合或类类型'
 # 'mapping of union members is not allowed'
 HD27CBEC61BC1: '联合成员的映射是不允许的'
 # "mark %0 as '%select{final|sealed}1' to silence this warning"
-HF7273FC85EE1: "将 %0 标记为'%select{final|sealed}1'以消除此警告"
+HF7273FC85EE1: "将 %0 标记为 '%select{final|sealed}1' 以消除此警告"
 # "mark 'operator==' as const or add a matching 'operator!=' to resolve the ambiguity"
-H5A25A1F05320: "将'operator=='声明为const，或添加匹配的'operator!='以解决歧义"
+H5A25A1F05320: "将 'operator==' 声明为const，或添加匹配的 'operator!=' 以解决歧义"
 # "mark function boundaries with break instruction to make sure we accidentally don't cross them"
 H5B830E6175D2: '使用断点指令标记函数边界，以确保我们不会意外跨过它们'
 # 'marked %0 here'
 HE33E97AC0225: '此处标记的 %0'
 # "marked as 'declare variant' here"
-H721AFFF82622: "此处标记为'declare variant'"
+H721AFFF82622: "此处标记为 'declare variant'"
 # "marked as 'device_type(%0)' here"
-HF283C800233B: "此处标记为'device_type(%0)'"
+HF283C800233B: "此处标记为 'device_type(%0)'"
 # 'mask type size must be between 1-byte and 8-bytes'
 HA5CB60FF0FBF: '掩码类型大小必须在 1 字节到 8 字节之间'
 # 'match functions in binary 2 to binary 1 if they have the same hash of a function in binary 1'
@@ -23861,7 +23861,7 @@ HAF6822E35564: '如果二进制文件 2 中的函数与二进制文件 1 中的�
 # "math errno enabled by '%0' after it was implicitly disabled by '%1', this may limit the utilization of the vector library"
 HE93B3822306D: "'%0' 启用的数学errno在被 '%1' 隐式禁用后可能限制向量库的使用效率"
 # 'mathematical notation character <U+%0> in an identifier is a Clang extension'
-H0378BC9B5A74: '标识符中的数学符号<U+%0>是Clang扩展'
+H0378BC9B5A74: '标识符中的数学符号 <U+%0> 是Clang扩展'
 # 'matrix %select{row|column}0 index is not an integer'
 H46FD8A206DB4: '矩阵%select{行|列}0索引不是整数类型'
 # 'matrix %select{row|column}0 index is outside the allowed range [0, %1)'
@@ -23923,7 +23923,7 @@ HE96F2F88498F: '成员 %0 在不同类型的多个基类中找到'
 # 'member %0 has the same name as its class'
 HBDCB2F361AEB: '成员 %0 与其所属类具有相同的名称'
 # 'member %0 of %1 is not a template; did you mean %select{|simply }2%3?'
-H88F478FC5C17: '%1 的成员 %0 不是模板；是否应改为%select{|直接}2%3？'
+H88F478FC5C17: '%1 的成员 %0 不是模板；是否应改为 %select{|直接}2%3？'
 # 'member %0 used before its declaration'
 H21EA4914C844: '在声明之前使用了成员 %0'
 # 'member access into incomplete type %0'
@@ -24015,7 +24015,7 @@ H93D8788321DF: '方法键参数类型 %0 不是对象类型'
 # 'method marked as designated initializer of the class here'
 H6D873EC57BBB: '此处标记为类的指定初始化器的方法'
 # "method name referenced in property setter attribute must end with ':'"
-H48FC25BCA089: '在属性设置器属性中引用的方法名称必须以":"结尾'
+H48FC25BCA089: '在属性设置器属性中引用的方法名称必须以 ":" 结尾'
 # 'method object parameter type %0 is not object type'
 H7C5EC09F4D4E: '方法对象参数类型 %0 不是对象类型'
 # 'method override for the designated initializer of the superclass %objcinstance0 not found'
@@ -24023,15 +24023,15 @@ H353D09FC8C8A: '未找到超类%objcinstance0的指定初始化器方法覆盖'
 # 'method parameter of type %0 with no explicit ownership'
 H012CAADA6E5A: '类型 %0 且没有显式所有权的方法参数'
 # 'method parameter type %diff{$ does not match super class method parameter type $|does not match super class method parameter type}0,1'
-H52F29D4B5323: '与超类方法参数类型%diff{$ does not match super class method parameter type $|does not match super class method parameter type}0,1不匹配'
+H52F29D4B5323: '与超类方法参数类型 %diff{$ does not match super class method parameter type $|does not match super class method parameter type}0,1 不匹配'
 # 'method possibly missing a [super %0] call'
 HF2DE0E720AA4: '方法可能缺少对[super %0]的调用'
 # 'method returns unexpected type %0 (should be an object type)'
 HDA228B7E04A3: '方法返回意外类型 %0（应为对象类型）'
 # "method type specifier must start with '-' or '+'"
-H60683402DB43: '方法类型说明符必须以"-"或"+"开头'
+H60683402DB43: '方法类型说明符必须以 "-" 或 "+" 开头'
 # "method was declared as %select{an 'alloc'|a 'copy'|an 'init'|a 'new'}0 method, but its implementation doesn't match because %select{its result type is not an object pointer|its result type is unrelated to its receiver type}1"
-H0332DF98668A: '该方法被声明为%select{一个"alloc"|一个"copy"|一个"init"|一个"new"}0方法，但其实现不匹配，因为%select{其结果类型不是对象指针|其结果类型与其接收器类型无关}1'
+H0332DF98668A: '该方法被声明为%select{一个 "alloc"|一个 "copy"|一个 "init"|一个 "new"}0 方法，但其实现不匹配，因为%select{其结果类型不是对象指针|其结果类型与其接收器类型无关}1'
 # 'methods that %select{override superclass methods|implement protocol requirements}0 cannot be direct'
 H10E1F7CDD559: '%select{覆盖超类方法|实现协议要求}0的方法不能是直接的'
 # "micromips is not supported for target CPU '%0'"
@@ -24057,7 +24057,7 @@ HB503599C3686: '归约操作的减法(-)运算符已弃用；请改用+或用户
 # 'misaligned atomic operation may incur significant performance penalty; the expected alignment (%0 bytes) exceeds the actual alignment (%1 bytes)'
 HB642C05FEFCE: '对齐不正确的原子操作可能导致显著性能损失；期望的对齐(%0 字节)超过实际对齐(%1 字节)'
 # "misleading indentation; statement is not part of the previous '%select{if|else|for|while}0'"
-H2D720E07A9B5: '误导性的缩进；该语句不属于前面的"%select{if|else|for|while}0"'
+H2D720E07A9B5: '误导性的缩进；该语句不属于前面的 "%select{if|else|for|while}0"'
 # "mismatch between architecture and environment in target triple '%0'; did you mean '%1'?"
 HFB1C45E0F3D8: '目标三元组 "%0" 中的架构和环境不匹配；您是指 "%1" 吗？'
 # 'mismatch in number of block parameters and local size arguments passed'
@@ -24071,39 +24071,39 @@ H2799B1202BB8: '间接调用中跳过ICP的预测错误阈值'
 # 'missing %1 after %0'
 H71A0939C10D8: '在 %0 之后缺少 %1'
 # "missing '(' after '#pragma %0' - ignoring"
-H9BCF4D2D832C: "在#pragma %0 后缺少'(' - 忽略"
+H9BCF4D2D832C: "在#pragma %0 后缺少 '(' - 忽略"
 # "missing '(' following __VA_OPT__"
-HFEF64C94E397: "__VA_OPT__后缺少'('"
+HFEF64C94E397: "__VA_OPT__后缺少 '('"
 # "missing ')' after '#pragma %0' - ignoring"
-HD628B31A25D9: "在#pragma %0 后缺少')' - 忽略"
+HD628B31A25D9: "在#pragma %0 后缺少 ')' - 忽略"
 # "missing ')' in macro parameter list"
-HBA1269832ABB: "宏参数列表中缺少')'"
+HBA1269832ABB: "宏参数列表中缺少 ')'"
 # "missing '*' in type bound %0 for type parameter %1"
-H0FC1C4510683: "在类型参数 %1 的类型边界 %0 中缺少'*'"
+H0FC1C4510683: "在类型参数 %1 的类型边界 %0 中缺少 '*'"
 # "missing ',' after %0"
-H36D833E1BE2F: "在 %0 之后缺少','"
+H36D833E1BE2F: "在 %0 之后缺少 ','"
 # "missing ',' between base or member initializers"
-HC0E2DA10BD59: "基类或成员初始化器之间的初始化器缺少','"
+HC0E2DA10BD59: "基类或成员初始化器之间的初始化器缺少 ','"
 # "missing ',' between enumerators"
-H3BCFAD409136: "枚举项之间缺少','"
+H3BCFAD409136: "枚举项之间缺少 ','"
 # "missing ':' after %0 - ignoring"
-H6D49C0F56471: "在 %0 之后缺少':' - 忽略"
+H6D49C0F56471: "在 %0 之后缺少 ':' - 忽略"
 # "missing ':' after %0 modifier"
-H1C42316D6361: "在 %0 修饰符之后缺少':'"
+H1C42316D6361: "在 %0 修饰符之后缺少 ':'"
 # "missing ':' in %0"
-HB39748BAFE7C: "在 %0 中缺少':'"
+HB39748BAFE7C: "在 %0 中缺少 ':'"
 # "missing ':' or ')' after %0 - ignoring"
-HA24B4C500D05: "在 %0 之后缺少':'或')' - 忽略"
+HA24B4C500D05: "在 %0 之后缺少 ':' 或 ')' - 忽略"
 # "missing '@end'"
 H91CC5F3C7087: '缺少@end'
 # "missing '[' at start of message send expression"
-H352486DC1A63: "消息发送表达式开头缺少'['"
+H352486DC1A63: "消息发送表达式开头缺少 '['"
 # "missing 'export module' declaration in module interface unit"
-H43BE56C41167: "在模块接口单元中缺少'export module'声明"
+H43BE56C41167: "在模块接口单元中缺少 'export module' 声明"
 # "missing 'export' specifier in module declaration while building module interface"
 H73E9D7F0EE4B: "构建模块接口时，在模块声明中缺少 'export' 指定符"
 # "missing 'get=' or 'put='"
-H5BBBF3CA84C4: "缺少'get='或'put='"
+H5BBBF3CA84C4: "缺少 'get=' 或 'put='"
 # "missing 'module' declaration at end of global module fragment introduced here"
 HECF75AD1494B: "在此处引入的全局模块片段结尾缺少 'module' 声明"
 # "missing 'template' keyword prior to dependent template name %0"
@@ -24115,11 +24115,11 @@ H15976F1154C9: "缺少依赖类型名称 %0 之前的 'typename'；隐式 'typen
 # "missing 'typename' prior to dependent type template name %0"
 HB65342C255DD: "缺少依赖类型模板名称 %0 之前的 'typename'"
 # "missing '}' at end of definition of %q0"
-HAF73F9C8E8E7: "在%q0定义末尾缺少'}'"
+HAF73F9C8E8E7: "在%q0定义末尾缺少 '}'"
 # 'missing actual type specifier for pipe'
 H369BCA42F29A: '管道缺少实际类型说明符'
 # "missing argument to '#pragma %0'%select{|; expected %2}1"
-H85D43DEA45AB: '#pragma %0 指令缺少参数%select{|；期望 %2}1'
+H85D43DEA45AB: '#pragma %0 指令缺少参数 %select{|；期望 %2}1'
 # "missing argument to '%0'"
 H52AC6CD34BC9: "缺少 '%0' 的参数"
 # "missing argument to debug command '%0'"
@@ -24157,7 +24157,7 @@ H8600AE8C89F9: '在 %1 中，插件 %0 缺少插件参数'
 # 'missing plugin name in %0'
 H4A2F8D6C22D3: '在 %0 中缺少插件名称'
 # "missing reduction operator, expected '+', '*', 'max', 'min', '&', '|', '^', '&&', or '||', follwed by a ':'"
-H9DF20C9098D2: "缺少规约运算符，期望'+', '*', 'max', 'min', '&', '|', '^', '&&', 或 '||' 后跟一个':'"
+H9DF20C9098D2: "缺少规约运算符，期望 '+', '*', 'max', 'min', '&', '|', '^', '&&', 或 '||' 后跟一个 ':'"
 # 'missing return type for function %0; did you mean the constructor name %1?'
 H0096A8359309: '函数 %0 缺少返回类型；您是否指的是构造函数名称 %1？'
 # "missing sanitizer ignorelist: '%0'"
@@ -24175,7 +24175,7 @@ HC91AE5B6C664: '缺少终止字符%select{‘|’"’}0'
 # "missing terminating ')' character"
 H110B9B84BD50: "缺少终止的 ')' 字符"
 # 'missing type bound %0 for type parameter %1 in %select{@interface|@class}2'
-HCB937BA83DD0: '在%select{@interface|@class}2中的类型参数 %1 缺少类型边界 %0'
+HCB937BA83DD0: '在 %select{@interface|@class}2 中的类型参数 %1 缺少类型边界 %0'
 # 'mixed CUDA and HIP compilation is not supported'
 HDE7D3706C5B5: '混合 CUDA 和 HIP 编译不受支持'
 # "mixing 'target_clones' specifier mechanisms is permitted for GCC compatibility; use a comma separated sequence of string literals, or a string literal containing a comma-separated list of versions"
@@ -24221,7 +24221,7 @@ H6556B7A46703: "模块 '%0' 已作为 '%1' 重新导出"
 # "module '%0' conflicts with already-imported module '%1': %2"
 HED958876B86C: "模块 '%0' 与已导入的模块 '%1' 冲突：%2"
 # "module '%0' in AST file '%1' %select{(imported by AST file '%2') |}4is not defined in any loaded module map file; maybe you need to load '%3'?"
-H951252F32734: "AST文件 '%1' 中的模块 '%0' %select{(被AST文件 '%2' 导入)|}4未在任何已加载的模块映射文件中定义；是否需要加载 '%3'？"
+H951252F32734: "AST文件 '%1' 中的模块 '%0' %select{(被AST文件 '%2' 导入)|}4 未在任何已加载的模块映射文件中定义；是否需要加载 '%3'？"
 # "module '%0' is defined in both '%1' and '%2'"
 H9937FAC6E395: "模块 '%0' 在 '%1' 和 '%2' 中均有定义"
 # "module '%0' is needed but has not been provided, and implicit use of module files is disabled"
@@ -24231,7 +24231,7 @@ H55DF0ED78DC5: "未找到模块 '%0'"
 # "module '%0' was built in directory '%1' but now resides in directory '%2'"
 H38AD29640B23: "模块 '%0' 是在目录 '%1' 构建的，但现在位于目录 '%2'"
 # "module compilation requires '-fmodules'"
-H6A96D77D9F41: "模块编译需要'-fmodules'选项"
+H6A96D77D9F41: "模块编译需要 '-fmodules' 选项"
 # 'module declaration can only appear at the top level'
 HB03E6C215813: '模块声明只能出现在顶层'
 # 'module declaration must occur at the start of the translation unit'
@@ -24269,7 +24269,7 @@ HB98F31FF7B9A: '模块分区仅支持 C++20 及更高版本'
 # 'module search directory'
 H3FAA97FDA5D1: '模块搜索目录'
 # 'module%select{| partition}0 imports cannot be in the %select{global|private}1 module fragment'
-HE6F2588D0369: '模块%select{|分区}0 导入不能位于 %select{全局|私有}1 模块片段中'
+HE6F2588D0369: '模块 %select{|分区}0 导入不能位于 %select{全局|私有}1 模块片段中'
 # "more '%%' conversions than data arguments"
 H9766AC9D490A: "存在多于数据参数的 '%%' 转换"
 # "more than one 'device_type' clause is specified"
@@ -24303,7 +24303,7 @@ H51BCFF1832A0: '多目标配置错误：%0'
 # "multiple %0 architectures are detected: %1; only the first one is used for '%2'"
 HF49114F051BF: "检测到多个 %0 架构： %1；仅使用第一个架构用于 '%2'"
 # "multiple %select{'step size'|'linear modifier'}0 found in linear clause"
-H6C58F45C9F56: "在线性子句中发现了多个 %select{'步长大小'|'线性修饰符'}0"
+H6C58F45C9F56: "在线性子句中发现了多个 %select{'步长大小 '|' 线性修饰符'}0"
 # "multiple 'callback' attributes specified"
 H9EF4CEF4A9C0: "指定了多个 'callback' 属性"
 # "multiple 'cpu_specific' functions cannot specify the same CPU: %0"
@@ -24377,7 +24377,7 @@ H94C16C029EFB: '必须明确描述对象数组参数的预期所有权'
 # 'must explicitly qualify name of member function when taking its address'
 H10EC7DC2756E: '在获取成员函数地址时必须显式限定其名称'
 # "must handle potential future platforms with '*'"
-H52CBF98EE88A: '必须处理未来平台中可能的"*"'
+H52CBF98EE88A: '必须处理未来平台中可能的 "*"'
 # 'must name member using the type of the current context %0'
 H0A063C055ADE: '必须使用当前上下文 %0 的类型命名该成员'
 # "must pass in an explicit %0 gpu architecture to '%1'"
@@ -24387,7 +24387,7 @@ H7FEC01DD8141: "必须使用'--symbol-graph-dir=<目录>'指定符号图输出�
 # 'must qualify identifier to find this declaration in dependent base class'
 HB8E730405435: '必须限定标识符才能在依赖基类中查找此声明'
 # "must specify '-fmodule-name=%0' to enter %select{|submodule of }1this module%select{ (current module is %3)|}2"
-HF0DE733FAF70: "必须指定'-fmodule-name=%0'以进入%select{|该模块的子模块}1此模块%select{（当前模块为 %3）|}2"
+HF0DE733FAF70: "必须指定 '-fmodule-name=%0' 以进入 %select{|该模块的子模块}1此模块%select{（当前模块为 %3）|}2"
 # 'must specify system root with -isysroot when building a relocatable PCH file'
 H530DD8BE4BB8: '构建可重定位的PCH文件时必须使用-isysroot指定系统根目录'
 # "must use '%1' tag to refer to type %0%select{| in this scope}2"
@@ -24409,7 +24409,7 @@ H69290D9B2469: '命名空间别名不能是内联的'
 # 'namespace alias must be a single identifier'
 HA11E2A62D886: '命名空间别名必须是一个标识符'
 # "namespace can only apply to 'push' or 'pop' directives"
-H6F30E709453F: '命名空间只能应用于"push"或"pop"指令'
+H6F30E709453F: '命名空间只能应用于 "push" 或 "pop" 指令'
 # 'namespaces can only be defined in global or namespace scope'
 HDB4E6C24AE7F: '命名空间只能在全局或命名空间作用域中定义'
 # "negated attribute subject matcher sub-rule '%0' contradicts sub-rule '%1'"
@@ -24425,7 +24425,7 @@ H326DE285E8C5: '声明的嵌套名称说明符 %0 不指向类、类模板或类
 # 'nested name specifier for a declaration cannot depend on a template parameter'
 H87A0C3C18BC3: '声明的嵌套名称说明符不能依赖于模板参数'
 # "nested namespace definition cannot be 'inline'"
-HB262A63F161A: '嵌套的命名空间定义不能是"inline"'
+HB262A63F161A: '嵌套的命名空间定义不能是 "inline"'
 # 'nested namespace definition is a C++17 extension; define each namespace separately'
 HEFB4B9AD8E01: '嵌套的命名空间定义是C++17扩展；请分别定义每个命名空间'
 # 'nested namespace definition is incompatible with C++ standards before C++17'
@@ -24463,7 +24463,7 @@ H5D9A45CF4470: "未指定 'assign'、'retain' 或 'copy' 属性，默认使用 '
 # 'no @interface declaration found in class messaging of %0'
 H39108401F4F8: '在 %0 的类消息中未找到@interface声明'
 # "no MCU device specified, but '-mhwmult' is set to 'auto', assuming no hardware multiply; use '-mmcu' to specify an MSP430 device, or '-mhwmult' to set the hardware multiply type explicitly"
-HF3E9B95BB7DD: "未指定MCU设备，但'-mhwmult'设置为 'auto'，假设没有硬件乘法；使用'-mmcu'指定MSP430设备，或使用'-mhwmult'显式设置硬件乘法类型"
+HF3E9B95BB7DD: "未指定MCU设备，但 '-mhwmult' 设置为 'auto'，假设没有硬件乘法；使用 '-mmcu' 指定MSP430设备，或使用 '-mhwmult' 显式设置硬件乘法类型"
 # 'no PowerPC native vector element order.'
 H49C9870074B0: '不使用PowerPC原生向量元素顺序。'
 # "no analyzer checkers or packages are associated with '%0'"
@@ -24475,7 +24475,7 @@ HC620314BA8FA: '未找到与相关 %select{member|friend}0 函数模板特化对
 # "no case matching constant switch condition '%0'"
 HBFE1788B232F: "没有与常量switch条件 '%0' 匹配的case"
 # "no closing ']' for '%%[' in scanf format string"
-H5E8D81CB9C26: "scanf格式字符串中的'%%['缺少闭合的']'"
+H5E8D81CB9C26: "scanf格式字符串中的 '%%[' 缺少闭合的 ']'"
 # 'no corresponding base class here'
 HBBF529A4447F: '此处没有对应的基类'
 # 'no corresponding enumerator here'
@@ -24491,7 +24491,7 @@ H247D438751B2: "在动态库中未找到导出符号 '%0' 的声明"
 # "no declaration was found for exported symbol '%0' in dynamic library"
 H01E907352618: "在动态库中未找到导出符号 '%0' 的声明"
 # "no expected directives found: consider use of '%0-no-diagnostics'"
-H60C61DB5DCD2: "未找到期望的指令；考虑使用'%0-no-diagnostics'"
+H60C61DB5DCD2: "未找到期望的指令；考虑使用 '%0-no-diagnostics'"
 # 'no function template matches function template specialization %0'
 H783C344DF4FC: '没有函数模板与函数模板特化 %0 匹配'
 # 'no getter method %1 for %select{increment|decrement}0 of property'
@@ -24509,7 +24509,7 @@ H41C44394DC27: '未找到选择器 %0 的已知 %select{实例|类}1 方法'
 # "no known method %select{%objcinstance1|%objcclass1}0; cast the message send to the method's return type"
 HD141497E30B9: '未找到已知方法 %select{%objcinstance1|%objcclass1}0；请将消息发送转换为目标方法返回类型'
 # "no library '%0' found in the default clang lib directory or in LIBRARY_PATH; use '--libomptarget-%1-bc-path' to specify %1 bitcode library"
-H56082C491F7D: "在默认clang库目录或LIBRARY_PATH中未找到库 '%0'；使用'--libomptarget-%1-bc-path'指定 %1 比特码库"
+H56082C491F7D: "在默认clang库目录或LIBRARY_PATH中未找到库 '%0'；使用 '--libomptarget-%1-bc-path' 指定 %1 比特码库"
 # 'no macro named %0'
 HDBF2015FF73B: '没有名为 %0 的宏'
 # 'no matching %0 function for non-allocating placement new expression; include <new>'
@@ -24539,9 +24539,9 @@ H6800794A683C: '%1 中没有成员 %0；尚未实例化该成员'
 # 'no member named %0 in %1'
 H85214E062B3A: '%1 中没有名为 %0 的成员'
 # 'no member named %0 in %1; did you mean %select{|simply }2%3?'
-H5B97925635DE: '在 %1 中没有名为 %0 的成员；您是否是指%select{|仅仅 }2%3？'
+H5B97925635DE: '在 %1 中没有名为 %0 的成员；您是否是指 %select{|仅仅 }2%3？'
 # "no member named %0 in %1; did you mean to use '->' instead of '.'?"
-HBE0974E3EE78: "在 %1 中没有名为 %0 的成员；是否应该使用'->'而不是'.'？"
+HBE0974E3EE78: "在 %1 中没有名为 %0 的成员；是否应该使用 '->' 而不是 '.'？"
 # 'no method with selector %0 is implemented in this translation unit'
 H0CDD4F98E18F: '在此翻译单元中未实现选择器 %0 对应的方法'
 # 'no module map available for module %0'
@@ -24559,11 +24559,11 @@ HA7094B5AEB21: "在 '%1' 中不可见名为 '%0' 的模块"
 # "no more 'if' clause is allowed"
 H8F7A1C6703AA: "不允许再有 'if' 子句"
 # "no more than one option '--config' is allowed"
-H3089388E4475: "选项'--config'最多允许指定一次"
+H3089388E4475: "选项 '--config' 最多允许指定一次"
 # 'no multilib found matching flags: %0'
 HCDE4340CFBD3: '未找到匹配标志 %0 的multilib'
 # 'no namespace named %0 in %1; did you mean %select{|simply }2%3?'
-HF6FEAE5E55D9: '在 %1 中没有名为 %0 的命名空间；您是否是指%select{|仅仅 }2%3？'
+HF6FEAE5E55D9: '在 %1 中没有名为 %0 的命名空间；您是否是指 %select{|仅仅 }2%3？'
 # 'no namespace named %0; did you mean %1?'
 H81CE4465B841: '没有名为 %0 的命名空间；您是否是指 %1？'
 # 'no newline at end of file'
@@ -24607,13 +24607,13 @@ HFC0C70B06D89: '没有名为 %0 的模板'
 # 'no template named %0 in %1'
 H16DB7E6BC24D: '%1 中没有名为 %0 的模板'
 # 'no template named %0 in %1; did you mean %select{|simply }2%3?'
-HCDFE5581F7D6: '%1 中没有名为 %0 的模板；是否是指%select{|简单}2%3？'
+HCDFE5581F7D6: '%1 中没有名为 %0 的模板；是否是指 %select{|简单}2%3？'
 # 'no template named %0; did you mean %1?'
 H32AFF6E21FDC: '没有名为 %0 的模板；是否是指 %1？'
 # 'no type named %0 in %1'
 H6E87E8CAFF42: '%1 中没有名为 %0 的类型'
 # 'no type named %0 in %1; did you mean %select{|simply }2%3?'
-H014C7B262D03: '%1 中没有名为 %0 的类型；是否是指%select{|简单}2%3？'
+H014C7B262D03: '%1 中没有名为 %0 的类型；是否是指 %select{|简单}2%3？'
 # "no type named 'type' in %0; 'enable_if' cannot be used to disable this declaration"
 H03B3775679FC: "%0 中没有名为 'type' 的类型；'enable_if' 无法用于禁用此声明"
 # 'no type or protocol named %0'
@@ -24623,7 +24623,7 @@ H136795D57206: "在OpenACC 'declare' 指令中未指定有效的子句"
 # 'no variable template matches specialization; did you mean to use %0 as function template instead?'
 H702E78FBEC31: '没有与特化匹配的变量模板；是否应将 %0 用作函数模板？'
 # 'no variable template matches%select{| partial}0 specialization'
-H0903C7695A91: '没有与%select{| 部分}0 特化匹配的变量模板'
+H0903C7695A91: '没有与 %select{| 部分}0 特化匹配的变量模板'
 # 'no viable candidate for explicit instantiation of %0'
 HAEBC7520AFB0: '显式实例化 %0 时没有可用的候选项'
 # 'no viable constructor %select{copying variable|copying parameter|initializing template parameter|returning object|initializing statement expression result|throwing object|copying member subobject|copying array element|allocating object|copying temporary|initializing base subobject|initializing vector element|capturing value}0 of type %1'
@@ -24633,9 +24633,9 @@ HBD2DEF3D3EA1: '在类型 %1 的%select{复制变量|复制参数|初始化模�
 # 'no viable constructor or deduction guide for deduction of template arguments of %0'
 HECA595B57B5C: '为 %0 的模板参数推导没有可用的构造函数或推导指引'
 # 'no viable conversion%diff{ from $ to incomplete type $|}0,1'
-H0DDC152C267D: '无法进行%diff{到不完整类型的转换|}0,1有效转换'
+H0DDC152C267D: '无法进行%diff{到不完整类型的转换|}0,1 有效转换'
 # 'no viable conversion%select{%diff{ from $ to $|}1,2|%diff{ from returned value of type $ to function return type $|}1,2}0'
-H742AD0829398: '无法进行%select{%diff{从$到$|}1,2|%diff{从类型$的返回值到函数返回类型$|}1,2}0有效转换'
+H742AD0829398: '无法进行 %select{%diff{从$到$|}1,2|%diff{从类型$的返回值到函数返回类型$|}1,2}0 有效转换'
 # 'no viable destructor found for class %0'
 HE8AA8B1D9E66: '未找到类 %0 的可用析构函数'
 # "no viable overloaded '%0'"
@@ -24667,7 +24667,7 @@ H3BE45C7BF2C1: '非consteval函数 %0 不能覆盖consteval函数'
 # 'non-constexpr comparison function declared here'
 H6CDFA8CCBBD8: '在此处声明的非constexpr比较函数'
 # 'non-constexpr comparison function would be used to compare %select{|member %1|base class %1}0'
-HFFB83E06B051: '非constexpr比较函数将用于比较%select{|成员 %1|基类 %1}0'
+HFFB83E06B051: '非constexpr比较函数将用于比较 %select{|成员 %1|基类 %1}0'
 # 'non-deducible template parameter %0'
 HD419F387C770: '非推导的模板参数 %0'
 # 'non-default #pragma pack value changes the alignment of struct or union members in the included file'
@@ -24675,7 +24675,7 @@ H2C52662649BE: '非默认的#pragma pack值会改变包含文件中结构体或�
 # "non-default visibility cannot be applied to 'dllimport' declaration"
 H2A9EC7D43705: "'dllimport' 声明无法应用非默认可见性"
 # 'non-defining declaration of enumeration with a fixed underlying type is only permitted as a standalone declaration%select{|; missing list of enumerators?}0'
-H4D151B6B2BF9: '具有固定基础类型的枚举的非定义声明仅允许作为独立声明%select{|; 缺少枚举列表？}0'
+H4D151B6B2BF9: '具有固定基础类型的枚举的非定义声明仅允许作为独立声明 %select{|; 缺少枚举列表？}0'
 # 'non-deleted function %0 cannot override a deleted function'
 H2F21A881D5B2: '非删除函数 %0 不能覆盖已删除的函数'
 # 'non-extern declaration of %0 follows extern declaration'
@@ -24811,7 +24811,7 @@ H6156F12DC3F9: "标记为 '%0' 的非虚成员函数隐藏了虚成员 %select{�
 # 'non-void %select{constexpr|consteval}1 function %0 should return a value'
 HCF55E17BA989: '非 void %select{constexpr|consteval}1 函数 %0 应返回一个值'
 # 'non-void %select{function|block|lambda|coroutine}0 does not return a value%select{| in all control paths}1'
-H75EE618D1AA4: '非 void %select{函数|块|lambda|协程}0 未返回一个值%select{|在所有控制路径中}1'
+H75EE618D1AA4: '非 void %select{函数|块|lambda|协程}0 未返回一个值 %select{|在所有控制路径中}1'
 # 'non-void %select{function|method}1 %0 should return a value'
 HEE95067001EB: '非 void %select{函数|方法}1 %0 应返回一个值'
 # 'non-void block should return a value'
@@ -24821,11 +24821,11 @@ H925BCFBBE426: "非空 %select{函数调用|参数}0 '%1' 在首次遇到时将�
 # 'not a Doxygen trailing comment'
 HB02E938B9DEC: '不是Doxygen尾部注释'
 # "not currently inside '#pragma clang arc_cf_code_audited'"
-HD79C4D940185: "不在'#pragma clang arc_cf_code_audited'指令范围内"
+HD79C4D940185: "不在 '#pragma clang arc_cf_code_audited' 指令范围内"
 # "not currently inside '#pragma clang assume_nonnull'"
-HF77D5E6601B3: "不在'#pragma clang assume_nonnull'指令范围内"
+HF77D5E6601B3: "不在 '#pragma clang assume_nonnull' 指令范围内"
 # "not currently inside '#pragma unsafe_buffer_usage'"
-H658512A345D7: "不在'#pragma unsafe_buffer_usage'指令范围内"
+H658512A345D7: "不在 '#pragma unsafe_buffer_usage' 指令范围内"
 # 'not enough variable arguments in %0 declaration to fit a sentinel'
 H9930B56495BC: '%0 声明中的可变参数数量不足以容纳哨兵'
 # 'not packing field %0 as it is non-POD for the purposes of layout'
@@ -24867,19 +24867,19 @@ HE591548912FE: '线程数'
 # 'numeric literal with user-defined suffix cannot be used here'
 H6D6640DAD12D: '此处不能使用带有用户自定义后缀的数值字面量'
 # "nvcc does not allow '__%0__' to appear after the parameter list in lambdas"
-H052A23E5C9DE: "nvcc不允许在lambda的参数列表后出现'__%0__'"
+H052A23E5C9DE: "nvcc不允许在lambda的参数列表后出现 '__%0__'"
 # 'nvptx-arch options'
 H195E97C080C6: 'nvptx-arch 选项'
 # 'obj2yaml Options'
 HDEB46CD09A6E: 'obj2yaml 选项'
 # 'objc_precise_lifetime is not meaningful for %select{__unsafe_unretained|__autoreleasing}0 objects'
-H3B4A7538E1D6: 'objc精准生命周期对%select{__unsafe_unretained|__autoreleasing}0对象没有意义'
+H3B4A7538E1D6: 'objc精准生命周期对 %select{__unsafe_unretained|__autoreleasing}0 对象没有意义'
 # 'objc_precise_lifetime only applies to retainable types; type here is %0'
 HCB888D9DBEF6: 'objc精准生命周期仅适用于可保留类型；此处类型为 %0'
 # 'objc_root_class attribute may only be specified on a root class declaration'
 H8B7E866F5F47: 'objc_root_class属性只能在根类声明中指定'
 # 'object backing %select{|the pointer }0%1 will be destroyed at the end of the full-expression'
-H4CCEF5B24A9C: '支撑%select{|指针 }0%1 的对象将在完整表达式结束时被销毁'
+H4CCEF5B24A9C: '支撑 %select{|指针 }0%1 的对象将在完整表达式结束时被销毁'
 # 'object backing the pointer %0 will be destroyed at the end of the full-expression'
 H4314D747B320: '支撑指针 %0 的对象将在完整表达式结束时被销毁'
 # 'object backing the pointer will be destroyed at the end of the full-expression'
@@ -24937,11 +24937,11 @@ HA318D6E65846: "期望其中一个：'for', 'parallel', 'sections' 或 'taskgrou
 # 'one possibility'
 HF5AE3D1F7A2D: '一种可能'
 # "only %select{'omp_priv' or 'omp_orig'|'omp_in' or 'omp_out'}0 variables are allowed in %select{initializer|combiner}0 expression"
-HBFBFE733ACC9: "在 %select{initializer|combiner}0 表达式中，仅允许%select{'omp_priv' 或 'omp_orig'|'omp_in' 或 'omp_out'}0变量"
+HBFBFE733ACC9: "在 %select{initializer|combiner}0 表达式中，仅允许 %select{'omp_priv' 或 'omp_orig'|'omp_in' 或 'omp_out'}0 变量"
 # "only '*' can be exported from an inferred submodule"
-HB1E7869E1AA8: "只能从推导的子模块导出'*'"
+HB1E7869E1AA8: "只能从推导的子模块导出 '*'"
 # "only 'device_type(any)' clause is allowed with indirect clause"
-H60FE040D9778: "间接子句仅允许使用'device_type(any)'子句"
+H60FE040D9778: "间接子句仅允许使用 'device_type(any)' 子句"
 # "only 'unavailable' and 'deprecated' are supported for Swift availability"
 H711C14834055: "Swift可用性仅支持 'unavailable' 和 'deprecated'"
 # 'only a single match extension allowed per OpenMP context selector'
@@ -24967,7 +24967,7 @@ H0BDC0C1C20D8: '只有函数可以具有已删除的定义'
 # 'only insert instrumentation on hot functions (needs profile, default: false)'
 H6921A5326E9E: '仅在热点函数中插入分析代码（需要分析资料，默认：false）'
 # "only loop iteration variables are allowed in 'lastprivate' clause in 'omp %0' directives"
-H93109DDAC062: "在'omp %0'指令的 'lastprivate' 子句中仅允许循环迭代变量"
+H93109DDAC062: "在 'omp %0' 指令的 'lastprivate' 子句中仅允许循环迭代变量"
 # "only loop iteration variables are allowed in 'linear' clause in distribute directives"
 HB4FBF6AB0B0A: "在distribute指令的 'linear' 子句中仅允许循环迭代变量"
 # 'only one %0 clause can appear on a requires directive in a single translation unit'
@@ -24999,7 +24999,7 @@ H1F90A0F5DC05: '仅当循环定义很可能已死时替换退出值'
 # 'only show the top N results'
 H31C65CA913F9: '仅显示前N项结果'
 # 'only special member functions %select{|and comparison operators }0may be defaulted'
-H7676F4E831FD: '只能默认特殊成员函数%select{|和比较运算符}0'
+H7676F4E831FD: '只能默认特殊成员函数 %select{|和比较运算符}0'
 # 'only submodules and framework modules may be inferred with wildcard syntax'
 HB41F304027AC: '只能通过通配符语法推断子模块和框架模块'
 # 'only the first dimension of an allocated array may have dynamic size'
@@ -25009,9 +25009,9 @@ H35599F0992E5: '仅顶级模块可以作为公共模块重新导出'
 # 'only use samples from process with specified PID'
 HE4657121A5A3: '仅使用指定PID的进程的采样数据'
 # "only variable %0 is allowed in map clauses of this 'omp declare mapper' directive"
-HCD77D6699FCF: "在此'omp declare mapper'指令的map子句中，仅允许变量 %0"
+HCD77D6699FCF: "在此 'omp declare mapper' 指令的map子句中，仅允许变量 %0"
 # "only variables can be arguments to '#pragma unused'"
-H454069F49B2C: "'#pragma unused'的参数只能是变量"
+H454069F49B2C: "'#pragma unused' 的参数只能是变量"
 # "only virtual member functions can be marked '%0'"
 H88BCFFA5846F: '只有虚成员函数可以被标记为 "%0"'
 # 'only zero-length WebAssembly tables are currently supported'
@@ -25019,7 +25019,7 @@ H834ECF2F9D5B: '当前仅支持零长度的WebAssembly表'
 # 'opcode to measure, by index, or -1 to measure all opcodes'
 H04C71CF551B6: '要测量的指令码，通过索引指定，或-1表示测量所有指令码'
 # "operand argument to %select{overflow builtin|checked integer operation}0 must be an integer type %select{|other than plain 'char', 'bool', bit-precise, or an enumeration }0(%1 invalid)"
-H232C02FD2560: '%select{溢出内建函数|带检查的整数运算}0的运算数参数必须为整数类型%select{|，而非普通"char"、"bool"、精确位宽或枚举类型}0（%1 无效）'
+H232C02FD2560: '%select{溢出内建函数|带检查的整数运算}0的运算数参数必须为整数类型 %select{|，而非普通 "char"、"bool"、精确位宽或枚举类型}0（%1 无效）'
 # 'operand of ? changes signedness: %0 to %1'
 H034F94202BD7: '问号运算符的运算数改变了符号：%0 到 %1'
 # 'operand of type %0 cannot be cast to a pointer type'
@@ -25027,11 +25027,11 @@ H39550A20AC28: '类型 %0 的运算数不能转换为指针类型'
 # 'operand of type %0 where arithmetic or pointer type is required'
 H73F559724DF8: '需要算术类型或指针类型的位置却使用了类型 %0 的运算数'
 # 'operands to conditional of types%diff{ $ and $|}0,1 are incompatible in ARC mode'
-HA7936DDDD636: '在ARC模式下，条件运算符的运算数类型%diff{ $和$ |}0,1不兼容'
+HA7936DDDD636: '在ARC模式下，条件运算符的运算数类型%diff{ $和$ |}0,1 不兼容'
 # "operator '%0' has lower precedence than '%1'; '%1' will be evaluated first"
 H7655BF3550EE: '运算符 "%0" 的优先级低于 "%1"；"%1" 将先被计算'
 # "operator '?:' has lower precedence than '%0'; '%0' will be evaluated first"
-HFCE2B46187B8: '运算符"?: "的优先级低于 "%0"；"%0" 将先被计算'
+HFCE2B46187B8: '运算符 "?: " 的优先级低于 "%0"；"%0" 将先被计算'
 # 'operators in fold expression must be the same'
 H1479CC2CDE54: '折叠表达式中的运算符必须相同'
 # 'opt-like flags'
@@ -25133,7 +25133,7 @@ H9036C41EDFF6: '输出文件；用于写入为每个模块创建的分区摘要'
 # 'output file to write out the dotgraph representation of the input module'
 H491BF84F04E2: '输出文件；用于写入输入模块的dotgraph表示'
 # "output file; use '-' for stdout"
-H239A9905E956: '输出文件；使用"-"表示标准输出'
+H239A9905E956: '输出文件；使用 "-" 表示标准输出'
 # 'output format'
 H8D3CACC9A576: '输出格式'
 # 'output in binary'
@@ -25173,7 +25173,7 @@ H329B9199B7C8: '重载的 %0 必须至少有一个参数是类或枚举类型'
 # 'overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension'
 H9DE4D96FF9C0: '带有%select{无|一个默认的|超过一个}1参数的重载 %0 是C++23的扩展'
 # 'overloaded operator %select{>>|<<}0 has higher precedence than comparison operator'
-H3D68DF30B083: '重载的%select{>>|<<}0运算符的优先级高于比较运算符'
+H3D68DF30B083: '重载的 %select{>>|<<}0 运算符的优先级高于比较运算符'
 # 'overridden method is here'
 H33E209C67E48: '被覆盖的方法在此处'
 # 'overridden method returns an instance of its class type'
@@ -25255,7 +25255,7 @@ HD7CC3BBE6634: '参数“%0”未在函数声明中找到'
 # "parameter '%0' not in expected state when the function returns: expected '%1', observed '%2'"
 H6EE5C60DD591: "函数返回时参数 '%0' 未处于期望状态：期望 '%1'，实际观察到 '%2'"
 # "parameter cannot be named '%select{global|unknown}0' while using 'lifetime_capture_by(%select{global|unknown}0)'"
-H56545E5909EB: "在使用'lifetime_capture_by(%select{global|unknown}0)'时，参数不能命名为'%select{global|unknown}0'"
+H56545E5909EB: "在使用 'lifetime_capture_by(%select{global|unknown}0)' 时，参数不能命名为 '%select{global|unknown}0'"
 # 'parameter declarator cannot be qualified'
 HEB6B080E8792: '参数声明符不能被限定'
 # 'parameter kind mismatch; parameter is %select{not a|a}0 parameter pack'
@@ -25273,7 +25273,7 @@ H6E3911EE67CF: '%0 属性的参数必须是Objective-C %select{类|协议}1的�
 # 'parameter of %0 cannot have a default argument'
 H9997206462BD: '%0 的参数不能有默认参数值'
 # "parameter of literal operator must have type 'unsigned long long', 'long double', 'char', 'wchar_t', 'char16_t', 'char32_t', or 'const char *'"
-H18EF0BD0BEB6: "字面量运算符的参数类型必须为'unsigned long long'、'long double'、'char'、'wchar_t'、'char16_t'、'char32_t' 或'const char *'"
+H18EF0BD0BEB6: "字面量运算符的参数类型必须为 'unsigned long long'、'long double'、'char'、'wchar_t'、'char16_t'、'char32_t' 或 'const char *'"
 # 'parameter of overloaded %0 cannot have a default argument'
 H31033CF29CE2: '重载的 %0 参数不能有默认参数值'
 # "parameter of overloaded post-%select{increment|decrement}1 operator must have type 'int' (not %0)"
@@ -25293,9 +25293,9 @@ H220429408CBD: '参数包不能有默认参数'
 # 'parameter references not allowed in naked functions'
 HE9A90AF8CF8F: '在naked函数中不允许使用参数引用'
 # "parameterized class %0 already conforms to the protocols listed; did you forget a '*'?"
-H0F239CE68A40: '参数化类 %0 已经符合列出的协议；是否漏掉了"*"?'
+H0F239CE68A40: '参数化类 %0 已经符合列出的协议；是否漏掉了 "*"?'
 # 'parameters for defaulted %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator must have the same type%diff{ (found $ vs $)|}1,2'
-H34C46A5FC53A: '默认的%select{<ERROR>|相等|三向|相等|关系}0比较运算符的参数必须具有相同的类型%diff{(发现$和$不同)|}1,2'
+H34C46A5FC53A: '默认的 %select{<ERROR>|相等|三向|相等|关系}0比较运算符的参数必须具有相同的类型 %diff{(发现$和$不同)|}1,2'
 # "parent region for 'omp %select{cancellation point|cancel}0' construct cannot be nowait"
 H10627ACFF3E1: "'omp %select{取消点|取消}0'结构的父区域不能是nowait"
 # "parent region for 'omp %select{cancellation point|cancel}0' construct cannot be ordered"
@@ -25335,7 +25335,7 @@ H84CBC790F3FB: '%0 的偏特化未使用其任何模板参数'
 # 'pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions'
 HB623B7D5D4C9: '使用 -fsafe-buffer-usage-suggestions 选项以接收代码强化建议'
 # 'passing %0-byte aligned argument to %1-byte aligned parameter %2%select{| of %4}3 may result in an unaligned pointer access'
-H8E7373BFAB19: '传递 %0 字节对齐的参数给 %1 字节对齐的参数 %2%select{| of %4}3可能导致未对齐指针访问'
+H8E7373BFAB19: '传递 %0 字节对齐的参数给 %1 字节对齐的参数 %2%select{| of %4}3 可能导致未对齐指针访问'
 # 'passing %select{address of|reference to}0 local temporary object to musttail function'
 H185CAE78405D: '将局部临时对象的%select{地址|引用}0传递给musttail函数'
 # "passing %select{an object that undergoes default argument promotion|an object of reference type|a parameter declared with the 'register' keyword}0 to 'va_start' has undefined behavior"
@@ -25353,39 +25353,39 @@ H30E4C5FD05FE: '此处传递参数给参数 %0'
 # 'passing argument to parameter here'
 HC7C3DD07B432: '此处传递参数给参数'
 # 'passing arguments to %select{a function|%1}0 without a prototype is deprecated in all versions of C and is not supported in C23'
-H192BBFFB4918: '向%select{函数|%1}0传递参数而不使用原型在所有C版本中已弃用，并且C23不支持'
+H192BBFFB4918: '向%select{函数|%1}0 传递参数而不使用原型在所有C版本中已弃用，并且C23不支持'
 # 'passing byval argument %0 with potentially incompatible alignment here'
 H730F797EFCA9: '此处传递的byval参数 %0 具有可能不兼容的对齐方式'
 # "passing no argument for the '...' parameter of a variadic macro is a C++20 extension"
-H6D5DB0C5BBB6: "为可变参数宏的'...'参数不传递参数是C++20扩展"
+H6D5DB0C5BBB6: "为可变参数宏的 '...' 参数不传递参数是C++20扩展"
 # "passing no argument for the '...' parameter of a variadic macro is a C23 extension"
-H0F0C361742D6: "为可变参数宏的'...'参数不传递参数是C23扩展"
+H0F0C361742D6: "为可变参数宏的 '...' 参数不传递参数是C23扩展"
 # "passing no argument for the '...' parameter of a variadic macro is incompatible with C standards before C23"
-HCA1A72FB669A: "为可变参数宏的'...'参数不传递参数与C23之前的C标准不兼容"
+HCA1A72FB669A: "为可变参数宏的 '...' 参数不传递参数与C23之前的C标准不兼容"
 # "passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20"
-H2B8F35860B3B: "为可变参数宏的'...'参数不传递参数与C++20之前的C++标准不兼容"
+H2B8F35860B3B: "为可变参数宏的 '...' 参数不传递参数与C++20之前的C++标准不兼容"
 # 'passing non-generic address space pointer to %0 may cause dynamic conversion affecting performance'
 HAEF068C749A4: '将地址空间非通用指针传递给 %0 可能导致影响性能的动态转换'
 # "passing object of class type %0 through variadic %select{function|block|method|constructor}1%select{|; did you mean to call '%3'?}2"
-H39C1EFFB876B: "通过可变%select{函数|块|方法|构造函数}1传递类类型 %0 的对象%select{|; 你是否想调用 '%3'?}2"
+H39C1EFFB876B: "通过可变%select{函数|块|方法|构造函数}1传递类类型 %0 的对象 %select{|; 你是否想调用 '%3'?}2"
 # 'passing object of trivial but non-POD type %0 through variadic %select{function|block|method|constructor}1 is incompatible with C++98'
 HD5D2FE67C0FC: '通过可变%select{函数|块|方法|构造函数}1传递平凡但非POD类型 %0 的对象与C++98不兼容'
 # "passing only one argument to 'va_start' is incompatible with C standards before C23"
 H0DFF95F6ABB1: "在C23之前的C标准中，向 'va_start' 仅传递一个参数是不兼容的"
 # "passing pointer %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
-H9E268E19A549: "传递指针 %1 需要持有 %0 %select{'%2'|'独占的 %2'}3"
+H9E268E19A549: "传递指针 %1 需要持有 %0 %select{'%2'|' 独占的 %2'}3"
 # "passing pointer to variable %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
-H0E1F82092409: "传递变量 %1 的指针需要持有 %0 %select{'%2'|'独占的 %2'}3"
+H0E1F82092409: "传递变量 %1 的指针需要持有 %0 %select{'%2'|' 独占的 %2'}3"
 # "passing the value that %1 points to by reference requires holding %0 %select{'%2'|'%2' exclusively}3"
-HFB2B4F9A02B6: "通过引用传递 %1 所指的值需要持有 %0 %select{'%2'|'独占的 %2'}3"
+HFB2B4F9A02B6: "通过引用传递 %1 所指的值需要持有 %0 %select{'%2'|' 独占的 %2'}3"
 # 'passing union across security boundary via %select{parameter %1|return value}0 may leak information'
 HA1E50C08E561: '通过%select{参数 %1|返回值}0传递联合体跨安全边界可能会泄露信息'
 # "passing variable %1 by reference requires holding %0 %select{'%2'|'%2' exclusively}3"
-HB011E968C37B: "通过引用传递变量 %1 需要持有 %0 %select{'%2'|'独占的 %2'}3"
+HB011E968C37B: "通过引用传递变量 %1 需要持有 %0 %select{'%2'|' 独占的 %2'}3"
 # "pasting formed '%0', an invalid preprocessing token"
 H17B929BA26C6: "连接形成无效预处理标记 '%0'"
 # "pasting two '/' tokens into a '//' comment is a Microsoft extension"
-HBFF0AAF786C4: "将两个'/'标记连接成'//'注释是微软扩展"
+HBFF0AAF786C4: "将两个 '/' 标记连接成 '//' 注释是微软扩展"
 # 'path to a pass plugin for HIP to SPIR-V passes.'
 HF42DFD9FA413: 'HIP 到 SPIR-V 转换的 Pass 插件路径。'
 # 'path to instrumented binary in case if /proc/self/map_files is not accessible due to access restriction issues'
@@ -25423,7 +25423,7 @@ H653C9447EE92: 'performSelector可能因选择器未知而导致内存泄漏'
 # 'performSelector names a selector which retains the object'
 HF51E4C8347B0: 'performSelector命名的会选择器会保留对象'
 # 'performing pointer arithmetic on a null pointer has undefined behavior%select{| if the offset is nonzero}0'
-HA288389E9F6A: '对空指针进行指针运算具有未定义行为%select{|如果偏移量非零}0'
+HA288389E9F6A: '对空指针进行指针运算具有未定义行为 %select{|如果偏移量非零}0'
 # 'performing pointer subtraction with a null pointer %select{has|may have}0 undefined behavior'
 HB725A707608F: '使用空指针%select{具有|可能具有}0未定义行为的指针减法'
 # 'performs disassembly sequentially'
@@ -25435,7 +25435,7 @@ H46CB03DD1B68: '基于 -O 选项选择寄存器分配器'
 # 'pipes packet types cannot be of reference type'
 H354A6AC50D78: '管道数据包类型不能是引用类型'
 # "place '...' %select{immediately before declared identifier|here}0 to declare a function parameter pack"
-HD82CBB258C12: "在%select{声明的标识符前直接|此处}0放置'...'以声明函数参数包"
+HD82CBB258C12: "在%select{声明的标识符前直接|此处}0放置 '...' 以声明函数参数包"
 # 'place all array allocations more than <size> elements on the heap'
 H7583F9BA4C9F: '将元素数超过 <size> 的数组分配到堆上'
 # 'place all array allocations of dynamic size on the heap'
@@ -25447,7 +25447,7 @@ HD79F2195D659: "在 '%0' 表达式周围添加括号以优先计算它"
 # "place parentheses around the '%0' expression to silence this warning"
 H7195F835EC30: "在 '%0' 表达式周围添加括号以消除此警告"
 # "place parentheses around the '?:' expression to evaluate it first"
-H9605DB1A560A: "在'?:'表达式周围添加括号以先进行求值"
+H9605DB1A560A: "在 '?:' 表达式周围添加括号以先进行求值"
 # 'place parentheses around the assignment to silence this warning'
 HE705E4D071BD: '在赋值周围添加括号以消除此警告'
 # 'place parentheses around the string literal to silence warning'
@@ -25461,7 +25461,7 @@ H6BE10CEEDF1B: '占位符变量与C++2c之前的C++标准不兼容'
 # 'placement new would change type of storage from %0 to %1'
 H83FB1C107237: 'placement new会将存储类型从 %0 更改为 %1'
 # "plain '_Complex' requires a type specifier; assuming '_Complex double'"
-HBC4E2F0D8FF6: "普通的 '_Complex' 需要类型说明符；假设为'_Complex double'"
+HBC4E2F0D8FF6: "普通的 '_Complex' 需要类型说明符；假设为 '_Complex double'"
 # "platform does not match: '%0' (provided) vs '%1' (found)"
 H5C64A2FB6312: "平台不匹配：提供的 '%0' 与检测到的 '%1'"
 # "please rebuild precompiled header '%0'"
@@ -25477,7 +25477,7 @@ H0546695B4A22: '指针不能转换为类型 %0'
 # 'pointer cannot be mapped along with a section derived from itself'
 HAF06E92DEBA3: '指针不能与其派生的部分同时映射'
 # 'pointer comparisons before C11 need to be between two complete or two incomplete types; %0 is %select{|in}2complete and %1 is %select{|in}3complete'
-H4DB22EDB67C8: 'C11之前的指针比较需要在两种完整类型或两种不完整类型之间；%0 是%select{|in}2complete，%1 是%select{|in}3complete'
+H4DB22EDB67C8: 'C11之前的指针比较需要在两种完整类型或两种不完整类型之间；%0 是 %select{|in}2complete，%1 是 %select{|in}3complete'
 # "pointer to function type %0 may not be 'restrict' qualified"
 H909D3E85FCFF: "指向函数类型 %0 的指针可能不能被 'restrict' 限定"
 # 'pointer to type %0 is invalid in OpenCL'
@@ -25581,7 +25581,7 @@ HBCF9A92B45C8: '保留中间.o文件'
 # 'pretty-print DWARF debug information in object files and debug info archives.\n'
 HFF4E6027BC6C: '以美观格式打印对象文件和调试信息存档中的DWARF调试信息。\n'
 # 'previous %select{template type|non-type template|template template}0 parameter%select{| pack}1 declared here'
-HEDFC0D57E1AE: '之前的 %select{模板类型|非类型模板|模板模板}0 参数%select{| 包}1 在此处声明'
+HEDFC0D57E1AE: '之前的 %select{模板类型|非类型模板|模板模板}0 参数 %select{| 包}1 在此处声明'
 # 'previous %select{unmarked |}0overload of function is here'
 HAE3E66A916BE: '之前的 %select{未标记 |}0 函数重载在此处'
 # "previous '#pragma pack' directive that modifies alignment is here"
@@ -25597,7 +25597,7 @@ H6E32F6609895: '前一个属性在此处'
 # 'previous binding pack specified here'
 H720F62C2E50B: '之前在这里指定的绑定包'
 # 'previous call is here%select{; set to nil to indicate it cannot be called afterwards|}0'
-HE8A56E8F5AF3: '之前的调用在这里%select{; 设置为nil以指示之后无法调用|}0'
+HE8A56E8F5AF3: '之前的调用在这里 %select{; 设置为nil以指示之后无法调用|}0'
 # 'previous case defined here'
 H67B17B33B89D: '之前在这里定义的case'
 # 'previous clause is here'
@@ -25635,7 +25635,7 @@ H2F8B22E01C4A: '之前的隐式声明在这里'
 # 'previous inheritance model specified here'
 HDD10F14D9687: '之前在这里指定的继承模型'
 # 'previous initialization %select{|with side effects }0is here%select{| (side effects will not occur at run time)}0'
-HFE059F4FA2A1: '之前的初始化%select{|带有副作用 }0在这里%select{|（副作用在运行时不会发生）}0'
+HFE059F4FA2A1: '之前的初始化 %select{|带有副作用 }0在这里 %select{|（副作用在运行时不会发生）}0'
 # 'previous initialization for field %0 is here'
 HEF0E98EA391B: '字段 %0 的先前初始化在这里'
 # 'previous module declaration is here'
@@ -25835,7 +25835,7 @@ H71912C66C3FC: '输出被修补的骨架编译单元的abbrev和debug_info的偏
 # 'prioritize low virtual register numbers for test and debug'
 H0A6C1C201BCE: '优先使用低虚寄存器号用于测试和调试'
 # "private API notes file for module '%0' should be named '%0_private.apinotes', not '%1'"
-HB68113D2F79A: "模块 '%0' 的私有API注释文件应命名为'%0_private.apinotes'，而非 '%1'"
+HB68113D2F79A: "模块 '%0' 的私有API注释文件应命名为 '%0_private.apinotes'，而非 '%1'"
 # 'private field %0 is not used'
 H3584A3B50C2A: '私有字段 %0 未被使用'
 # 'private module fragment begins here'
@@ -25879,7 +25879,7 @@ H4ECC248CA95F: '属性 %0 已被实现'
 # 'property %0 is declared %select{deprecated|unavailable|partial}1 here'
 HC2D276377832: '属性 %0 在此处被声明为%select{已弃用|不可用|部分}1'
 # 'property %0 is implemented with %select{@synthesize|@dynamic}1 here'
-H43FFE47B4C6F: '属性 %0 在此处使用%select{@synthesize|@dynamic}1实现'
+H43FFE47B4C6F: '属性 %0 在此处使用 %select{@synthesize|@dynamic}1 实现'
 # 'property %0 is implemented with %select{@synthesize|@dynamic}1 in one translation but %select{@dynamic|@synthesize}1 in another translation unit'
 H7C85E91BA02D: '属性 %0 在一个翻译单元中使用 %select{@synthesize|@dynamic}1 实现，但在另一个翻译单元中使用 %select{@dynamic|@synthesize}1'
 # 'property %0 is synthesized to different ivars in different translation units (%1 vs. %2)'
@@ -26013,7 +26013,7 @@ HAF3B1E936CB4: '调用前可用r11，但跳转前不可用'
 # 'r11 not available'
 HD51A31809CB5: 'r11不可用'
 # "range-based 'for' statement uses ':', not '='"
-HC53E3757D97C: "基于范围的 'for' 语句使用':'而非'='"
+HC53E3757D97C: "基于范围的 'for' 语句使用 ':' 而非 '='"
 # 'range-based for loop has empty body'
 H2C4FFAA3CE47: '基于范围的for循环具有空主体'
 # 'range-based for loop initialization statements are a C++20 extension'
@@ -26113,11 +26113,11 @@ H9380CBD04275: '将 %0 重新定义为不同类型符号'
 # 'redefinition of %0 will not be visible outside of this function'
 H6605A7137B7E: '%0 的重新定义在函数外部不可见'
 # 'redefinition of %0 with a different type%diff{: $ vs $|}1,2'
-HB1C0A119B95E: '使用不同的类型%diff{: $ vs $|}1,2重新定义 %0'
+HB1C0A119B95E: '使用不同的类型 %diff{: $ vs $|}1,2 重新定义 %0'
 # 'redefinition of %select{typedef|type alias}0 for variably-modified type %1'
-HB599B51A5F4D: '为可变修改类型 %1 重定义%select{typedef|类型别名}0'
+HB599B51A5F4D: '为可变修改类型 %1 重定义 %select{typedef|类型别名}0'
 # "redefinition of a 'extern inline' function %0 is not supported in %select{C99 mode|C++}1"
-HF158368144B8: "在%select{C99模式|C++}1中不支持对 %0 的'extern inline'函数的重新定义"
+HF158368144B8: "在 %select{C99模式|C++}1 中不支持对 %0 的 'extern inline' 函数的重新定义"
 # 'redefinition of concept %0 with different template parameters or requirements'
 H4C4283523181: '使用不同的模板参数或要求重新定义概念 %0'
 # 'redefinition of default argument'
@@ -26207,7 +26207,7 @@ H76762B8F478F: '在全局初始化器中引用 %select{__device__|__global__|__h
 # 'reference to %select{destructor|pseudo-destructor}0 must be called%select{|; did you mean to call it with no arguments?}1'
 H3484C551C20A: '必须调用 %select{析构函数|伪析构函数}0%select{|；是否需要以无参数形式调用？}1'
 # 'reference to %select{overloaded|multiversioned}1 function could not be resolved; did you mean to call it%select{| with no arguments}0?'
-HA7DE06C12730: '无法解析对 %select{重载|多版本}1 函数的引用；是否需要%select{|以无参数形式}0调用它？'
+HA7DE06C12730: '无法解析对 %select{重载|多版本}1 函数的引用；是否需要 %select{|以无参数形式}0调用它？'
 # "reference to a %select{bit-field|vector element|global register variable}0 in asm %select{input|output}1 with a memory constraint '%2'"
 HCCFE4F550EEB: "在asm %select{输入|输出}1 约束 '%2' 中引用 %select{位域|向量元素|全局寄存器变量}0"
 # "reference to enumeration must use 'enum' not 'enum %select{struct|class}0'"
@@ -26217,7 +26217,7 @@ H9B72122A433C: '对局部 %select{变量|绑定项}1 %0 的引用，该变量在
 # "reference to marker '%0' is ambiguous"
 HD452BD6D3FB0: "对标记 '%0' 的引用存在歧义"
 # 'reference to non-static member function must be called%select{|; did you mean to call it with no arguments?}0'
-H472EE5EB17CD: '对非静态成员函数的引用必须调用%select{|; 是否应以无参数调用？}0'
+H472EE5EB17CD: '对非静态成员函数的引用必须调用 %select{|; 是否应以无参数调用？}0'
 # 'reference to type %0 cannot bind to an initializer list'
 H9194F3CD2BD5: '类型 %0 的引用无法绑定到初始化列表'
 # 'reference to type %0 requires an initializer'
@@ -26231,7 +26231,7 @@ H8DB9210452D3: '被引用的成员 %0 在此处声明'
 # "referring to 'main' within an expression is a Clang extension"
 H5EC3F4017EE7: "'main' 在表达式中被引用是 Clang 扩展特性"
 # "region cannot be%select{| closely}0 nested inside '%1' region%select{|; perhaps you forget to enclose 'omp %3' directive into a parallel region?|; perhaps you forget to enclose 'omp %3' directive into a for or a parallel for region with 'ordered' clause?|; perhaps you forget to enclose 'omp %3' directive into a target region?|; perhaps you forget to enclose 'omp %3' directive into a teams region?|; perhaps you forget to enclose 'omp %3' directive into a for, simd, for simd, parallel for, or parallel for simd region?}2"
-H9F4A9870BA07: "区域不能%select{|紧密}0 嵌套在 '%1' 区域内%select{|; 是否忘记将 'omp %3' 指令包含在并行区域中？|; 是否忘记将 'omp %3' 指令包含在带有 'ordered' 子句的 for 或并行 for 区域中？|; 是否忘记将 'omp %3' 指令包含在目标区域中？|; 是否忘记将 'omp %3' 指令包含在 teams 区域中？|; 是否忘记将 'omp %3' 指令包含在 for、simd、for simd、并行 for 或并行 for simd 区域中？}2"
+H9F4A9870BA07: "区域不能 %select{|紧密}0 嵌套在 '%1' 区域内 %select{|; 是否忘记将 'omp %3' 指令包含在并行区域中？|; 是否忘记将 'omp %3' 指令包含在带有 'ordered' 子句的 for 或并行 for 区域中？|; 是否忘记将 'omp %3' 指令包含在目标区域中？|; 是否忘记将 'omp %3' 指令包含在 teams 区域中？|; 是否忘记将 'omp %3' 指令包含在 for、simd、for simd、并行 for 或并行 for simd 区域中？}2"
 # "register '%0' unsuitable for global register variables on this target"
 HAC3AEFE8413B: "寄存器 '%0' 不适用于此目标的全局寄存器变量"
 # 'register number should be an integer'
@@ -26353,7 +26353,7 @@ H149741EFCCA5: '请求的移位是一个类型为 %0 的向量，但第一个操
 # 'required alignment of type %0 (%1 bytes) is larger than the supported alignment of C++ exception objects on this target (%2 bytes)'
 HFFCA5AAB79EE: '类型 %0 的必需对齐值（%1 字节）大于此目标支持的C++异常对象的最大对齐值（%2 字节）'
 # "required by %select{'require_constant_initialization' attribute|'constinit' specifier}0 here"
-H669C2D015B6E: '由%select{require_constant_initialization属性|constinit说明符}0在此处要求'
+H669C2D015B6E: '由 %select{require_constant_initialization属性|constinit说明符}0在此处要求'
 # 'requires clause differs in template redeclaration'
 H3C91EEDA34FA: '模板重新声明中的requires子句不同'
 # "requires expression in requirement body; did you intend to place it in a nested requirement? (add another 'requires' before the expression)"
@@ -26371,7 +26371,7 @@ H044B0871CB3F: 'restrict需要指针或引用'
 # 'restrict requires a pointer or reference (%0 is invalid)'
 HB4AA3977DC42: 'restrict需要指针或引用（%0 无效）'
 # "result argument to %select{overflow builtin|checked integer operation}0 must be a pointer to a non-const integer type %select{|other than plain 'char', 'bool', bit-precise, or an enumeration }0(%1 invalid)"
-HD81ECBB4661A: "传给%select{溢出内建函数|有符号整数运算}0的result参数必须是指向非const整数类型的指针%select{|而不是普通的 'char'、'bool'、精确位数或枚举类型}0（%1 无效）"
+HD81ECBB4661A: "传给%select{溢出内建函数|有符号整数运算}0的result参数必须是指向非const整数类型的指针 %select{|而不是普通的 'char'、'bool'、精确位数或枚举类型}0（%1 无效）"
 # "result of '%0' is %1; did you mean '%2' (%3)?"
 H369683737B3D: "'%0' 的结果是 %1；是否是指 '%2' (%3)？"
 # "result of '%0' is %1; did you mean '%2'?"
@@ -26379,19 +26379,19 @@ H1B6516041439: "'%0' 的结果是 %1；是否是指 '%2'？"
 # "result of '%0' is %1; did you mean exponentiation?"
 H6BDF285BA0FF: "'%0' 的结果是 %1；是否是指指数运算？"
 # 'result of comparison %select{%3|%1}0 %2 %select{%1|%3}0 is always %4'
-H3D76D2CD2831: '%select{%3|%1}0 %2 %select{%1|%3}0的比较结果始终为 %4'
+H3D76D2CD2831: '%select{%3|%1}0 %2 %select{%1|%3}0 的比较结果始终为 %4'
 # 'result of comparison against %select{a string literal|@encode}0 is unspecified (use an explicit string comparison function instead)'
-H42F5B6822163: '与%select{字符串字面量|@encode}0的比较结果未指定（请改用显式字符串比较函数）'
+H42F5B6822163: '与%select{字符串字面量|@encode}0 的比较结果未指定（请改用显式字符串比较函数）'
 # 'result of comparison of %select{%3|char expression}0 %2 %select{char expression|%3}0 is always %4, since char is interpreted as unsigned'
-H2652DE195D69: '比较%select{%3|字符表达式}0 %2 %select{字符表达式|%3}0的结果始终为 %4，因为char被视为无符号类型'
+H2652DE195D69: '比较 %select{%3|字符表达式}0 %2 %select{字符表达式|%3}0 的结果始终为 %4，因为char被视为无符号类型'
 # 'result of comparison of %select{%3|unsigned enum expression}0 %2 %select{unsigned enum expression|%3}0 is always %4'
-H86DA5A0E3154: '比较%select{%3|无符号枚举表达式}0 %2 %select{无符号枚举表达式|%3}0的结果始终为 %4'
+H86DA5A0E3154: '比较 %select{%3|无符号枚举表达式}0 %2 %select{无符号枚举表达式|%3}0 的结果始终为 %4'
 # 'result of comparison of %select{%3|unsigned expression}0 %2 %select{unsigned expression|%3}0 is always %4'
-HABA37A2C23DF: '比较%select{%3|无符号表达式}0 %2 %select{无符号表达式|%3}0的结果始终为 %4'
+HABA37A2C23DF: '比较 %select{%3|无符号表达式}0 %2 %select{无符号表达式|%3}0 的结果始终为 %4'
 # 'result of comparison of %select{%4|%1-bit %select{signed|unsigned}2 value}0 %3 %select{%1-bit %select{signed|unsigned}2 value|%4}0 is always %5'
-H3E54DBA92461: '比较%select{%4|%1 位%select{有符号|无符号}2类型值}0 %3 和 %select{%1 位%select{有符号|无符号}2类型值|%4}0的结果始终为 %5'
+H3E54DBA92461: '比较 %select{%4|%1 位%select{有符号|无符号}2类型值}0 %3 和 %select{%1 位%select{有符号|无符号}2类型值|%4}0 的结果始终为 %5'
 # 'result of comparison of %select{constant %0|true|false}1 with %select{expression of type %2|boolean expression}3 is always %4'
-H0604EEA5685E: '将%select{常量 %0|true|false}1与%select{类型 %2 的表达式|布尔表达式}3比较的结果始终为 %4'
+H0604EEA5685E: '将%select{常量 %0|true|false}1 与%select{类型 %2 的表达式|布尔表达式}3比较的结果始终为 %4'
 # "result of comparison of constant %0 with expression of type 'BOOL' is always %1, as the only well defined values for 'BOOL' are YES and NO"
 H641A75823917: "与类型 'BOOL' 的表达式比较的常量 %0 结果始终为 %1，因为 'BOOL' 的唯一定义值是YES和NO"
 # "retain'ed block property does not copy the block - use copy attribute instead"
@@ -26403,25 +26403,25 @@ H2753EF9C9B3B: "为不可消耗类型 '%0' 设置了返回状态"
 # "return statement not allowed in coroutine; did you mean 'co_return'?"
 HD15AAC2A320B: "协程中不允许使用return语句；是否应使用 'co_return'？"
 # "return type %0 of selected 'operator==' function for rewritten '%1' comparison is not 'bool'"
-HC9853B2276CB: "为重写 '%1' 比较的选定'operator=='函数，其返回类型 %0 不是 'bool'"
+HC9853B2276CB: "为重写 '%1' 比较的选定 'operator==' 函数，其返回类型 %0 不是 'bool'"
 # 'return type cannot be qualified with address space'
 H90249355EB7F: '返回类型不能用地址空间修饰'
 # 'return type deduction is incompatible with C++ standards before C++14'
 HB4A5F5EFADA6: '返回类型推导与C++14之前的C++标准不兼容'
 # "return type for defaulted %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator must be 'bool', not %1"
-H2EF639AB940D: "默认实现的%select{<ERROR>|相等|三向|相等|关系}0比较运算符的返回类型必须是 'bool' 而非 %1"
+H2EF639AB940D: "默认实现的 %select{<ERROR>|相等|三向|相等|关系}0比较运算符的返回类型必须是 'bool' 而非 %1"
 # "return type of 'await_ready' is required to be contextually convertible to 'bool'"
 H043CECD8EB91: "'await_ready' 的返回类型必须能上下文转换为 'bool'"
 # "return type of 'await_suspend' is required to be 'void' or 'bool' (have %0)"
 H64AB2C323A61: "'await_suspend' 的返回类型必须是 'void' 或 'bool'（当前为 %0）"
 # "return type of 'coroutine_handle<>::address should be 'void*' (have %0) in order to get capability with existing async C API"
-HA713CB41D910: "'coroutine_handle<>::address'的返回类型应为'void*'（当前为 %0），以便通过现有异步C API获取功能"
+HA713CB41D910: "'coroutine_handle<>::address' 的返回类型应为 'void*'（当前为 %0），以便通过现有异步C API获取功能"
 # "return type of 'main' is not 'int'"
 HFBAC240E8034: "'main' 的返回类型不是 'int'"
 # "return type of defaulted 'operator<=>' cannot be deduced because return type %2 of three-way comparison for %select{|member|base class}0 %1 is not a standard comparison category type"
-H424FC8A53CC9: "默认的'operator<=>'的返回类型无法推导，因为%select{|member|base class}0 %1 的三向比较返回类型 %2 不是标准比较类别类型"
+H424FC8A53CC9: "默认的 'operator<=>' 的返回类型无法推导，因为 %select{|member|base class}0 %1 的三向比较返回类型 %2 不是标准比较类别类型"
 # "return type of defaulted 'operator<=>' cannot be deduced because three-way comparison for %select{|member|base class}0 %1 has a deduced return type and is not yet defined"
-H0105A22E2A8D: "默认的'operator<=>'的返回类型无法推导，因为%select{|member|base class}0 %1 的三向比较具有推导出的返回类型且尚未定义"
+H0105A22E2A8D: "默认的 'operator<=>' 的返回类型无法推导，因为 %select{|member|base class}0 %1 的三向比较具有推导出的返回类型且尚未定义"
 # 'return type of out-of-line definition of %q0 differs from that in the declaration'
 H469315680A98: '%q0的外部定义的返回类型与声明中的不同'
 # 'return type of virtual function %0 is not covariant with the return type of the function it overrides (%1 has different qualifiers than %2)'
@@ -26445,9 +26445,9 @@ H7C6FDC7A79CE: '返回局部标签的地址，该标签是局部作用域内的'
 # 'returning block that lives on the local stack'
 HFB5C6DCAD180: '返回存活在局部栈上的代码块'
 # "returning pointer %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
-H524B3D4E5221: "返回指针 %1 需要持有 %0 %select{'%2'|'排他性 %2'}3"
+H524B3D4E5221: "返回指针 %1 需要持有 %0 %select{'%2'|' 排他性 %2'}3"
 # "returning pointer to variable %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
-HC47B423E80E3: "返回变量 %1 的指针需要持有 %0 %select{'%2'|'排他性 %2'}3"
+HC47B423E80E3: "返回变量 %1 的指针需要持有 %0 %select{'%2'|' 排他性 %2'}3"
 # 'returning reference to local temporary object'
 H3C7B38DADD40: '返回局部临时对象的引用'
 # "returning the value that %1 points to by reference requires holding %0 %select{'%2'|'%2' exclusively}3"
@@ -26645,7 +26645,7 @@ HC25A9009F181: '此处存在类似的约束表达式'
 # 'similar constraint expressions not considered equivalent; constraint expressions cannot be considered equivalent unless they originate from the same concept'
 H671259A4BAC3: '类似的约束表达式不被视为等效；除非源自同一概念，否则约束表达式不被视为等效'
 # "similar to '-lite-threshold-pct' but specify threshold using absolute function call count. I.e. limit processing to functions executed at least the specified number of times."
-HAE7D7FD96C23: '与"-lite-threshold-pct"类似，但使用绝对函数调用次数指定阈值。即仅处理执行次数至少达到指定次数的函数。'
+HAE7D7FD96C23: '与 "-lite-threshold-pct" 类似，但使用绝对函数调用次数指定阈值。即仅处理执行次数至少达到指定次数的函数。'
 # 'simple ddg dot graph'
 H18F32B7E23D9: '简单的DDG DOT图'
 # 'simple-rename options'
@@ -26793,15 +26793,15 @@ HA2B9806ED1A1: '在函数原型之外使用星号修饰符'
 # "state of variable '%0' must match at the entry and exit of loop"
 H7D285ABC5B72: "变量 '%0' 在循环入口和出口处的状态必须一致"
 # "statement after '#pragma omp dispatch' must be a direct call to a target function or an assignment to one"
-H172FE1A4272E: "在'#pragma omp dispatch'之后的语句必须是直接调用目标函数或将其赋值"
+H172FE1A4272E: "在 '#pragma omp dispatch' 之后的语句必须是直接调用目标函数或将其赋值"
 # "statement associated with OpenACC 'atomic%select{| %1}0' directive is invalid"
-H42056AC9B64A: "与OpenACC 'atomic%select{| %1}0'指令关联的语句无效"
+H42056AC9B64A: "与OpenACC 'atomic%select{| %1}0' 指令关联的语句无效"
 # "statement attribute %0 has higher precedence than function attribute '%select{always_inline|flatten|noinline}1'"
-H0AF92FCED836: "语句属性 %0 的优先级高于函数属性'%select{always_inline|flatten|noinline}1'"
+H0AF92FCED836: "语句属性 %0 的优先级高于函数属性 '%select{always_inline|flatten|noinline}1'"
 # 'statement expression not allowed at file scope'
 HB4FE90B7D7C8: '文件作用域内不允许使用语句表达式'
 # "statement in 'omp %0' directive must be enclosed into a section region"
-H69791FF123D5: "在'omp %0'指令中的语句必须包含在section区域中"
+H69791FF123D5: "在 'omp %0' 指令中的语句必须包含在section区域中"
 # 'statement not allowed in %select{constexpr|consteval}1 %select{function|constructor}0'
 HD56C75E5841E: '在 %select{constexpr|consteval}1 %select{函数|构造函数}0中不允许使用该语句'
 # 'statement requires expression of integer type (%0 invalid)'
@@ -26889,7 +26889,7 @@ HE2D46EB90348: "'operator' 之后的字符串字面量不能带有编码前缀"
 # 'string literal after \'operator\' must be \'""\''
 HB2C541BB7B81: "'operator' 之后的字符串字面量必须是''"
 # 'string literal of length %0 exceeds maximum length %1 that %select{C90|ISO C99|C++}2 compilers are required to support'
-H446F1FE51F67: '长度为 %0 的字符串字面量超过了%select{C90|ISO C99|C++}2编译器必须支持的最大长度 %1'
+H446F1FE51F67: '长度为 %0 的字符串字面量超过了 %select{C90|ISO C99|C++}2 编译器必须支持的最大长度 %1'
 # 'string literal operator templates are a GNU extension'
 HC7C4AAEBD81D: '字符串字面量操作符模板是GNU扩展'
 # 'string literal with user-defined suffix cannot be used here'
@@ -26899,7 +26899,7 @@ HA27BA101BC94: '超过此长度的字符串字面量将使用哈希值作为其�
 # 'string to set default kind values'
 H7121B365791A: '设置默认类型值的字符串'
 # "strip 'repz' prefix from 'repz retq' sequence (on by default)"
-H5E0A0D55638D: "从'repz retq'序列中剥离 'repz' 前缀（默认启用）"
+H5E0A0D55638D: "从 'repz retq' 序列中剥离 'repz' 前缀（默认启用）"
 # 'structured binding declaration in a condition is a C++2c extension'
 H7AF1E5D1A2D0: '条件中的结构化绑定声明是C++2c扩展'
 # 'structured binding declaration in a condition is incompatible with C++ standards before C++2c'
@@ -26921,7 +26921,7 @@ H1DA53EDBF661: '模块映射中未声明子模块 %0.%1'
 # "submodule of top-level module '%0' implicitly imported here"
 HDAE6F5126C46: "顶级模块 '%0' 的子模块在此处被隐式导入"
 # 'subobject %select{of type |}0%1 is not initialized'
-HF2C7BC6C2C0D: '子对象%select{of type |}0%1 未初始化'
+HF2C7BC6C2C0D: '子对象 %select{of type |}0%1 未初始化'
 # 'subobject declared here'
 H554F161157BC: '子对象在此处声明'
 # 'subscript of a pointer to void is a GNU extension'
@@ -26955,9 +26955,9 @@ H122DA545D844: '建议在子对象的初始化周围使用花括号'
 # 'sum of call durations'
 H97819C630794: '调用持续时间之和'
 # "support for '/Yc' and '/Yu' with different filenames not implemented yet; flags ignored"
-HC924164CBDE2: "对不同文件名的'/Yc'和'/Yu'支持尚未实现；忽略该标志"
+HC924164CBDE2: "对不同文件名的 '/Yc' 和 '/Yu' 支持尚未实现；忽略该标志"
 # "support for '/Yc' with more than one source file not implemented yet; flag ignored"
-H7450874B7BA1: "对多个源文件的'/Yc'支持尚未实现；忽略该标志"
+H7450874B7BA1: "对多个源文件的 '/Yc' 支持尚未实现；忽略该标志"
 # 'support for HLSL language version %0 is incomplete, recommend using %1 instead'
 H68BB4F93A02C: '对HLSL语言版本 %0 的支持不完整，建议改用 %1'
 # "support for linking stdlibs for microcontroller '%0' is not implemented"
@@ -27059,11 +27059,11 @@ H5C1974A3FA23: 'using声明的目标与作用域内已有的声明冲突'
 # 'target profile option (-T) is missing'
 HD96117F3AEE8: '目标配置文件选项（-T）缺失'
 # 'target-attribute based function overloads are not supported by NVCC and will be treated as a function redeclaration:new declaration is %select{__device__|__global__|__host__|__host__ __device__}0 function, old declaration is %select{__device__|__global__|__host__|__host__ __device__}1 function'
-H48B3A7876AE7: '基于target-attribute的函数重载不被NVCC支持，将被视为函数重新声明：新声明是%select{__device__|__global__|__host__|__host__ __device__}0函数，旧声明是%select{__device__|__global__|__host__|__host__ __device__}1函数'
+H48B3A7876AE7: '基于target-attribute的函数重载不被NVCC支持，将被视为函数重新声明：新声明是 %select{__device__|__global__|__host__|__host__ __device__}0 函数，旧声明是 %select{__device__|__global__|__host__|__host__ __device__}1 函数'
 # 'tbd'
 H1D9C8AC0B205: 'tbd'
 # 'template %0 has no definition and no %select{|viable }1deduction guides for deduction of template arguments'
-H39A2D17F6485: '模板 %0 没有定义，也没有%select{|可行的 }1推导指南来推导模板参数'
+H39A2D17F6485: '模板 %0 没有定义，也没有 %select{|可行的 }1推导指南来推导模板参数'
 # 'template argument / label address difference / what did you expect?'
 H4022196FB5B0: '模板参数/标签地址差异/您期望的是什么？'
 # 'template argument does not refer to a class or alias template, or template template parameter'
@@ -27073,7 +27073,7 @@ HF7C463216541: '非类型模板参数的模板参数被解释为函数类型 %0'
 # 'template argument for non-type template parameter must be an expression'
 HA6F518CB9F6F: '非类型模板参数的模板参数必须是一个表达式'
 # 'template argument for template template parameter must be a class template%select{| or type alias template}0'
-H4605CB1853A3: '模板模板参数的模板参数必须是一个类模板%select{|或类型别名模板}0'
+H4605CB1853A3: '模板模板参数的模板参数必须是一个类模板 %select{|或类型别名模板}0'
 # 'template argument for template type parameter must be a type'
 H9FFBB255FD4F: '模板类型参数的模板参数必须是一个类型'
 # "template argument for template type parameter must be a type; did you forget 'typename'?"
@@ -27095,7 +27095,7 @@ H8B583108C6ED: '模板在此处声明'
 # 'template name refers to non-type template %0'
 HD8E4D2A7EC89: '模板名称引用非类型模板 %0'
 # 'template non-type parameter has a different type %0 in template %select{|template parameter }1redeclaration'
-H29D49A380D2B: '模板%select{|模板参数 }1重新声明中，模板非类型参数具有不同类型 %0'
+H29D49A380D2B: '模板 %select{|模板参数 }1重新声明中，模板非类型参数具有不同类型 %0'
 # 'template non-type parameter has a different type %0 in template argument'
 H83C8844C296B: '模板参数中的非类型参数具有不同类型 %0'
 # "template parameter '%0' is already documented"
@@ -27109,7 +27109,7 @@ H6440E4D1834B: '模板参数默认参数与之前的定义不一致'
 # 'template parameter from hidden source: %0'
 HE652270F3F6D: '来自隐藏源的模板参数：%0'
 # 'template parameter has a different kind in template %select{|template parameter }0redeclaration'
-HBF82CEEA37C8: '模板参数在模板%select{|模板参数 }0重新声明中的类型不同'
+HBF82CEEA37C8: '模板参数在模板 %select{|模板参数 }0重新声明中的类型不同'
 # 'template parameter has a different kind in template argument'
 H8F8F50E907A1: '模板参数在模板实参中的类型不同'
 # 'template parameter has different kinds in different translation units'
@@ -27185,17 +27185,17 @@ HCC2A02E45E01: '类型 %0 不能用于声明程序作用域变量'
 # 'the %0 type cannot be used to declare a structure or union field'
 H3AA824360E4A: '类型 %0 不能用于声明结构体或联合体的字段'
 # 'the %select{1st|2nd|3rd}1 template parameter of %0 needs to be %select{a type|an integer or enum value}2'
-HC15D25E5BA46: '模板 %0 的第%select{1位|2位|3位}1个模板参数需要是%select{一个类型|一个整数或枚举值}2'
+HC15D25E5BA46: '模板 %0 的第 %select{1位|2位|3位}1个模板参数需要是%select{一个类型|一个整数或枚举值}2'
 # 'the %select{function or variable|function}0 specified in an %select{alias|ifunc}1 must refer to its mangled name'
-H2A963C3F164E: '在%select{别名|ifunc}1中指定的%select{函数或变量|函数}0必须引用其mangled名称'
+H2A963C3F164E: '在%select{别名|ifunc}1 中指定的%select{函数或变量|函数}0必须引用其mangled名称'
 # "the %select{message|string}0 object in %select{this static assertion|this asm operand}0 is missing %select{a 'size()' member function|a 'data()' member function|'data()' and 'size()' member functions}1"
-HF8EFF7FCD3A1: "在%select{此静态断言|此asm操作数}0中的%select{消息|string}0对象缺少%select{'size()'成员函数|'data()'成员函数|'data()'和'size()'成员函数}1"
+HF8EFF7FCD3A1: "在%select{此静态断言|此asm操作数}0中的%select{消息|string}0 对象缺少 %select{'size()' 成员函数|'data()' 成员函数|'data()' 和 'size()' 成员函数}1"
 # "the '%0' unit is not supported with this instruction set"
 H66612647AED8: "单元 '%0' 不受当前指令集支持"
 # "the '%select{&|*|->}0' operator is unsupported in HLSL"
-H831B25ED6E8C: "操作符'%select{&|*|->}0'在HLSL中不受支持"
+H831B25ED6E8C: "操作符 '%select{&|*|->}0' 在HLSL中不受支持"
 # "the '[[_Noreturn]]' attribute spelling is deprecated in C23; use '[[noreturn]]' instead"
-H584C1C164ECE: "在C23中，'[[Noreturn]]'属性拼写已弃用；请改用'[[noreturn]]'"
+H584C1C164ECE: "在C23中，'[[Noreturn]]' 属性拼写已弃用；请改用 '[[noreturn]]'"
 # "the 'copyprivate' clause must not be used with the 'nowait' clause"
 H026F61D558F6: "'copyprivate' 子句不能与 'nowait' 子句一起使用"
 # "the 'static' modifier for the array size is not legal in new expressions"
@@ -27211,7 +27211,7 @@ H2951C6144658: '__block存储类型不允许使用'
 # 'the address of a declaration with unknown type can only be cast to a pointer type'
 H6D4B76B01E9C: '未知类型的声明的地址只能转换为指针类型'
 # "the argument '%0' is not supported for option '%1'. Mapping to '%1%2'"
-HA4EFCA49DC99: "选项 '%1' 不支持参数 '%0'。映射到'%1%2'"
+HA4EFCA49DC99: "选项 '%1' 不支持参数 '%0'。映射到 '%1%2'"
 # "the clang compiler does not support '%0'"
 HCB0DF6FD34A3: "clang编译器不支持 '%0'"
 # "the clang compiler does not support '%0' for C++ on Darwin/i386"
@@ -27219,7 +27219,7 @@ HAB9E0C38E134: "clang编译器在Darwin/i386的C++中不支持 '%0'"
 # "the clang compiler does not support '%0', %1"
 H70791B1776AF: "clang编译器不支持 '%0'，%1"
 # 'the clang compiler does not support -pg option on %select{Darwin|versions of OS X 10.9 and later}0'
-HEC221F97986E: 'clang编译器在%select{Darwin|OS X 10.9及更高版本}0上不支持-pg选项'
+HEC221F97986E: 'clang编译器在 %select{Darwin|OS X 10.9及更高版本}0上不支持-pg选项'
 # 'the clustering algorithm to use'
 HEE034B797939: '要使用的聚类算法'
 # "the combination of '%0' and '%1' is incompatible"
@@ -27269,13 +27269,13 @@ HE724FD8D9E24: '被忽略的标记一直延续到此处'
 # 'the implementation of header units is in an experimental phase'
 H822B183C153E: '头单元的实现尚处于实验阶段'
 # "the implicit output of reduced BMI may be overrided by the output file specified by '--precompile'. please consider use '-fmodule-output=' to specify the output file for reduced BMI explicitly"
-HC77BA90C9A9E: "简化的BMI的隐式输出可能被'--precompile'指定的输出文件覆盖。建议使用'-fmodule-output='显式指定简化的BMI的输出文件"
+HC77BA90C9A9E: "简化的BMI的隐式输出可能被 '--precompile' 指定的输出文件覆盖。建议使用 '-fmodule-output=' 显式指定简化的BMI的输出文件"
 # "the inscan reduction list item must appear as a list item in an 'inclusive' or 'exclusive' clause on an inner 'omp scan' directive"
-H5A6903CB5B88: "inscan缩减列表项必须出现在内部'omp scan'指令的 'inclusive' 或 'exclusive' 子句的列表项中"
+H5A6903CB5B88: "inscan缩减列表项必须出现在内部 'omp scan' 指令的 'inclusive' 或 'exclusive' 子句的列表项中"
 # "the last '/TC' or '/TP' option takes precedence over earlier instances"
-H1D4C07143ED6: "最后一个'/TC'或'/TP'选项覆盖前面的实例"
+H1D4C07143ED6: "最后一个 '/TC' 或 '/TP' 选项覆盖前面的实例"
 # "the library '%0=%1' is not supported, OpenMP will not be enabled"
-H8332E220148A: "库'%0=%1'不受支持，OpenMP将不会启用"
+H8332E220148A: "库 '%0=%1' 不受支持，OpenMP将不会启用"
 # "the list item must appear in 'reduction' clause with the 'inscan' modifier of the parent directive"
 H331559E5A96C: "列表项必须出现在父指令的 'reduction' 子句中带有 'inscan' 修饰符的位置"
 # 'the loop %select{initializer|condition}0 expression depends on the current loop control variable'
@@ -27293,7 +27293,7 @@ H205DE1F2F79F: '预处理器源标记的数量（%0）超过此限制（%1）'
 # 'the object size sanitizer has no effect at -O0, but is explicitly enabled: %0'
 H314C428C1C64: '对象大小检查器在-O0时无效，但被显式启用：%0'
 # "the option '-flto=thin' is a work in progress"
-H5F57C367214A: "选项'-flto=thin'尚在开发中"
+H5F57C367214A: "选项 '-flto=thin' 尚在开发中"
 # "the other acquisition of %0 '%1' is here"
 HF9475FC44959: "另一个对 %0 '%1' 的获取在此处"
 # 'the parameter for an explicitly-defaulted %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}0 may not be volatile'
@@ -27325,7 +27325,7 @@ HA6A6824B2746: "委托初始化调用的结果必须立即返回或赋值给 'se
 # 'the resulting value is always non-negative after implicit conversion'
 H9908ECBF3885: '隐式转换后的结果始终为非负值'
 # "the second argument of '-fpatchable-function-entry' must be smaller than the first argument"
-HEC0EC1D581E8: "参数'-fpatchable-function-entry'的第二个参数必须小于第一个参数"
+HEC0EC1D581E8: "参数 '-fpatchable-function-entry' 的第二个参数必须小于第一个参数"
 # "the selected code is not a part of a function's / method's body"
 H09129ED39DF9: '所选代码不属于某个函数/方法的主体部分'
 # 'the selected expression cannot be extracted'
@@ -27351,13 +27351,13 @@ H09C6A6DB560B: "'atomic compare capture' 的语句必须是以下形式的复合
 # "the statement for 'atomic compare' must be a compound statement of form '{x = expr ordop x ? expr : x;}', '{x = x ordop expr? expr : x;}', '{x = x == e ? d : x;}', '{x = e == x ? d : x;}', or 'if(expr ordop x) {x = expr;}', 'if(x ordop expr) {x = expr;}', 'if(x == e) {x = d;}', 'if(e == x) {x = d;}' where 'x' is an lvalue expression with scalar type, 'expr', 'e', and 'd' are expressions with scalar type, and 'ordop' is one of '<' or '>'"
 H4091D9BED6D2: "'atomic compare' 的语句必须是以下形式的复合语句：'{x = expr ordop x ? expr : x;}'、'{x = x ordop expr ? expr : x;}'、'{x = x == e ? d : x;}'、'{x = e == x ? d : x;}' 或 'if(expr ordop x) {x = expr;}'、'if(x ordop expr) {x = expr;}'、'if(x == e) {x = d;}'、'if(e == x) {x = d;}'，其中 'x' 是标量类型左值表达式，'expr'、'e'、'd' 是标量类型表达式，'ordop' 是 '<' 或 '>' 中的一个"
 # "the statement for 'atomic read' must be an expression statement of form 'v = x;', where v and x are both lvalue expressions with scalar type"
-HDAD21CA5AD66: "'atomic update'的语句必须是形式为'++x;'等的表达式语句"
+HDAD21CA5AD66: "'atomic update' 的语句必须是形式为 '++x;' 等的表达式语句"
 # "the statement for 'atomic update' must be an expression statement of form '++x;', '--x;', 'x++;', 'x--;', 'x binop= expr;', 'x = x binop expr' or 'x = expr binop x', where x is an lvalue expression with scalar type"
-H106E8810ABCE: "'atomic write'的语句必须是形式为'x = expr;'的表达式语句"
+H106E8810ABCE: "'atomic write' 的语句必须是形式为 'x = expr;' 的表达式语句"
 # "the statement for 'atomic write' must be an expression statement of form 'x = expr;', where x is a lvalue expression with scalar type"
-HAEE051C701D8: "用于'atomic write'的语句必须是形式为'x = expr;'的表达式语句，其中x是标量类型的左值表达式"
+HAEE051C701D8: "用于 'atomic write' 的语句必须是形式为 'x = expr;' 的表达式语句，其中x是标量类型的左值表达式"
 # "the statement for 'atomic' must be an expression statement of form '++x;', '--x;', 'x++;', 'x--;', 'x binop= expr;', 'x = x binop expr' or 'x = expr binop x', where x is an lvalue expression with scalar type"
-H182C909CFBBD: "用于 'atomic' 的语句必须是形式为'++x;'、'--x;'、'x++;'、'x--;'、'x binop= expr;'、'x = x binop expr'或'x = expr binop x'的表达式语句，其中x是标量类型的左值表达式"
+H182C909CFBBD: "用于 'atomic' 的语句必须是形式为 '++x;'、'--x;'、'x++;'、'x--;'、'x binop= expr;'、'x = x binop expr' 或 'x = expr binop x' 的表达式语句，其中x是标量类型的左值表达式"
 # "the target architecture '%0' is not supported by the target '%1'"
 H9EB5284C09D2: "目标架构 '%0' 不受目标 '%1' 支持"
 # 'the total number of preprocessor source tokens (%0) exceeds the token limit (%1)'
@@ -27369,7 +27369,7 @@ H462F56962031: '类型 %0 已经显式具有所有权限定符'
 # 'the type %0 is not a pointer to a fast-enumerable object'
 HF043D197C95F: '类型 %0 不是指向快速可枚举对象的指针'
 # 'the type of object expression %diff{($) does not match the type being destroyed ($)|does not match the type being destroyed}0,1 in pseudo-destructor expression'
-HF8245CD4DD36: '对象表达式%diff{($)的类型与伪析构表达式中正在销毁的类型($)|不匹配}0,1'
+HF8245CD4DD36: '对象表达式 %diff{($)的类型与伪析构表达式中正在销毁的类型($)|不匹配}0,1'
 # 'the type of the explicit object parameter of an explicitly-defaulted %select{copy|move}0 assignment operator should be reference to %1'
 H48B3F2D609BF: '显式默认的%select{拷贝|移动}0赋值运算符的显式对象参数类型应为 %1 的引用'
 # 'the user condition in the OpenMP context selector needs to be constant; %0 is not'
@@ -27385,7 +27385,7 @@ HB24B6E1BF839: 'vecreturn属性只能用于POD（普通旧数据）类或结构�
 # 'the vecreturn attribute can only be used on a class or structure with one member, which must be a vector'
 H91431B029CC5: 'vecreturn属性只能用于包含一个成员的类或结构体，该成员必须是向量类型'
 # "the warning option '-%0' is not supported"
-H961C96696067: "警告选项'-%0'不受支持"
+H961C96696067: "警告选项 '-%0' 不受支持"
 # 'there is no external assembler that can be used on this platform'
 H36CA569B9742: '当前平台没有可用的外部汇编器'
 # 'there is no symbol at the given location'
@@ -27399,7 +27399,7 @@ HC0C706B2D8E7: '此内建函数仅在 64 位目标平台上可用'
 # 'this builtin is only available on x86-64 and aarch64 targets'
 H81BF150D8949: '此内建函数仅在x86-64和aarch64目标平台上可用'
 # "this builtin requires 'dsp r2' ASE, please use -mdspr2"
-HF59F7FBACC6E: "此内建函数需要'dsp r2' ASE，请使用-mdspr2选项"
+HF59F7FBACC6E: "此内建函数需要 'dsp r2' ASE，请使用-mdspr2选项"
 # "this builtin requires 'dsp' ASE, please use -mdsp"
 H2B317AB4FDC4: "此内建函数需要 'dsp' ASE，请使用-mdsp选项"
 # "this builtin requires 'msa' ASE, please use -mmsa"
@@ -27409,7 +27409,7 @@ H6643558E97E9: '此内建函数需要ABI -mabi=%0'
 # 'this coroutine may be split into pieces; not every piece is guaranteed to be inlined'
 HEF5E3EA3F783: '此协程可能被拆分为多个部分；并非每个部分都能保证被内联'
 # "this declaration is not a prototype; add %select{'void'|parameter declarations}0 to make it %select{a prototype for a zero-parameter function|one}0"
-HDD90A70940A7: '此声明不是函数原型；请添加%select{void|参数声明}0使其成为%select{一个无参数函数的原型|一个}0'
+HDD90A70940A7: '此声明不是函数原型；请添加 %select{void|参数声明}0使其成为%select{一个无参数函数的原型|一个}0'
 # 'this expression will be parsed as explicit(bool) in C++20'
 HE2974A48FA92: '在C++20中，此表达式将被视为显式(bool)转换'
 # 'this function cannot be a coroutine: %0 is an incomplete type'
@@ -27417,13 +27417,13 @@ HEB887A198DFF: '此函数不能是协程：%0 是一个不完整类型'
 # 'this function cannot be a coroutine: %0 is not a class'
 HF896DD5CD9DB: '此函数不能是协程：%0 不是一个类'
 # "this function cannot be a coroutine: %q0 has no member named 'promise_type'"
-HAD42B5488901: '此函数不能是协程：%q0 没有名为"promise_type"的成员'
+HAD42B5488901: '此函数不能是协程：%q0 没有名为 "promise_type" 的成员'
 # 'this function cannot be a coroutine: missing definition of specialization %0'
 HFC5D41C5C0FA: '此函数不能是协程：缺少特化定义 %0'
 # 'this is generally caused by modules with the same name found in multiple paths'
 HB435423839CE: '这通常是由多个路径下找到同名模块所导致的'
 # 'this placement new expression is not supported in constant expressions %select{|before C++2c}0'
-HFED2CB8F9A5D: '在常量表达式中不支持此placement new表达式%select{|在C++2c之前}0'
+HFED2CB8F9A5D: '在常量表达式中不支持此placement new表达式 %select{|在C++2c之前}0'
 # 'this pragma cannot appear in %0 declaration'
 HCE58A657A4E9: '此#pragma不能出现在 %0 声明中'
 # 'this style of line directive is a GNU extension'
@@ -27477,11 +27477,11 @@ H17EA53E3423A: '记录ICF步骤的时间'
 # "timed out waiting to acquire lock file for module '%0'"
 HD7ADFA168199: "等待获取模块 '%0' 的锁文件超时"
 # 'tls_model must be "global-dynamic", "local-dynamic", "initial-exec" or "local-exec"'
-H2BCDC88FA47E: 'tls_model必须是"global-dynamic"、"local-dynamic"、"initial-exec"或"local-exec"'
+H2BCDC88FA47E: 'tls_model必须是 "global-dynamic"、"local-dynamic"、"initial-exec" 或 "local-exec"'
 # 'to match this %0'
 HDA13A5D2D868: '与这个 %0 匹配'
 # "to match this ']'"
-HEF9A1EC0D665: "与这个']'匹配"
+HEF9A1EC0D665: "与这个 ']' 匹配"
 # "to match this '{'"
 H013B6E508561: "以匹配这个 '{'"
 # 'token is not a valid binary operator in a preprocessor subexpression'
@@ -27501,13 +27501,13 @@ HF6BA10037D33: '调用 %select{函数|代码块|方法|内核函数}0 时，%sel
 # 'too few %select{|||execution configuration }0%select{|non-object }2arguments to %select{function|block|method|kernel function}0 call, single argument %1 was not specified'
 H9CA8A408A5C7: '调用 %select{函数|代码块|方法|内核函数}0 时，%select{|||执行配置 }0%select{|非对象 }2参数不足，单个参数 %1 未指定'
 # 'too few %select{|||execution configuration }0%select{|non-object }3arguments to %select{function|block|method|kernel function}0 call, expected %1, have %2'
-H5939FAB31ED6: '调用%select{函数|块|方法|内核函数}0时%select{|||执行配置 }0%select{|非对象 }3参数太少，期望 %1，实际 %2'
+H5939FAB31ED6: '调用%select{函数|块|方法|内核函数}0时 %select{|||执行配置 }0%select{|非对象 }3参数太少，期望 %1，实际 %2'
 # 'too few %select{|||execution configuration }0%select{|non-object }3arguments to %select{function|block|method|kernel function}0 call, expected %1, have %2; did you mean %4?'
-HF20F679C52F2: '调用%select{函数|块|方法|内核函数}0时%select{|||执行配置 }0%select{|非对象 }3参数太少，期望 %1，实际 %2；您是否是指 %4？'
+HF20F679C52F2: '调用%select{函数|块|方法|内核函数}0时 %select{|||执行配置 }0%select{|非对象 }3参数太少，期望 %1，实际 %2；您是否是指 %4？'
 # 'too few %select{|||execution configuration }0%select{|non-object }3arguments to %select{function|block|method|kernel function}0 call, expected at least %1, have %2'
-HD24171A04B0B: '调用%select{函数|块|方法|内核函数}0时%select{|||执行配置 }0%select{|非对象 }3参数太少，期望至少 %1，实际 %2'
+HD24171A04B0B: '调用%select{函数|块|方法|内核函数}0时 %select{|||执行配置 }0%select{|非对象 }3参数太少，期望至少 %1，实际 %2'
 # 'too few %select{|||execution configuration }0%select{|non-object }3arguments to %select{function|block|method|kernel function}0 call, expected at least %1, have %2; did you mean %4?'
-HD3BBC6D9EFC0: '调用%select{函数|块|方法|内核函数}0时%select{|||执行配置 }0%select{|非对象 }3参数太少，期望至少 %1，实际 %2；您是否是指 %4？'
+HD3BBC6D9EFC0: '调用%select{函数|块|方法|内核函数}0时 %select{|||执行配置 }0%select{|非对象 }3参数太少，期望至少 %1，实际 %2；您是否是指 %4？'
 # 'too few arguments provided to function-like macro invocation'
 H1E346A7B8B3C: '函数式宏调用提供的参数太少'
 # 'too many %select{|||execution configuration }0%select{|non-object }3arguments to %select{function|block|method|kernel function}0 call, expected %1, have %2'
@@ -27525,13 +27525,13 @@ HDAC13624D426: '对 %select{函数|代码块|方法|内核函数}0 的调用参�
 # 'too many arguments provided to function-like macro invocation'
 HBB5E8EFBFD08: '提供给函数式宏调用的参数过多'
 # 'too many braces around %select{scalar |}0initializer'
-H5C95D607138A: '在%select{标量 |}0初始化器周围有过多的花括号'
+H5C95D607138A: '在%select{标量 |}0 初始化器周围有过多的花括号'
 # 'too many errors emitted, stopping now'
 H208E3BCCF078: '报告了过多的错误，现在停止'
 # 'too many function parameters; subsequent parameters will be ignored'
 H803517A338E0: '函数参数过多；后续参数将被忽略'
 # "too many parameters (%0) for 'main': must be 0, 2, or 3"
-H39E16B39631F: "'main' 函数的参数过多（%0）：必须为 0、2或 3 "
+H39E16B39631F: "'main' 函数的参数过多（%0）：必须为 0、2或 3"
 # 'tool-template options'
 HBCF3F3069BB4: 'tool-template 选项'
 # 'top-level comma expression in array subscript is deprecated in C++20 and unsupported in C++23'
@@ -27573,7 +27573,7 @@ H0FA024F7C782: "在C++模式下将 '%0' 输入视为 '%1'，此行为已弃用"
 # 'treating Ctrl-Z as end-of-file is a Microsoft extension'
 H2B9F3B693225: '将Ctrl-Z视为文件结束符是Microsoft扩展'
 # "treating Unicode character <U+%0> as an identifier character rather than as '%1' symbol"
-H50914464E633: "将Unicode字符<U+%0>视为标识符字符而不是 '%1' 符号"
+H50914464E633: "将Unicode字符 <U+%0> 视为标识符字符而不是 '%1' 符号"
 # 'treating Unicode character as whitespace'
 HF7B2E2527DE4: '将Unicode字符视为空白符'
 # "trigraph converted to '%0' character"
@@ -27585,7 +27585,7 @@ H1C535A7D3139: '忽略三元组'
 # 'trust the input to be from a well-formed source'
 H9D6FAC2CFAB6: '信任输入来自格式正确的源'
 # "try 'match(%0={%1%2})'"
-H766B462800CF: "尝试'match(%0={%1%2})'"
+H766B462800CF: "尝试 'match(%0={%1%2})'"
 # 'try to preserve basic block alignment'
 H8B07C548FF85: '尽量保留基本块的对齐'
 # 'trying to recursively use %0 as superclass of %1'
@@ -27601,9 +27601,9 @@ HA66630D471E5: '类型 %0 在初始化列表中无法缩小为 %1'
 # 'type %0 cannot be narrowed to %1 in initializer list in C++11'
 H121C0CF66257: '类型 %0 在C++11的初始化列表中无法缩小为 %1'
 # "type %0 cannot be used prior to '::' because it has no members"
-HB29A2AE6A5EB: "类型 %0 在'::'之前无法使用，因为它没有成员"
+HB29A2AE6A5EB: "类型 %0 在 '::' 之前无法使用，因为它没有成员"
 # 'type %0 decomposes into %3 %plural{1:element|:elements}2, but %select{%plural{0:no|:only %1}1|%1}4 %plural{1:name was|:names were}1 provided'
-HF59CA2FD696F: '类型 %0 分解为 %3 %plural{1:元素|:元素}2，但%select{%plural{0:没有提供|:只提供 %1}1|%1}4 %plural{1:名字|:名字}1'
+HF59CA2FD696F: '类型 %0 分解为 %3 %plural{1:元素|:元素}2，但 %select{%plural{0:没有提供|:只提供 %1}1|%1}4 %plural{1:名字|:名字}1'
 # 'type %0 does not provide a %select{subscript|call}1 operator'
 HCAF6714D32F7: '类型 %0 未提供 %select{subscript|call}1 运算符'
 # 'type %0 found by destructor name lookup'
@@ -27669,11 +27669,11 @@ H51291DDF6B58: 'constexpr %select{函数|构造函数}0 中的类型定义与C++
 # 'type inference of a declaration other than a plain identifier with optional trailing attributes is a Clang extension'
 HB4EF9FC7F52F: '非普通标识符（可带尾置属性）的类型推导是Clang扩展'
 # 'type is given name %0 for linkage purposes by this %select{typedef|alias}1 declaration'
-HFEABA5A13E20: '此%select{typedef|别名}1声明为链接目的将类型命名为 %0'
+HFEABA5A13E20: '此 %select{typedef|别名}1声明为链接目的将类型命名为 %0'
 # 'type is not C-compatible due to this %select{base class|default member initializer|lambda expression|friend declaration|member declaration}0'
 H8BEB926AC2A7: '由于以下%select{基类|默认成员初始化器|lambda表达式|友元声明|成员声明}0，类型不兼容C兼容'
 # 'type name does not allow %select{<ERROR>|constexpr|consteval|constinit}0 specifier to be specified'
-H2BAC4BD9B411: '类型名称不允许指定%select{<ERROR>|constexpr|consteval|constinit}0说明符'
+H2BAC4BD9B411: '类型名称不允许指定 %select{<ERROR>|constexpr|consteval|constinit}0 说明符'
 # 'type name does not allow function specifier to be specified'
 H63933758FA41: '类型名称不允许指定函数说明符'
 # 'type name does not allow storage class to be specified'
@@ -27719,7 +27719,7 @@ H4B268E82A57A: "缺少类型说明符，缺省为 'int'"
 # "type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int"
 H8CEE1B0F6CB9: "缺少类型说明符，缺省为 'int'; ISO C99 及后续标准不支持隐式 int"
 # 'type trait requires %0%select{| or more}1 argument%select{|s}2; have %3 argument%s3'
-H5F2DEBC2DD6F: '类型特征需要 %0%select{|或更多}1 参数%select{|s}2；但提供了 %3 参数%s3'
+H5F2DEBC2DD6F: '类型特征需要 %0%select{|或更多}1 参数 %select{|s}2；但提供了 %3 参数%s3'
 # 'type was declared read-only here'
 HAFE8C580C1C1: '类型在此处被声明为只读'
 # 'type-id cannot have a name'
@@ -27835,7 +27835,7 @@ H76DFE4FB888F: '未声明的选择器 %0'
 # 'undeclared selector %0; did you mean %1?'
 HFF50CB7951F9: '未声明的选择器 %0；是否是指 %1？'
 # "undeclared variable %0 used as an argument for '#pragma unused'"
-H1A926D40EA78: "未声明的变量 %0 被用作'#pragma unused'的参数"
+H1A926D40EA78: "未声明的变量 %0 被用作 '#pragma unused' 的参数"
 # 'undef all system defines'
 H5E817AACEB7A: '取消定义所有系统宏定义'
 # 'undefining builtin macro'
@@ -27845,23 +27845,23 @@ H677A6074184D: '在-fcoro-aligned-allocation下，承诺类型 %0 的非对齐�
 # 'underaligned exception object thrown'
 H67F3421C41BE: '抛出未对齐的异常对象'
 # "unelaborated friend declaration is a C++11 extension; specify '%select{struct|interface|union|class|enum}0' to befriend %1"
-H85486A35A143: "未详细声明的友元声明是C++11扩展；请指定'%select{struct|interface|union|class|enum}0'来与 %1 建立友元关系"
+H85486A35A143: "未详细声明的友元声明是C++11扩展；请指定 '%select{struct|interface|union|class|enum}0' 来与 %1 建立友元关系"
 # 'unexpected %0 in function call; perhaps remove the %0?'
 HF91D5DDAC941: '函数调用中出现意外的 %0；是否需要移除 %0？'
 # "unexpected %0, expected to see one of %select{|'best_case', 'full_generality', }1'single_inheritance', 'multiple_inheritance', or 'virtual_inheritance'"
-H715E4C7A8362: "意外的 %0，期望看到%select{|'best_case', 'full_generality', }1'single_inheritance', 'multiple_inheritance' 或 'virtual_inheritance' 之一"
+H715E4C7A8362: "意外的 %0，期望看到 %select{|'best_case', 'full_generality', }1'single_inheritance', 'multiple_inheritance' 或 'virtual_inheritance' 之一"
 # "unexpected '#pragma acc ...' in program"
-H1E1E01704393: "程序中出现意外的'#pragma acc ...'"
+H1E1E01704393: "程序中出现意外的 '#pragma acc ...'"
 # "unexpected '#pragma omp ...' in program"
-H46D7021997C2: "程序中出现意外的'#pragma omp ...'"
+H46D7021997C2: "程序中出现意外的 '#pragma omp ...'"
 # "unexpected '%0' clause, '%1' is specified already"
 H5B200478E6AE: "意外的 '%0' 子句，'%1' 已被指定"
 # "unexpected '%0' clause, only %select{'device_type'|'enter' or 'link'|'enter', 'link' or 'device_type'|'device_type', 'indirect'|'enter', 'link', 'device_type' or 'indirect'}1 clauses expected"
-H3763BE9D9C9F: "意外的 '%0' 子句，仅允许%select{'device_type'|'enter' 或 'link'|'enter', 'link' 或 'device_type'|'device_type', 'indirect'|'enter', 'link', 'device_type' 或 'indirect'}1子句"
+H3763BE9D9C9F: "意外的 '%0' 子句，仅允许 %select{'device_type'|'enter' 或 'link'|'enter', 'link' 或 'device_type'|'device_type', 'indirect'|'enter', 'link', 'device_type' 或 'indirect'}1 子句"
 # "unexpected '%0' clause, only %select{'device_type'|'to' or 'link'|'to', 'link' or 'device_type'|'device_type', 'indirect'|'to', 'link', 'device_type' or 'indirect'}1 clauses expected"
-H1A9F6651CC12: "意外的 '%0' 子句，仅期望%select{'device_type'|'to' 或 'link'|'to', 'link' 或 'device_type'|'device_type', 'indirect'|'to', 'link', 'device_type' 或 'indirect'}1子句"
+H1A9F6651CC12: "意外的 '%0' 子句，仅期望 %select{'device_type'|'to' 或 'link'|'to', 'link' 或 'device_type'|'device_type', 'indirect'|'to', 'link', 'device_type' 或 'indirect'}1 子句"
 # "unexpected '(', only 'to', 'link' or 'device_type' clauses expected for 'begin declare target' directive"
-H5361030EF185: "在'begin declare target'指令中，'('意外，仅期望 'to'、'link' 或 'device_type' 子句"
+H5361030EF185: "在 'begin declare target' 指令中，'(' 意外，仅期望 'to'、'link' 或 'device_type' 子句"
 # "unexpected ':' in nested name specifier; did you mean '::'?"
 HC8B611B07937: "嵌套名称限定符中的意外 ':'，您是否想输入 '::'？"
 # "unexpected ';' before %0"
@@ -27883,13 +27883,13 @@ H1C5752C27ACF: "在指令 '#pragma omp %1' 中，OpenMP 子句 '%0' 意外"
 # "unexpected OpenMP directive %select{|'#pragma omp %1'}0"
 HEF8086A19118: "意外的 OpenMP 指令 %select{|'#pragma omp %1'}0"
 # "unexpected argument '%0' to '#pragma %1'%select{|; expected %3}2"
-HB8C385DE07A5: "对'#pragma %1'的意外参数 '%0'%select{|；期望 %3}"
+HB8C385DE07A5: "对 '#pragma %1' 的意外参数 '%0'%select{|；期望 %3}"
 # "unexpected argument '%0' to '#pragma clang attribute'; expected 'push' or 'pop'"
-H3133E5143B09: "对'#pragma clang attribute'的意外参数 '%0'；期望 'push' 或 'pop'"
+H3133E5143B09: "对 '#pragma clang attribute' 的意外参数 '%0'；期望 'push' 或 'pop'"
 # "unexpected argument '%0' to '#pragma clang fp %1'; expected %select{'fast' or 'on' or 'off'|'on' or 'off'|'on' or 'off'|'ignore', 'maytrap' or 'strict'|'source', 'double' or 'extended'}2"
-H371571C43BD4: "对'#pragma clang fp %1'的意外参数 '%0'；期望%select{'fast' 或 'on' 或 'off'|'on' 或 'off'|'on' 或 'off'|'ignore', 'maytrap' 或 'strict'|'source', 'double' 或 'extended'}2"
+H371571C43BD4: "对 '#pragma clang fp %1' 的意外参数 '%0'；期望 %select{'fast' 或 'on' 或 'off'|'on' 或 'off'|'on' 或 'off'|'ignore', 'maytrap' 或 'strict'|'source', 'double' 或 'extended'}2"
 # "unexpected argument '%0' to '#pragma clang optimize'; expected 'on' or 'off'"
-H1485FAA86056: "对'#pragma clang optimize'的意外参数 '%0'；期望 'on' 或 'off'"
+H1485FAA86056: "对 '#pragma clang optimize' 的意外参数 '%0'；期望 'on' 或 'off'"
 # 'unexpected argument to debug command'
 H3827CC068DE1: '调试命令的意外参数'
 # 'unexpected character <U+%0>'
@@ -27973,7 +27973,7 @@ H38343641D115: '通用字符名引用了代理字符'
 # 'universal character names are only valid in C99 or C++'
 H6C064E2FEAA1: '通用字符名仅在C99或C++中有效'
 # "universal character names are only valid in C99 or C++; treating as '\\' followed by identifier"
-H57AF83D90AE3: "通用字符名仅在C99或C++中有效；将其视为反斜杠'\\'后接标识符"
+H57AF83D90AE3: "通用字符名仅在C99或C++中有效；将其视为反斜杠 '\\' 后接标识符"
 # "unknown %0 warning specifier: '%1'"
 HE021FCA9FD45: "未知的 %0 警告说明符: '%1'"
 # 'unknown %select{type|class}1 name %0; did you mean %2?'
@@ -28127,7 +28127,7 @@ H2798CD78D9FC: '不支持的组合：CC_PRINT_HEADERS_FORMAT=%0 和 CC_PRINT_HEA
 # 'unsupported expression with unknown type'
 H3F334416D50C: '包含未知类型的表达式'
 # 'unsupported inline asm: input with type %diff{$ matching output with type $|}0,1'
-HA68AF7F61C41: '不支持的内联汇编：类型%diff{$与输出类型匹配的$|}0,1输入'
+HA68AF7F61C41: '不支持的内联汇编：类型 %diff{$与输出类型匹配的$|}0,1 输入'
 # 'unsupported non-standard concatenation of string literals'
 H5B7E63184569: '不支持的非标准字符串字面量连接'
 # "unsupported option '%0'"
@@ -28483,7 +28483,7 @@ HA2145EBF1AF4: '在二进制中使用重定位信息（默认=自动检测）'
 # 'use same count for BBs that should have equivalent count (used in non-LBR and shrink wrapping)'
 H2FCA1FC45D12: '为应具有等效计数的BB块使用相同计数（用于非LBR和收缩包装场景）'
 # "use same version number separators '_' or '.'; as in 'major[.minor[.subminor]]'"
-H152CFF6748B3: "请使用相同的版本号分隔符 '_' 或'.'，例如'major[.minor[.subminor]]'"
+H152CFF6748B3: "请使用相同的版本号分隔符 '_' 或 '.'，例如 'major[.minor[.subminor]]'"
 # 'use short granules in allocas and outlined checks'
 H1D7871DD27F1: '在allocas和分离检查中使用短粒度'
 # 'use strict dwarf'
@@ -28509,7 +28509,7 @@ H46DF1623ED73: '此处使用类型 %0，但需要整数或浮点类型'
 # 'used%select{| in pointer arithmetic| in buffer access}0 here'
 H2D0FA9F859F9: '此处%select{使用|在指针运算中使用|在缓冲区访问中使用}0'
 # "user-defined literal suffixes %select{<ERROR>|not starting with '_'|containing '__'}0 are reserved%select{; no literal will invoke this operator|}1"
-H414028466FC2: '用户定义的字面量后缀%select{<ERROR>|不以"_"开头|包含"__"}0是保留的%select{；没有字面量会调用此运算符|}1'
+H414028466FC2: '用户定义的字面量后缀 %select{<ERROR>|不以 "_" 开头|包含 "__"}0 是保留的%select{；没有字面量会调用此运算符|}1'
 # 'using'
 H92BD75EBD8FD: '使用'
 # 'using %0 directive in %select{NSString|CFString}1 which is being passed as a formatting argument to the formatting %select{method|CFfunction}2'
@@ -28519,9 +28519,9 @@ HA26F40AA0176: '与字面量一起使用 %0 是多余的'
 # 'using %select{integer|floating point|complex}1 absolute value function %0 when argument is of %select{integer|floating point|complex}2 type'
 H2A1C61EF88A1: '当参数为%select{整数|浮点|复数}2类型时，使用%select{整数|浮点|复数}1类型的绝对值函数 %0'
 # "using '%%P' format specifier with an Objective-C pointer results in dumping runtime object structure, not object value"
-H513C1ECC12E7: '在Objective-C指针中使用"%%P"格式说明符会导致转储运行时对象结构，而不是对象值'
+H513C1ECC12E7: '在Objective-C指针中使用 "%%P" 格式说明符会导致转储运行时对象结构，而不是对象值'
 # "using '%%P' format specifier without precision"
-HE89A56274479: '未指定精度时使用"%%P"格式说明符'
+HE89A56274479: '未指定精度时使用 "%%P" 格式说明符'
 # "using '%0' format specifier annotation outside of os_log()/os_trace()"
 H2CE6DDE79E74: '在os_log()/os_trace()之外使用 "%0" 格式说明符注释'
 # "using '%0' format specifier, but argument has boolean value"
@@ -28557,7 +28557,7 @@ H435B6D84F0D6: 'using声明引用其自身类'
 # 'using declaration requires a qualified name'
 H9CE75E7C4CF5: 'using声明需要限定名称'
 # "using directive refers to implicitly-defined namespace 'std'"
-H5C8831D062A8: 'using指令引用隐式定义的命名空间"std"'
+H5C8831D062A8: 'using指令引用隐式定义的命名空间 "std"'
 # 'using enum %select{requires an enum or typedef name|does not permit an elaborated enum specifier}0'
 H07DCC7345590: '使用枚举%select{需要枚举或typedef名称|不允许使用扩展的枚举说明符}0'
 # 'using enum declaration is a C++20 extension'
@@ -28575,7 +28575,7 @@ HD808A1E3A9FB: '将赋值表达式的结果用作条件时未使用括号'
 # 'using the undeclared type %0 as a default template argument is a Microsoft extension'
 H9BAAEE7535FA: '将未声明的类型 %0 作为默认模板参数是Microsoft扩展'
 # 'using unversioned Android target directory %0 for target %1; unversioned directories will not be used in Clang 19 -- provide a versioned directory for the target version or lower instead'
-H120D3110B47A: '为目标 %1 使用未版本化的Android目标目录 %0；Clang 19将不再使用未版本化的目录——请为对应版本提供版本化的目录或使用更低版本'
+H120D3110B47A: '为目标 %1 使用未版本化的Android目标目录 %0；Clang 19 将不再使用未版本化的目录——请为对应版本提供版本化的目录或使用更低版本'
 # 'using-enum cannot name a dependent type'
 H3DC57F2168E8: 'using-enum不能命名一个相关依赖类型'
 # 'usual LSP protocol'
@@ -28623,7 +28623,7 @@ H9648530537F2: '具有推导类型 %1 的变量 %0 不能出现在自身的初�
 # 'variable %0 is %select{decremented|incremented}1 both in the loop header and in the loop body'
 H5880C36D679C: '变量 %0 在循环头和循环体中均被%select{递减|递增}1'
 # "variable %0 is %select{used|captured}1 uninitialized whenever %select{'%3' condition is %select{true|false}4|'%3' loop %select{is entered|exits because its condition is false}4|'%3' loop %select{condition is true|exits because its condition is false}4|switch %3 is taken|its declaration is reached|%3 is called}2"
-H5B3E786190C7: "当%select{'%3' 条件%select{为真|为假}4|'%3' 循环%select{被进入|因条件为假退出}4|'%3' 循环%select{条件为真|因条件为假退出}4|switch %3 被选中|其声明被访问|%3 被调用}2时，变量 %0 在%select{使用|被捕获}1时未初始化"
+H5B3E786190C7: "当 %select{'%3' 条件%select{为真|为假}4|'%3' 循环%select{被进入|因条件为假退出}4|'%3' 循环%select{条件为真|因条件为假退出}4|switch %3 被选中|其声明被访问|%3 被调用}2时，变量 %0 在%select{使用|被捕获}1时未初始化"
 # 'variable %0 is declared here'
 H9C1D29CE922D: '变量 %0 在此处声明'
 # 'variable %0 is uninitialized when %select{used here|captured by block}1'
@@ -28633,7 +28633,7 @@ H12F79B618200: '变量 %0 在作为常量引用参数传递时未初始化'
 # 'variable %0 is uninitialized when used within its own initialization'
 H9B3210B51205: '变量 %0 在自身初始化过程中使用时未初始化'
 # 'variable %0 is%select{| explicitly}1 captured here'
-HC5A87C36FF05: '变量 %0%select{被显式|}1在此处捕获'
+HC5A87C36FF05: '变量 %0%select{被显式|}1 在此处捕获'
 # 'variable %0 may be uninitialized when %select{used here|captured by block}1'
 HC0A7D9F9078D: '变量 %0 可能在%select{此处使用时|被捕获到块中时}1时未初始化'
 # 'variable %0 must have explicitly specified data sharing attributes'
@@ -28649,7 +28649,7 @@ HECE6754B3154: '类型为 %1 的变量 %0 具有类型 %2 的不兼容初始值'
 # 'variable %0 with unknown type cannot be given a function type'
 HBD6B0E34602F: '类型未知的变量 %0 不能被赋予函数类型'
 # "variable %select{|in unary expression|on right hand side of assignment|on left hand side of assignment|on left hand side of compound assignment|on left hand side of assignment}2('%3') must match variable used %select{|in unary expression|on right hand side of assignment|<not possible>|on left hand side of compound assignment|on left hand side of assignment}0('%1') from the first statement"
-H68D8E5C8B649: "在%select{|单目表达式中|赋值语句右侧|赋值语句左侧|复合赋值语句左侧|赋值语句左侧}2的变量 '%3' 必须与第一条语句中%select{|单目表达式使用的|赋值右侧使用的|<不可用>|复合赋值左侧使用的|赋值左侧使用的}0的变量 '%1' 保持一致"
+H68D8E5C8B649: "在 %select{|单目表达式中|赋值语句右侧|赋值语句左侧|复合赋值语句左侧|赋值语句左侧}2的变量 '%3' 必须与第一条语句中 %select{|单目表达式使用的|赋值右侧使用的|<不可用>|复合赋值左侧使用的|赋值左侧使用的}0的变量 '%1' 保持一致"
 # 'variable already marked as mapped in current construct'
 HA15930719644: '变量已在当前上下文中被标记为映射'
 # "variable appearing in '%0' clause of OpenACC 'declare' directive must be in the same scope as the directive"
@@ -28657,7 +28657,7 @@ H32CD6FB44C7B: "在OpenACC 'declare' 指令的 '%0' 子句中出现的变量必�
 # "variable can appear only once in OpenMP '%0' clause"
 H084B181F0F6F: "OpenMP '%0' 子句中的变量只能出现一次"
 # "variable can appear only once in OpenMP 'target update' construct"
-H78D2AF4A7A62: "OpenMP 'target update'构造中的变量只能出现一次"
+H78D2AF4A7A62: "OpenMP 'target update' 构造中的变量只能出现一次"
 # 'variable captured in declare target region must appear in a to clause'
 H2004C3E36B6D: '在declare target区域捕获的变量必须出现在to子句中'
 # 'variable declaration in a constexpr %select{function|constructor}0 is a C++14 extension'
@@ -28705,7 +28705,7 @@ H50B2A4B545B7: '当前目标不支持可变长数组'
 # 'variable length arrays are not supported in OpenCL'
 H201996231D1A: 'OpenCL中不支持可变长数组'
 # "variable length arrays are not supported in OpenMP tasking regions with 'untied' clause"
-H20FB8AB94029: '在带有"untied"子句的OpenMP任务区域中不支持可变长数组'
+H20FB8AB94029: '在带有 "untied" 子句的OpenMP任务区域中不支持可变长数组'
 # 'variable length arrays in C++ are a Clang extension'
 HCD7C2CD01723: 'C++中的可变长数组是Clang扩展'
 # "variable length arrays in C++ are a Clang extension; did you mean to use 'static_assert'?"
@@ -28719,7 +28719,7 @@ H38BA25ED2BA1: "具有外部链接的名为 'main' 的变量具有未定义行�
 # 'variable of non-literal type %1 cannot be defined in a constexpr %select{function|constructor}0 before C++23'
 H5F89C6201D7E: '非字面类型 %1 的变量在C++23之前不能在constexpr %select{函数|构造函数}0中定义'
 # "variable of non-reference type %0 can be used only with 'val' modifier, but used with '%1'"
-HFF57CDDBE63D: '非引用类型 %0 的变量只能与"val"修饰符一起使用，但实际使用了 "%1"'
+HFF57CDDBE63D: '非引用类型 %0 的变量只能与 "val" 修饰符一起使用，但实际使用了 "%1"'
 # 'variable of type %1 has %select{private|protected}2 destructor'
 H8BC8C9632B1A: '类型 %1 的变量具有 %select{private|protected}2 访问权限的析构函数'
 # "variable referenced by 'link' clause not in global or namespace scope must be marked 'extern'"
@@ -28755,9 +28755,9 @@ H0326E5892284: '不允许在文件作用域中声明可变修改类型'
 # 'variably-modified type %0 cannot be used in a constexpr %select{function|constructor}1'
 HA78DFABA86CF: '可变修改类型 %0 不能在constexpr %select{函数|构造函数}1中使用'
 # "variadic 'friend' declarations are a C++2c extension"
-H3D2FFF66A145: '可变参数的"friend"声明是C++2c的扩展'
+H3D2FFF66A145: '可变参数的 "friend" 声明是C++2c的扩展'
 # "variadic 'friend' declarations are incompatible with C++ standards before C++2c"
-H365CB532BF3E: '可变参数的"friend"声明与C++2c之前的C++标准不兼容'
+H365CB532BF3E: '可变参数的 "friend" 声明与C++2c之前的C++标准不兼容'
 # 'variadic function cannot use %0 calling convention'
 HEC894E082768: '可变参数函数不能使用 %0 调用约定'
 # 'variadic macros are a C99 feature'
@@ -28795,7 +28795,7 @@ H20CF2F14B1AB: '向量操作数的元素大小不一致（%0 和 %1）'
 # 'vector operands do not have the same number of elements (%0 and %1)'
 H02E2D0489C4C: '向量操作数的元素数量不一致（%0 和 %1）'
 # 'vector operands to the vector conditional must be the same type %diff{($ and $)|}0,1}'
-HBD47DE4A7313: '向量条件运算符的向量操作数必须是相同类型%diff{($和$)|}0,1}'
+HBD47DE4A7313: '向量条件运算符的向量操作数必须是相同类型 %diff{($和$)|}0,1}'
 # 'vector size not an integral multiple of component size'
 H77E12186A8E0: '向量大小不是组件大小的整数倍'
 # "vectorize_width loop hint malformed; use vectorize_width(X, fixed) or vectorize_width(X, scalable) where X is an integer, or vectorize_width('fixed' or 'scalable')"
@@ -28835,15 +28835,15 @@ H2738AB0FED80: '虚基类在此处声明'
 # 'virtual constexpr functions are incompatible with C++ standards before C++20'
 H0CA73C06B6D5: '虚constexpr函数与C++20之前的C++标准不兼容'
 # "virtual destructor requires an unambiguous, accessible 'operator delete'"
-H23281750E023: '虚析构函数需要明确且可访问的"operator delete"'
+H23281750E023: '虚析构函数需要明确且可访问的 "operator delete"'
 # "virtual filesystem overlay file '%0' not found"
 H26F74FB8B8C2: '未找到虚文件系统覆盖文件 "%0"'
 # 'virtual function %0 has a different return type %diff{($) than the function it overrides (which has return type $)|than the function it overrides}1,2'
-HD8B18D2DDADC: '虚函数 %0 的返回类型%diff{($) 与它覆盖的函数（其返回类型为 $）不同|与它覆盖的函数不同}1,2'
+HD8B18D2DDADC: '虚函数 %0 的返回类型 %diff{($) 与它覆盖的函数（其返回类型为 $）不同|与它覆盖的函数不同}1,2'
 # 'virtual function %0 has different attributes %diff{($) than the function it overrides (which has $)|than the function it overrides}1,2'
-H105CB368BBFA: '虚函数 %0 的属性%diff{($) 与它覆盖的函数（其属性为 $）不同|与它覆盖的函数不同}1,2'
+H105CB368BBFA: '虚函数 %0 的属性 %diff{($) 与它覆盖的函数（其属性为 $）不同|与它覆盖的函数不同}1,2'
 # 'virtual function %0 has different calling convention attributes %diff{($) than the function it overrides (which has calling convention $)|than the function it overrides}1,2'
-HB03FA37606B1: '虚函数 %0 的调用约定属性%diff{($) 与它覆盖的函数（其调用约定为 $）不同|与它覆盖的函数不同}1,2'
+HB03FA37606B1: '虚函数 %0 的调用约定属性 %diff{($) 与它覆盖的函数（其调用约定为 $）不同|与它覆盖的函数不同}1,2'
 # 'virtual function %q0 has more than one final overrider in %1'
 H80394FC58D1D: '虚函数 %q0 在 %1 中有多个最终覆盖者'
 # 'virtual function cannot be constexpr'
@@ -28857,7 +28857,7 @@ H207695B65E04: 'HLSL中不支持虚函数'
 # 'virtual inheritance is unsupported in HLSL'
 H8C2B278220B7: 'HLSL中不支持虚继承'
 # "virtual method %0 is inside a 'final' class and can never be overridden"
-HAC30D95A1570: '虚方法 %0 位于"final"类中，无法被覆盖'
+HAC30D95A1570: '虚方法 %0 位于 "final" 类中，无法被覆盖'
 # 'visibility does not match previous declaration'
 H17040BB5EC03: '可见性与之前的声明不匹配'
 # 'void %select{function|method|block}1 %0 should not return void expression'
@@ -28977,7 +28977,7 @@ HD1698255B212: '将此字段的宽度扩展为 %0 位以存储 %1 的所有值'
 # 'width of bit-field %0 (%1 bits) exceeds the width of its type; value will be truncated to %2 bit%s2'
 H8896C13CC6D9: '位字段 %0 (%1 位) 的宽度超过其类型宽度；值将被截断至 %2 bit%s2'
 # 'width of%select{ anonymous|}0 bit-field%select{| %1}0 (%2 bits) exceeds the %select{width|size}3 of its type (%4 bit%s4)'
-H02B50746D7D1: '位字段%select{匿名|}0 的宽度%select{| %1}0 (%2 位) 超过其类型的%select{宽度|大小}3 (%4 bit%s4)'
+H02B50746D7D1: '位字段%select{匿名|}0 的宽度 %select{| %1}0 (%2 位) 超过其类型的%select{宽度|大小}3 (%4 bit%s4)'
 # 'with jt-footprint-reduction, only process PIC jumptables and turn off other transformations that increase code size'
 H3BB007DE5DDB: '启用jt-footprint-reduction时，仅处理PIC跳转表并关闭其他增大代码体积的转换'
 # 'within field of type %0 declared here'

--- a/i18n/zh_CN.yml
+++ b/i18n/zh_CN.yml
@@ -101,7 +101,7 @@ HBCB4550F177A: "#pragma warning 期望 'push'、'pop'、'default'、'disable'、
 # '#pragma warning expected a warning number'
 HB9A465F10016: '#pragma warning 期望一个警告编号'
 # '#pragma warning(push, level) requires a level between 0 and 4'
-H99A37FD4A6D8: '#pragma warning(push, level) 需要级别在0到4之间'
+H99A37FD4A6D8: '#pragma warning(push, level) 需要级别在 0 到 4之间'
 # '#warning is a %select{C23|C++23}0 extension'
 H0F157EC51CD6: '#warning 是 %select{C23|C++23}0 的扩展'
 # '#warning is incompatible with C standards before C23'
@@ -143,17 +143,17 @@ H2B10B0C97CC4: '%0 MTE内建函数参数必须是整数类型（%1 无效）'
 # '%0 argument to %1 must be of vector type'
 H61B90BC8950E: '%0 参数传递给 %1 时必须为向量类型'
 # '%0 attribute %plural{0:takes no arguments|1:takes one argument|:requires exactly %1 arguments}1'
-H8625FD5B48BC: '%0 属性 %plural{0:不需要参数|1:需要一个参数|:需要恰好%1个参数}1'
+H8625FD5B48BC: '%0 属性 %plural{0:不需要参数|1:需要一个参数|:需要恰好 %1 个参数}1'
 # '%0 attribute applied to non-RVV type %1'
-H49243AEFBCDB: '%0 属性应用于非RVV类型%1'
+H49243AEFBCDB: '%0 属性应用于非RVV类型 %1'
 # '%0 attribute applied to non-SVE type %1'
-H7CA8225CCF33: '%0 属性应用于非SVE类型%1'
+H7CA8225CCF33: '%0 属性应用于非SVE类型 %1'
 # "%0 attribute applies to function parameters only if their type is a reference to a 'scoped_lockable'-annotated type"
-H8F04340A3021: "%0 属性仅适用于其类型是引用带有'scoped_lockable'注解类型的函数参数"
+H8F04340A3021: "%0 属性仅适用于其类型是引用带有 'scoped_lockable' 注解类型的函数参数"
 # "%0 attribute argument '%1' not supported on a global variable"
-H12B4D27D7798: "%0 属性参数'%1'不支持全局变量"
+H12B4D27D7798: "%0 属性参数 '%1' 不支持全局变量"
 # '%0 attribute argument is invalid: %select{max must be 0 since min is 0|min must not be greater than max}1'
-HD3E478873102: '%0 属性参数无效：%select{max必须设为0，因为min已经是0|min不能大于max}1'
+HD3E478873102: '%0 属性参数无效：%select{max必须设为 0，因为min已经是 0|min不能大于max}1'
 # '%0 attribute argument may only refer to a function parameter of integer type'
 H05E563701DF2: '%0 属性参数只能引用整数类型的函数参数'
 # '%0 attribute argument must be a string literal specifying a Swift function name'
@@ -161,7 +161,7 @@ H056A97564B83: '%0 属性参数必须是一个指定Swift函数名的字符串�
 # '%0 attribute argument not supported: %1'
 HB519160711B1: '%0 属性参数不支持：%1'
 # "%0 attribute can only be applied in a context annotated with 'capability' attribute"
-H9411040D8420: "%0 属性只能应用于标注有'capability'属性的上下文中"
+H9411040D8420: "%0 属性只能应用于标注有 'capability' 属性的上下文中"
 # '%0 attribute can only be applied once per parameter'
 H3C2BAB720741: '%0 属性每个参数只能应用一次'
 # '%0 attribute can only be applied to a %select{function|method}1 with an error parameter'
@@ -171,7 +171,7 @@ H63E9059C2A3F: '%0 属性只能应用于ARM、HLSL或RISC-V内建函数'
 # '%0 attribute can only be applied to instance variables or properties'
 H30E90B5958C9: '%0 属性只能应用于实例变量或属性'
 # "%0 attribute cannot be applied to %select{a function parameter|a variable with 'register' storage class|a 'catch' variable|a bit-field|an enumeration}1"
-HD202D2E58321: "%0 属性不能应用于%select{函数参数|具有'register'存储类的变量|'catch'变量|位域|枚举}1"
+HD202D2E58321: "%0 属性不能应用于%select{函数参数|具有 'register' 存储类的变量|'catch' 变量|位域|枚举}1"
 # '%0 attribute cannot be applied to %select{methods in protocols|dealloc}1'
 HC18046C82752: '%0 属性不能应用于%select{协议中的方法|dealloc}1'
 # '%0 attribute cannot be applied to a %select{function|method}1 with no parameters'
@@ -183,7 +183,7 @@ H3AD0DE140148: '%0 属性不能应用于模块导入'
 # '%0 attribute cannot be applied to non-static member functions'
 HCA6FA0E6C0E4: '%0 属性不能应用于非静态成员函数'
 # '%0 attribute cannot be applied to sizeless type %1'
-H60D82BB85EBA: '%0 属性不能应用于大小未知类型%1'
+H60D82BB85EBA: '%0 属性不能应用于大小未知类型 %1'
 # '%0 attribute cannot be applied to this declaration'
 H1A106E97EE94: '%0 属性不能应用于此声明'
 # '%0 attribute cannot be repeated'
@@ -199,9 +199,9 @@ HE84901B6BFC0: '%0 属性未出现在首次声明中'
 # '%0 attribute expression never produces a constant expression'
 H6DB854C2324C: '%0 属性表达式无法生成常量表达式'
 # "%0 attribute for 'subscript' getter cannot have a 'newValue:' parameter"
-HEBB5613EEF15: "%0 属性的'subscript'获取器不能包含'newValue:'参数"
+HEBB5613EEF15: "%0 属性的 'subscript' 获取器不能包含'newValue:'参数"
 # "%0 attribute for 'subscript' must %select{be a getter or setter|have at least one parameter|have a 'self:' parameter}1"
-H445CA4D5B31B: "%0 属性的'subscript'必须%select{是getter或setter|至少有一个参数|具有'self:'参数}1"
+H445CA4D5B31B: "%0 属性的 'subscript' 必须%select{是getter或setter|至少有一个参数|具有'self:'参数}1"
 # "%0 attribute for 'subscript' setter cannot have multiple 'newValue:' parameters"
 H2C95053B8BED: "%0 'subscript' setter 的属性不能有多个 'newValue:' 参数"
 # "%0 attribute for 'subscript' setter must have a 'newValue:' parameter"
@@ -287,13 +287,13 @@ HB94334A9F06D: '%0 属性的参数 %1 为负数，将被忽略'
 # '%0 attribute parameter %1 is out of bounds'
 H9C7D1C19F9DB: '%0 属性的参数 %1 超出范围'
 # '%0 attribute parameter %1 is out of bounds: %plural{0:no parameters to index into|1:can only be 1, since there is one parameter|:must be between 1 and %2}2'
-HF05125794562: '%0 属性的参数 %1 超出范围：%plural{0:没有参数可供索引|1:只能是1，因为只有一个参数|:必须在1和%2之间}2'
+HF05125794562: '%0 属性的参数 %1 超出范围：%plural{0:没有参数可供索引|1:只能是 1，因为只有一个参数|:必须在 1 和 %2 之间}2'
 # '%0 attribute parameter types do not match: parameter %1 of function %2 has type %3, but parameter %4 of function %5 has type %6'
 H4FBE5E81E84C: '%0 属性的参数类型不匹配：函数 %2 的参数 %1 类型为 %3，而函数 %5 的参数 %4 类型为 %6'
 # '%0 attribute parameters do not match the previous declaration'
 HBB1E6D667EEA: '%0 属性的参数与之前的声明不匹配'
 # '%0 attribute references function %1, which %plural{0:takes no arguments|1:takes one argument|:takes exactly %2 arguments}2'
-HC6916839EF90: '%0 属性引用函数 %1，该函数%plural{0:没有参数|1:有一个参数|:恰好有%2个参数}2'
+HC6916839EF90: '%0 属性引用函数 %1，该函数%plural{0:没有参数|1:有一个参数|:恰好有 %2 个参数}2'
 # '%0 attribute references parameter %1, but the function %2 has only %3 parameters'
 H95C6EBBF3D05: '%0 属性引用参数 %1，但函数 %2 只有 %3 个参数'
 # '%0 attribute requires %select{int or bool|an integer constant|a string|an identifier}1'
@@ -301,7 +301,7 @@ H4D660FD4970F: '%0 属性需要%select{int或bool类型|一个整型常量|一�
 # '%0 attribute requires a %select{positive|non-negative}1 integral compile time constant expression'
 H88B2A4A1C6F1: '%0 属性需要一个%select{正数|非负数}1 类型的整型编译时常量表达式'
 # '%0 attribute requires an integer argument which is a constant power of two between %1 and %2 inclusive; provided argument was %3'
-HBE3281153430: '%0 属性需要一个介于 %1 和 %2 之间的2的常量幂整数参数；提供的参数是 %3'
+HBE3281153430: '%0 属性需要一个介于 %1 和 %2 之间的 2 的常量幂整数参数；提供的参数是 %3'
 # "%0 attribute requires arguments whose type is annotated with 'capability' attribute; type here is %1"
 H6A637254187D: '%0 属性需要参数类型带有"capability"属性；此处的类型是 %1'
 # '%0 attribute requires integer constant between %1 and %2 inclusive'
@@ -317,9 +317,9 @@ HADEF6E200C29: '%0 属性至少需要 %1 个参数%s1'
 # '%0 attribute takes no more than %1 argument%s1'
 H19CAD7127F59: '%0 属性最多允许 %1 个参数%s1'
 # "%0 attribute with '%1' convention can only be applied to a %select{function|method}2 returning %select{an integral type|a pointer}3"
-HD834E8E626F3: '%0 属性使用"%1"约定时只能应用于返回%select{整型类型|指针}3的%select{函数|方法}2'
+HD834E8E626F3: '%0 属性使用 "%1" 约定时只能应用于返回%select{整型类型|指针}3的%select{函数|方法}2'
 # "%0 attribute with '%1' convention must have an integral-typed parameter in completion handler at index %2, type here is %3"
-HA510BC647385: '%0 属性使用"%1"约定时，完成处理程序在索引 %2 处必须具有整型参数，此处的类型为 %3'
+HA510BC647385: '%0 属性使用 "%1" 约定时，完成处理程序在索引 %2 处必须具有整型参数，此处的类型为 %3'
 # "%0 attribute with 'nonnull_error' convention can only be applied to a %select{function|method}1 with a completion handler with an error parameter"
 HB02ECE112485: '%0 属性使用"nonnull_error"约定时只能应用于具有带有错误参数的完成处理程序的%select{函数|方法}1'
 # '%0 attribute without capability arguments can only be applied to non-static methods of a class'
@@ -527,23 +527,23 @@ H0BC00170201E: '%0 不是有效的 SYCL 内核名称类型；需要非联合类�
 # '%0 is not a valid literal type for NSNumber'
 H994AF662B0D5: '%0 不是NSNumber的有效文字类型'
 # '%0 is not a valid property name (accessing an object of type %1)'
-HA0D8AFF85380: '%0 不是有效的属性名称（访问类型为%1的对象）'
+HA0D8AFF85380: '%0 不是有效的属性名称（访问类型为 %1 的对象）'
 # "%0 is not an availability stage; use 'introduced', 'deprecated', or 'obsoleted'"
-H5FED6488A0D9: "%0 不是可用性阶段；请使用'introduced'、'deprecated'或'obsoleted'"
+H5FED6488A0D9: "%0 不是可用性阶段；请使用 'introduced'、'deprecated' 或 'obsoleted'"
 # '%0 is not an enumerated type'
 H7F1BAB170C64: '%0 不是枚举类型'
 # '%0 is not defined, but forward declared here; conversion would be valid if it was derived from %1'
-H176B6CEA9A74: '%0 未定义，但在此处有前置声明；如果其派生于%1类型则转换有效'
+H176B6CEA9A74: '%0 未定义，但在此处有前置声明；如果其派生于 %1 类型则转换有效'
 # '%0 is not defined, evaluates to 0'
-HBDB44DE505CF: '%0 未定义，计算结果为0'
+HBDB44DE505CF: '%0 未定义，计算结果为 0'
 # '%0 is not literal because it has a non-trivial destructor'
 HC9535B0A1692: '%0 不是文字类型，因为它具有非平凡的析构函数'
 # '%0 is not literal because it has a user-provided destructor'
 H35BFFB66B4EF: '%0 不是文字类型，因为它具有用户提供的析构函数'
 # '%0 is not literal because it has base class %1 of non-literal type'
-H41CFD9851FA8: '%0 不是文字类型，因为它具有基类%1属于非文字类型'
+H41CFD9851FA8: '%0 不是文字类型，因为它具有基类 %1 属于非文字类型'
 # '%0 is not literal because it has data member %1 of %select{non-literal|volatile}3 type %2'
-H39754ECC239F: '%0 不是文字类型，因为它具有%select{非文字型|volatile}3类型%2的成员%1'
+H39754ECC239F: '%0 不是文字类型，因为它具有%select{非文字型|volatile}3类型 %2 的成员 %1'
 # '%0 is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors'
 HD7160BA9A570: '%0 不是文字类型，因为它不是聚合类型且除了拷贝或移动构造函数外没有constexpr构造函数'
 # '%0 is not literal because its destructor is not constexpr'
@@ -551,7 +551,7 @@ HEAC0F5C26B7E: '%0 不是文字类型，因为它的析构函数不是constexpr'
 # '%0 is not polymorphic'
 H67C71DB95F18: '%0 不是多态类型'
 # '%0 is not supported on HVX %1'
-H7927AD732A30: '%0 不受HVX %1支持'
+H7927AD732A30: '%0 不受HVX %1 支持'
 # '%0 is not supported on this target'
 H331CCFBB5DA0: '%0 不受此目标平台支持'
 # '%0 is not supported with -fembed-bitcode'
@@ -559,11 +559,11 @@ H580226EF44DA: '%0 不能与-fembed-bitcode选项同时使用'
 # '%0 is not virtual and cannot be declared pure'
 HFCE20933CC31: '%0 不是虚函数，不能声明为纯虚函数'
 # '%0 is only available %select{|in %4 environment }3on %1 %2 or newer'
-H1926B8ADA9BD: '%0 仅在%select{|%4环境 }3%1 %2或更高版本中可用'
+H1926B8ADA9BD: '%0 仅在%select{|%4 环境 }3%1 %2 或更高版本中可用'
 # '%0 is only supported when \'-mrvv-vector-bits=<bits>\' is specified with a value of "zvl" or a power 2 in the range [64,65536]'
-H714177E08C3D: '%0 仅在指定‘-mrvv-vector-bits=<bits>’参数为"zvl"或64到65536之间的2的幂时支持'
+H714177E08C3D: '%0 仅在指定‘-mrvv-vector-bits=<bits>’参数为"zvl"或 64 到 65536之间的 2 的幂时支持'
 # "%0 is only supported when '-msve-vector-bits=<bits>' is specified with a value of 128, 256, 512, 1024 or 2048"
-H5256E220BB0F: '在指定‘-msve-vector-bits=<bits>’参数值为128、256、512、1024或2048时支持%0'
+H5256E220BB0F: '在指定‘-msve-vector-bits=<bits>’参数值为 128、256、512、1024或 2048 时支持 %0'
 # "%0 is required to declare the member 'unhandled_exception()'"
 H72F7248FC774: "%0 必须声明成员 'unhandled_exception()'"
 # "%0 is required to declare the member 'unhandled_exception()' when exceptions are enabled"
@@ -605,9 +605,9 @@ H3F1AA6022CE0: '%0 可能不打算支持类模板实参推导'
 # '%0 may not respond to %1'
 HE863B7C4E09E: '%0 可能无法响应 %1'
 # '%0 must be explicitly converted to %1; use %select{%objcclass2|%objcinstance2}3 method for this conversion'
-H7B5D141884DB: '%0 必须显式转换为%1；使用%select{%objcclass2|%objcinstance2}3方法进行此转换'
+H7B5D141884DB: '%0 必须显式转换为 %1；使用%select{%objcclass2|%objcinstance2}3方法进行此转换'
 # '%0 must be name of an Objective-C class to be able to convert %1 to %2'
-HF9706A398326: '%0 必须是Objective-C类的名称，以便将%1转换为%2'
+HF9706A398326: '%0 必须是Objective-C类的名称，以便将 %1 转换为 %2'
 # '%0 must be specified on definition if it is specified on any declaration'
 H593384CDC4FD: '如果在任何声明中指定了 %0，必须在定义中指定它'
 # '%0 must be used within a preprocessing directive'
@@ -617,13 +617,13 @@ H2488FE597801: '%0 必须至少有一个参数'
 # "%0 must not appear in both clauses 'to' and 'link'"
 HC3403F617C92: "%0 不得同时出现在' to '和' link '子句中"
 # '%0 must return type %1'
-H561F31EBFB23: '%0 必须返回类型%1'
+H561F31EBFB23: '%0 必须返回类型 %1'
 # '%0 needs target feature %1'
-H5236119E54CB: '%0 需要目标特性%1'
+H5236119E54CB: '%0 需要目标特性 %1'
 # '%0 needs to be instantiated from a class template with proper template arguments'
 H6CDDF6DD374E: '%0 需要从具有适当模板参数的类模板实例化'
 # '%0 needs to have exactly %1 template parameters'
-HD0C675913338: '%0 必须恰好有%1个模板参数'
+HD0C675913338: '%0 必须恰好有 %1 个模板参数'
 # '%0 only allowed in __except block or filter expression'
 H5D665A901228: '%0 仅允许在__except块或过滤表达式中使用'
 # '%0 only allowed in __except filter expression'
@@ -631,17 +631,17 @@ H6152837B25ED: '%0 仅允许在__except过滤表达式中使用'
 # '%0 only allowed in __finally block'
 H4B415A24C89A: '%0 仅允许在__finally块中使用'
 # '%0 only applies to pointer types; type here is %1'
-HAB4FE8662D8D: '%0 仅适用于指针类型；此处的类型是%1'
+HAB4FE8662D8D: '%0 仅适用于指针类型；此处的类型是 %1'
 # "%0 overrides a destructor but is not marked 'override'"
-HEE01F5122D86: "%0 覆盖了一个析构函数但未标记为'override'"
+HEE01F5122D86: "%0 覆盖了一个析构函数但未标记为 'override'"
 # "%0 overrides a member function but is not marked 'override'"
-H7449F9821D96: "%0 覆盖了一个成员函数但未标记为'override'"
+H7449F9821D96: "%0 覆盖了一个成员函数但未标记为 'override'"
 # "%0 parameter marked 'called_once' is called twice"
-H9B0F1F204498: "%0 标记为'called_once'的参数被调用了两次"
+H9B0F1F204498: "%0 标记为 'called_once' 的参数被调用了两次"
 # "%0 parameter marked 'called_once' is never %select{used|called}1 when %select{taking true branch|taking false branch|handling this case|none of the cases applies|entering the loop|skipping the loop|taking one of the branches}2"
-HBB87206669E4: "%0 标记为'called_once'的参数在%select{取真分支|取假分支|处理这种情况|所有情况都不适用|进入循环时|跳过循环时|取其中一个分支}2时%select{未被使用|未被调用}1"
+HBB87206669E4: "%0 标记为 'called_once' 的参数在%select{取真分支|取假分支|处理这种情况|所有情况都不适用|进入循环时|跳过循环时|取其中一个分支}2时%select{未被使用|未被调用}1"
 # "%0 redeclared with '%1' access"
-H6D05457F8E04: '%0 重新声明为具有"%1"访问权限'
+H6D05457F8E04: '%0 重新声明为具有 "%1" 访问权限'
 # '%0 released here'
 H2E4FF4BE13D1: '%0 在此处释放'
 # "%0 requires %1 type support, but ABI '%2' does not support it"
@@ -705,9 +705,9 @@ H45C12381C633: '%0%select{属性|}1 仅适用于 %2'
 # '%0%select{ attribute|}1 only applies to %select{functions|unions|variables and functions|functions and methods|functions, methods and blocks|functions, methods, and parameters|variables|variables and fields|variables, data members and tag types|types and namespaces|variables, functions and classes|kernel functions|non-K&R-style functions|for loop statements|virtual functions|parameters and implicit object parameters|non-member functions|functions, classes, or enumerations|classes|typedefs}2'
 H9D37840D3CB2: '%0%select{ attribute|}1 仅适用于 %select{函数|联合|变量和函数|函数和方法|函数、方法和代码块|函数、方法和参数|变量|变量和字段|变量、数据成员和标号类型|类型和命名空间|变量、函数和类|内核函数|非K&R风格函数|for循环语句|虚函数|参数和隐式对象参数|非成员函数|函数、类或枚举|类|typedef}2'
 # "%0%select{| following the 'template' keyword}1 cannot refer to a dependent template"
-HA18DA36B7236: "%0%select{|在'template'关键字后}1不能引用依赖模板"
+HA18DA36B7236: "%0%select{|在 'template' 关键字后}1不能引用依赖模板"
 # "%0%select{| following the 'template' keyword}1 does not refer to a template"
-HCADF8F759262: "%0%select{|在'template'关键字后}1未引用模板"
+HCADF8F759262: "%0%select{|在 'template' 关键字后}1未引用模板"
 # "%0: '%1' input unused in cpp mode"
 HF14789F9D841: "%0: 'cpp模式中未使用 '%1' 输入"
 # "%0: '%1' input unused%select{ when '%3' is present|}2"
@@ -765,25 +765,25 @@ H68AA8A549FAA: "%q0 在不同模块中有不同的定义；%select{模块 '%2' �
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{%4 base %plural{1:class|:classes}4|%4 virtual base %plural{1:class|:classes}4|%ordinal4 base class with type %5|%ordinal4 %select{non-virtual|virtual}5 base class %6|%ordinal4 base class %5 with %select{public|protected|private|no}6 access specifier}3"
 HC4303FABC437: "%q0 在不同模块中有不同的定义；第一个差异是 %select{在模块 '%2' 的定义|在此处定义}1 发现 %select{有 %4 个基类%plural{1:类|:类}4|有 %4 个虚基类%plural{1:类|:类}4|%ordinal4 基类类型为 %5|%ordinal4 %select{非虚|虚}5 基类 %6|%ordinal4 基类 %5 的访问说明符为 %select{public|protected|private|无}6}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{%4 referenced %plural{1:protocol|:protocols}4|%ordinal4 referenced protocol with name %5}3"
-HC9695A16C965: "%q0 在不同模块中有不同的定义；第一个差异是 %select{在模块'%2'中的定义|在此处定义}1 发现 %select{引用了%4 %plural{1:协议|:协议}4|%ordinal4 参考的协议名称为%5}3"
+HC9695A16C965: "%q0 在不同模块中有不同的定义；第一个差异是 %select{在模块 '%2' 中的定义|在此处定义}1 发现 %select{引用了 %4 %plural{1:协议|:协议}4|%ordinal4 参考的协议名称为 %5}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{%select{method %5|constructor|destructor}4 that has %6 parameter%s6|%select{method %5|constructor|destructor}4 with %ordinal6 parameter of type %7%select{| decayed from %9}8|%select{method %5|constructor|destructor}4 with %ordinal6 parameter named %7}3"
-HA17814A91726: "%q0 在不同模块中有不同的定义；第一个差异是 %select{模块 '%2'中的定义|在此处定义}1 发现 %select{%select{方法 %5|构造函数|析构函数}4 具有 %6 参数%s6|%select{方法 %5|构造函数|析构函数}4 的第 %ordinal6 参数类型为 %7%select{| 衰减为 %9}8|%select{方法 %5|构造函数|析构函数}4 的第 %ordinal6 参数名为 %7}3"
+HA17814A91726: "%q0 在不同模块中有不同的定义；第一个差异是 %select{模块 '%2' 中的定义|在此处定义}1 发现 %select{%select{方法 %5|构造函数|析构函数}4 具有 %6 参数%s6|%select{方法 %5|构造函数|析构函数}4 的第 %ordinal6 参数类型为 %7%select{| 衰减为 %9}8|%select{方法 %5|构造函数|析构函数}4 的第 %ordinal6 参数名为 %7}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{%select{typedef|type alias}4 name %5|%select{typedef|type alias}4 %5 with underlying type %6}3"
-H290AB6198D53: "%q0 在不同模块中有不同的定义；第一个差异是 %select{模块 '%2'中的定义|在此处定义}1 发现 %select{%select{typedef|类型别名}4 名称 %5|%select{typedef|类型别名}4 %5 其底层类型为 %6}3"
+H290AB6198D53: "%q0 在不同模块中有不同的定义；第一个差异是 %select{模块 '%2' 中的定义|在此处定义}1 发现 %select{%select{typedef|类型别名}4 名称 %5|%select{typedef|类型别名}4 %5 其底层类型为 %6}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{data member with name %4|data member %4 with type %5|data member %4 with%select{out|}5 an initializer|data member %4 with an initializer|data member %4 %select{is constexpr|is not constexpr}5}3"
-H3C6A067820A4: "%q0 在不同模块中有不同的定义；第一个差异是 %select{模块 '%2'中的定义|在此处定义}1 发现 %select{具有名称 %4 的数据成员|数据成员 %4 的类型 %5|数据成员 %4%select{有|}5 初始值设定项|数据成员 %4 具有初始值设定项|数据成员 %4 %select{是constexpr|不是constexpr}5}3"
+H3C6A067820A4: "%q0 在不同模块中有不同的定义；第一个差异是 %select{模块 '%2' 中的定义|在此处定义}1 发现 %select{具有名称 %4 的数据成员|数据成员 %4 的类型 %5|数据成员 %4%select{有|}5 初始值设定项|数据成员 %4 具有初始值设定项|数据成员 %4 %select{是constexpr|不是constexpr}5}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{end of class|public access specifier|private access specifier|protected access specifier|static assert|field|method|type alias|typedef|data member|friend declaration|function template|method|instance variable|property}3"
-HC7FCD2470FA2: "%q0 在不同模块中有不同的定义；第一个差异是 %select{模块 '%2'中的定义|在此处定义}1 发现 %select{类结尾|public访问说明符|private访问说明符|protected访问说明符|静态断言|字段|方法|类型别名|typedef|数据成员|朋友声明|函数模板|方法|实例变量|属性}3"
+HC7FCD2470FA2: "%q0 在不同模块中有不同的定义；第一个差异是 %select{模块 '%2' 中的定义|在此处定义}1 发现 %select{类结尾|public访问说明符|private访问说明符|protected访问说明符|静态断言|字段|方法|类型别名|typedef|数据成员|朋友声明|函数模板|方法|实例变量|属性}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{field %4|field %4 with type %5|%select{non-|}5bit-field %4|bit-field %4 with one width expression|%select{non-|}5mutable field %4|field %4 with %select{no|an}5 initializer|field %4 with an initializer}3"
-H60D85DC0E685: "%q0 在不同模块中有不同的定义；第一个差异是 %select{模块 '%2'中的定义|在此处定义}1 发现 %select{字段 %4|字段 %4 的类型 %5|%select{非-|}5位字段 %4|位字段 %4 具有单个宽度表达式|%select{非-|}5可变字段 %4|字段 %4 具有%select{无|}5初始值设定项|字段 %4 具有初始值设定项}3"
+H60D85DC0E685: "%q0 在不同模块中有不同的定义；第一个差异是 %select{模块 '%2' 中的定义|在此处定义}1 发现 %select{字段 %4|字段 %4 的类型 %5|%select{非-|}5位字段 %4|位字段 %4 具有单个宽度表达式|%select{非-|}5可变字段 %4|字段 %4 具有%select{无|}5初始值设定项|字段 %4 具有初始值设定项}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{method %4 with return type %5|%select{class|instance}5 method %4|%select{no|'required'|'optional'}4 method control|method %4 with %select{no designated initializer|designated initializer}5|%select{regular|direct}5 method %4|method %4}3"
-H5AECB1226BDE: "%q0 在不同模块中有不同的定义；第一个差异是 %select{模块 '%2'中的定义|在此处定义}1 发现 %select{返回类型为 %5 的方法 %4|%select{类|实例}5 方法 %4|%select{无|'required'|'optional'}4 方法控制|方法 %4 具有%select{无指定初始化器|指定初始化器}5|%select{常规|直接}5 方法 %4|方法 %4}3"
+H5AECB1226BDE: "%q0 在不同模块中有不同的定义；第一个差异是 %select{模块 '%2' 中的定义|在此处定义}1 发现 %select{返回类型为 %5 的方法 %4|%select{类|实例}5 方法 %4|%select{无|'required'|'optional'}4 方法控制|方法 %4 具有%select{无指定初始化器|指定初始化器}5|%select{常规|直接}5 方法 %4|方法 %4}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{property %4|property %4 with type %5|%select{no|'required'|'optional'}4 property control|property %4 with %select{default |}6'%select{none|readonly|getter|assign|readwrite|retain|copy|nonatomic|setter|atomic|weak|strong|unsafe_unretained|nullability|null_resettable|class|direct}5' attribute}3"
-H47E62251068F: "%q0 在不同模块中有不同的定义；第一个差异是 %select{模块 '%2'中的定义|在此处定义}1 发现 %select{属性 %4|属性 %4 的类型 %5|%select{无|'required'|'optional'}4 属性控制|属性 %4 具有%select{默认 |}6'%select{none|readonly|getter|assign|readwrite|retain|copy|nonatomic|setter|atomic|weak|strong|unsafe_unretained|nullability|null_resettable|class|direct}5' 属性}3"
+H47E62251068F: "%q0 在不同模块中有不同的定义；第一个差异是 %select{模块 '%2' 中的定义|在此处定义}1 发现 %select{属性 %4|属性 %4 的类型 %5|%select{无|'required'|'optional'}4 属性控制|属性 %4 具有%select{默认 |}6'%select{none|readonly|getter|assign|readwrite|retain|copy|nonatomic|setter|atomic|weak|strong|unsafe_unretained|nullability|null_resettable|class|direct}5' 属性}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{static assert with condition|static assert with message|static assert with %select{|no }4message|%select{method %5|constructor|destructor}4|%select{method %5|constructor|destructor}4 is %select{not deleted|deleted}6|%select{method %5|constructor|destructor}4 is %select{not defaulted|defaulted}6|%select{method %5|constructor|destructor}4 is %select{|pure }6%select{not virtual|virtual}7|%select{method %5|constructor|destructor}4 is %select{not static|static}6|%select{method %5|constructor|destructor}4 is %select{not volatile|volatile}6|%select{method %5|constructor|destructor}4 is %select{not const|const}6|%select{method %5|constructor|destructor}4 is %select{not inline|inline}6|%select{method %5|constructor|destructor}4 with %ordinal6 parameter with%select{out|}7 a default argument|%select{method %5|constructor|destructor}4 with %ordinal6 parameter with a default argument|%select{method %5|constructor|destructor}4 with %select{no |}6template arguments|%select{method %5|constructor|destructor}4 with %6 template argument%s6|%select{method %5|constructor|destructor}4 with %6 for %ordinal7 template argument|%select{method %5|constructor|destructor}4 with %select{no body|body}6|%select{method %5|constructor|destructor}4 with body|friend %select{class|function}4|friend %4|friend function %4|function template %4 with %5 template parameter%s5|function template %4 with %ordinal5 template parameter being a %select{type|non-type|template}6 template parameter|function template %4 with %ordinal5 template parameter %select{with no name|named %7}6|function template %4 with %ordinal5 template parameter with %select{no |}6default argument|function template %4 with %ordinal5 template parameter with default argument %6|function template %4 with %ordinal5 template parameter with one type|function template %4 with %ordinal5 template parameter %select{not |}6being a template parameter pack|}3"
-HCEB41952ED68: "%q0 在不同模块中具有不同的定义；第一个差异是 %select{模块 '%2'中的定义|在此处定义}1 发现 %select{带有条件的静态断言|带有消息的静态断言|%select{|无 }4消息的静态断言|%select{方法 %5|构造函数|析构函数}4|%select{方法 %5|构造函数|析构函数}4 是 %select{未删除|已删除}6|%select{方法 %5|构造函数|析构函数}4 是 %select{未默认|已默认}6|%select{方法 %5|构造函数|析构函数}4 是 %select{|纯 }6%select{非虚|虚}7|%select{方法 %5|构造函数|析构函数}4 是 %select{非静态|静态}6|%select{方法 %5|构造函数|析构函数}4 是 %select{非volatile|volatile}6|%select{方法 %5|构造函数|析构函数}4 是 %select{非const|const}6|%select{方法 %5|构造函数|析构函数}4 是 %select{非内联|内联}6|%select{方法 %5|构造函数|析构函数}4 具有第 %ordinal6 参数带有%select{出|}7 默认参数|%select{方法 %5|构造函数|析构函数}4 具有第 %ordinal6 参数带有默认参数|%select{方法 %5|构造函数|析构函数}4 具有%select{无 |}6模板参数|%select{方法 %5|构造函数|析构函数}4 具有 %6 模板参数%s6|%select{方法 %5|构造函数|析构函数}4 具有 %6 作为第 %ordinal7 模板参数|%select{方法 %5|构造函数|析构函数}4 具有%select{无|有}6函数体|%select{方法 %5|构造函数|析构函数}4 具有函数体|友元 %select{类|函数}4|友元 %4|友元函数 %4|函数模板 %4 具有 %5 模板参数%s5|函数模板 %4 具有第 %ordinal5 模板参数是 %select{类型|非类型|模板}6 模板参数|函数模板 %4 具有第 %ordinal5 模板参数%select{无名称|名称为 %7}6|函数模板 %4 具有第 %ordinal5 模板参数%select{无|}6默认参数|函数模板 %4 具有第 %ordinal5 模板参数默认参数 %6|函数模板 %4 具有第 %ordinal5 模板参数具有一个类型|函数模板 %4 具有第 %ordinal5 模板参数%select{不|}6是模板参数包|}3"
+HCEB41952ED68: "%q0 在不同模块中具有不同的定义；第一个差异是 %select{模块 '%2' 中的定义|在此处定义}1 发现 %select{带有条件的静态断言|带有消息的静态断言|%select{|无 }4消息的静态断言|%select{方法 %5|构造函数|析构函数}4|%select{方法 %5|构造函数|析构函数}4 是 %select{未删除|已删除}6|%select{方法 %5|构造函数|析构函数}4 是 %select{未默认|已默认}6|%select{方法 %5|构造函数|析构函数}4 是 %select{|纯 }6%select{非虚|虚}7|%select{方法 %5|构造函数|析构函数}4 是 %select{非静态|静态}6|%select{方法 %5|构造函数|析构函数}4 是 %select{非volatile|volatile}6|%select{方法 %5|构造函数|析构函数}4 是 %select{非const|const}6|%select{方法 %5|构造函数|析构函数}4 是 %select{非内联|内联}6|%select{方法 %5|构造函数|析构函数}4 具有第 %ordinal6 参数带有%select{出|}7 默认参数|%select{方法 %5|构造函数|析构函数}4 具有第 %ordinal6 参数带有默认参数|%select{方法 %5|构造函数|析构函数}4 具有%select{无 |}6模板参数|%select{方法 %5|构造函数|析构函数}4 具有 %6 模板参数%s6|%select{方法 %5|构造函数|析构函数}4 具有 %6 作为第 %ordinal7 模板参数|%select{方法 %5|构造函数|析构函数}4 具有%select{无|有}6函数体|%select{方法 %5|构造函数|析构函数}4 具有函数体|友元 %select{类|函数}4|友元 %4|友元函数 %4|函数模板 %4 具有 %5 模板参数%s5|函数模板 %4 具有第 %ordinal5 模板参数是 %select{类型|非类型|模板}6 模板参数|函数模板 %4 具有第 %ordinal5 模板参数%select{无名称|名称为 %7}6|函数模板 %4 具有第 %ordinal5 模板参数%select{无|}6默认参数|函数模板 %4 具有第 %ordinal5 模板参数默认参数 %6|函数模板 %4 具有第 %ordinal5 模板参数具有一个类型|函数模板 %4 具有第 %ordinal5 模板参数%select{不|}6是模板参数包|}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{unnamed template parameter|template parameter %5|template parameter with %select{no |}4default argument|template parameter with default argument}3"
-HA9E92FE31082: "%q0 在不同模块中有不同的定义；第一个差异是 %select{模块 '%2'中的定义|在此处定义}1 发现 %select{未命名的模板参数|模板参数 %5|模板参数%select{无 |}4默认参数|模板参数具有默认参数}3"
+HA9E92FE31082: "%q0 在不同模块中有不同的定义；第一个差异是 %select{模块 '%2' 中的定义|在此处定义}1 发现 %select{未命名的模板参数|模板参数 %5|模板参数%select{无 |}4默认参数|模板参数具有默认参数}3"
 # '%q0 hides overloaded virtual %select{function|functions}1'
 H2FDDD909C4BF: '%q0 隐藏重载虚 %select{函数|函数}1'
 # '%q0 is not a member of class %1'
@@ -795,7 +795,7 @@ HE698B2D72430: '%q0 重复声明为内联；忽略 %1 属性'
 # '%q0 redeclared without %1 attribute: previous %1 ignored'
 HD8FE54A130EE: '%q0 未重复声明 %1 属性：忽略先前的 %1 属性'
 # "%q0 redeclared without 'dllimport' attribute: 'dllexport' attribute added"
-H6D76D4BE2232: "%q0 未重复声明'dllimport'属性：添加'dllexport'属性"
+H6D76D4BE2232: "%q0 未重复声明 'dllimport' 属性：添加 'dllexport' 属性"
 # '%select{#elif|#elifdef|#elifndef}0 after #else'
 H66B8B159F15D: '%select{#elif|#elifdef|#elifndef}0 在#else之后'
 # '%select{#elif|#elifdef|#elifndef}0 without #if'
@@ -859,7 +859,7 @@ HC530D462FB18: "%select{MIPS|MSP430|RISC-V|AVR}0 '%select{interrupt|signal}1' �
 # "%select{OpenACC '%3' construct|while loop|do loop}0 cannot appear in intervening code of a '%1' with a '%2' clause"
 HB2C5F39C46C3: "%select{OpenACC '%3' 构造|while 循环|do 循环}0 不能出现在带有 '%2' 子句的 '%1' 中间代码段"
 # "%select{OpenACC 'gang' clause with a 'dim' value greater than 1|OpenACC 'reduction' clause}0 cannot appear on the same '%1' construct as a %select{'reduction' clause|'gang' clause with a 'dim' value greater than 1}0"
-H3449F0200ABB: "%select{OpenACC 'gang' 子句（dim 值大于1）|OpenACC 'reduction' 子句}0 不能与同一 '%1' 构造中的 %select{'reduction' 子句|'gang' 子句（dim 值大于1）}0 同时存在"
+H3449F0200ABB: "%select{OpenACC 'gang' 子句（dim 值大于 1）|OpenACC 'reduction' 子句}0 不能与同一 '%1' 构造中的 %select{'reduction' 子句|'gang' 子句（dim 值大于 1）}0 同时存在"
 # '%select{OpenACC sub-array|OpenMP array section}0 is not allowed here'
 H8129F6E36883: '%select{OpenACC 子数组|OpenMP 数组区间}0 在此处无效'
 # '%select{PCH|current translation unit}0 has no VFS overlays'
@@ -923,7 +923,7 @@ HA87D7335D9EB: "%select{并且|因为}0 '%1' 可能抛出异常"
 # "%select{and|because}0 '%1' would be invalid"
 HAD3CC48247E5: "%select{并且|因为}0 '%1' 将会无效"
 # "%select{and|because}0 '%1' would be invalid%2"
-HEF46AC24BE27: "%select{并且|因为}0 '%1' 将会无效%2"
+HEF46AC24BE27: "%select{并且|因为}0 '%1' 将会无效 %2"
 # "%select{and|because}0 '%1' would be invalid: %2"
 HD3831227C190: "%select{并且|因为}0 '%1' 会导致无效：%2"
 # "%select{and|because}0 type constraint '%1' was not satisfied:"
@@ -1045,21 +1045,21 @@ H804351062C9E: '%select{声明|定义|默认参数声明|显式特化声明|部�
 # "%select{declaration|definition|default argument|explicit specialization|partial specialization}0 of %1 must be imported from module '%2' before it is required"
 HC491502A3888: "%select{声明|定义|默认参数|显式特化|部分特化}0 的 %1 必须在需要前从模块 '%2' 导入"
 # '%select{declaration|definition|default argument|explicit specialization|partial specialization}0 of %1 must be imported from one of the following modules before it is required:%2'
-HA8E1DF60359B: '%select{声明|定义|默认参数|显式特化|偏特化}0的%1必须在需要前从以下模块导入：%2'
+HA8E1DF60359B: '%select{声明|定义|默认参数|显式特化|偏特化}0的 %1 必须在需要前从以下模块导入：%2'
 # '%select{declaration|definition}0 of %select{struct|interface|union|class|enum}1 in a dependent scope'
 H690477FDDE60: '%select{声明|定义}0的%select{结构体|接口|联合|类|枚举}1在依赖作用域中'
 # '%select{decremented|incremented}0 here'
 HD8461A402F1F: '此处%select{递减|递增}0'
 # '%select{decrement|increment}0 of object of volatile-qualified type %1 is deprecated'
-H57C759966E48: '%select{递减|递增}0类型为volatile限定的%1的对象已弃用'
+H57C759966E48: '%select{递减|递增}0类型为volatile限定的 %1 的对象已弃用'
 # '%select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20'
 H3C92D92BB26F: '%select{默认构造|赋值}0的lambda与C++20之前的C++标准不兼容'
 # '%select{default constructor of|constructor inherited by}0 %1 is implicitly deleted because all %select{data members|data members of an anonymous union member}2 are const-qualified'
-HF80E1E94C448: '%select{的默认构造函数|继承构造函数}0%1因所有%select{数据成员|匿名联合成员的数据成员}2为const限定而隐式删除'
+HF80E1E94C448: '%select{的默认构造函数|继承构造函数}0%1 因所有%select{数据成员|匿名联合成员的数据成员}2为const限定而隐式删除'
 # '%select{default constructor of|constructor inherited by}0 %1 is implicitly deleted because field %2 of %select{reference|const-qualified}4 type %3 would not be initialized'
 H3F45472DFCD6: '%select{的默认构造函数|继承构造函数}0 %1 被隐式删除，因为字段 %2 的 %select{引用|const限定}4 类型 %3 未被初始化'
 # '%select{default constructor of|copy constructor of|move constructor of|copy assignment operator of|move assignment operator of|destructor of|constructor inherited by}0 %1 is implicitly deleted because %select{base class %3|%select{||||variant }4field %3}2 %select{has %select{no|a deleted|multiple|an inaccessible|a non-trivial}4 %select{%select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor|%select{default|corresponding|default|default|default}4 constructor}0|destructor}5%select{||s||}4|is an ObjC pointer}6'
-H1BB10C6BA0EA: '%select{的默认构造函数|的复制构造函数|的移动构造函数|的复制赋值运算符|的移动赋值运算符|的析构函数|继承构造函数}0%1因%select{基类%3|%select{||||variant }4字段%3}2%select{具有%select{无|被删除的|多个|不可访问的|非平凡的}4%select{%select{默认构造函数|复制构造函数|移动构造函数|复制赋值运算符|移动赋值运算符|析构函数|%select{默认|对应|默认|默认|默认}4构造函数}0|析构函数}5%select{||s||}4|是ObjC指针}6而隐式删除'
+H1BB10C6BA0EA: '%select{的默认构造函数|的复制构造函数|的移动构造函数|的复制赋值运算符|的移动赋值运算符|的析构函数|继承构造函数}0%1 因%select{基类 %3|%select{||||variant }4字段 %3}2%select{具有%select{无|被删除的|多个|不可访问的|非平凡的}4%select{%select{默认构造函数|复制构造函数|移动构造函数|复制赋值运算符|移动赋值运算符|析构函数|%select{默认|对应|默认|默认|默认}4构造函数}0|析构函数}5%select{||s||}4|是ObjC指针}6而隐式删除'
 # "%select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}0 cannot be 'constexpr' in a class with virtual base class"
 HAA0AD1F4C5AC: '%select{默认构造函数|复制构造函数|移动构造函数|复制赋值运算符|移动赋值运算符|析构函数}0在具有虚基类的类中不能为constexpr'
 # '%select{defaulted|deleted}0 function definitions are a C++11 extension'
@@ -1067,25 +1067,25 @@ H2588FE2C83FF: '%select{默认化|删除化}0函数定义是C++11扩展'
 # '%select{defaulted|deleted}0 function definitions are incompatible with C++98'
 HE7CB963644EA: '%select{默认化|删除化}0函数定义与C++98不兼容'
 # "%select{definition|#undef}0 of configuration macro '%1' has no effect on the import of '%2'; pass '%select{-D%1=...|-U%1}0' on the command line to configure the module"
-H20DEB068BA86: "%select{定义|#undef}0的配置宏'%1'对导入'%2'无影响；请通过命令行Pass'%select{-D%1=...|-U%1}0'配置模块"
+H20DEB068BA86: "%select{定义|#undef}0的配置宏 '%1' 对导入 '%2' 无影响；请通过命令行Pass'%select{-D%1=...|-U%1}0'配置模块"
 # '%select{delete|destructor}0 called on %1 that is abstract but has non-virtual destructor'
-HD3B2B405330A: '对具有非虚析构函数的抽象%1调用%select{delete|析构函数}0'
+HD3B2B405330A: '对具有非虚析构函数的抽象 %1 调用%select{delete|析构函数}0'
 # '%select{delete|destructor}0 called on non-final %1 that has virtual functions but non-virtual destructor'
-HD186820BFF8C: '对非final且包含虚函数但非虚析构函数的%1调用%select{delete|析构函数}0'
+HD186820BFF8C: '对非final且包含虚函数但非虚析构函数的 %1 调用%select{delete|析构函数}0'
 # '%select{delimited|named}0 escape sequences are a %select{C++23|C2y|Clang}1 extension'
-HDBE05BE4D14B: '%select{限定|命名}0转义序列是%select{C++23|C2y|Clang}1扩展'
+HDBE05BE4D14B: '%select{限定|命名}0转义序列是 %select{C++23|C2y|Clang}1 扩展'
 # '%select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23'
 HFB62920439FF: '%select{限定|命名}0转义序列与C++23之前的C++标准不兼容'
 # '%select{destination for|source of|first operand of|second operand of}0 this %1 call is a pointer to %select{|class containing a }2dynamic class %3; vtable pointer will be %select{overwritten|copied|moved|compared}4'
-H63A8D05F544B: '此%1调用的%select{目标|源|第一个操作数|第二个操作数}0是指向%select{|包含动态类的类}2%3的指针；vtable指针将被%select{覆盖|复制|移动|比较}4'
+H63A8D05F544B: '此 %1 调用的%select{目标|源|第一个操作数|第二个操作数}0是指向%select{|包含动态类的类}2%3 的指针；vtable指针将被%select{覆盖|复制|移动|比较}4'
 # '%select{destination for|source of|first operand of|second operand of}0 this %1 call is a pointer to record %2 that is not trivial to %select{primitive-default-initialize|primitive-copy}3'
 HB6A0DAA8C1C8: '%select{此 %1 调用的|源|第一个操作数的|第二个操作数的}0 目标是指向非 %select{原始默认初始化|原始复制}3 类型 %2 的指针'
 # '%select{destination for|source of}0 this %1 call is a pointer to ownership-qualified type %2'
-HEE4DB03498AC: '此%1调用的%select{目标|源}0是指向所有权限定类型%2的指针'
+HEE4DB03498AC: '此 %1 调用的%select{目标|源}0是指向所有权限定类型 %2 的指针'
 # '%select{destructor|deallocator}0 has a %select{non-throwing|implicit non-throwing}1 exception specification'
 H78E56ACB6245: '%select{析构函数|解分配器}0具有%select{不抛出异常的|隐式不抛出异常的}1异常规范'
 # '%select{dictionary|array}1 subscript base type %0 is not an Objective-C object'
-HE2828D54BB1B: '%select{字典|array}1 下标基类型 %0 不是 Objective-C 对象'
+HE2828D54BB1B: '%select{字典|数组}1 下标基类型 %0 不是 Objective-C 对象'
 # '%select{equality|inequality|relational|three-way}0 comparison result unused'
 H69C6598EFBD9: '%select{相等|不等|关系|三向}0 比较结果未被使用'
 # '%select{expected an expression statement|expected built-in assignment operator|expected expression of scalar type|expected lvalue expression}0'
@@ -1121,7 +1121,7 @@ HBF77ADC8F095: '%select{第一个|第二个}0 操作数被隐式转换为类型 
 # '%select{forward class declaration|class definition|category|extension}0 has too %select{few|many}1 type parameters (expected %2, have %3)'
 HF027D432E158: '%select{前向类声明|类定义|类别|扩展}0 的类型参数数量%select{太少|太多}1（期望 %2，实际 %3）'
 # '%select{function %1 which returns const-qualified type %2 declared here|variable %1 declared const here|%select{non-|}1static data member %2 declared const here|member function %q1 is declared const here|%select{|nested }1data member %2 declared const here}0'
-HA9209A7005BD: '%select{返回const限定类型%2的函数%1在此声明|在此声明为const的变量%1|非%select{静态|匿名}1数据成员%2在此声明为const|在此声明为const的成员函数%q1|%select{嵌套|}1数据成员%2在此声明为const}0'
+HA9209A7005BD: '%select{返回const限定类型 %2 的函数 %1 在此声明|在此声明为const的变量 %1|非%select{静态|匿名}1数据成员 %2 在此声明为const|在此声明为const的成员函数%q1|%select{嵌套|}1数据成员 %2 在此声明为const}0'
 # '%select{function parameter|typedef}0 cannot be %select{<ERROR>|constexpr|consteval|constinit}1'
 H86C3A8B0C257: '%select{函数参数|typedef}0 不能是 %select{<ERROR>|constexpr|consteval|constinit}1'
 # '%select{function template|class template|variable template|type alias template|template template parameter}0 %1 declared here'
@@ -1249,7 +1249,7 @@ H7895E4BCBED9: '此处%select{非虚|虚}0派生'
 # "%select{non-|function }0pointer argument to '__builtin_is_within_lifetime' is not allowed"
 HEC6E2A0FBA29: "传递给 '__builtin_is_within_lifetime' 的%select{非-|函数 }0指针参数不允许"
 # "%select{no|too many}0 integer expression arguments provided to OpenACC 'num_gangs' %select{|clause: '%1' directive expects maximum of %2, %3 were provided}0"
-HDF54FE517944: "为OpenACC 'num_gangs' %select{|子句 '%1' 指令最多接受 %2，但提供了 %3个}0提供了%select{no|too many}0整型表达式参数"
+HDF54FE517944: "为OpenACC 'num_gangs' %select{|子句 '%1' 指令最多接受 %2，但提供了 %3 个}0提供了 %select{no|too many}0 整型表达式参数"
 # "%select{orphaned 'omp section' directives are prohibited, it|'omp section' directive}0 must be closely nested to a sections region%select{|, not a %1 region}0"
 HF07F4A64D372: "%select{孤儿的 'omp section' 指令被禁止，它|'omp section' 指令}0必须紧密嵌套到一个 sections 区域%select{|，而不是一个 %1 区域}0"
 # "%select{overridden|current}0 method is explicitly declared 'instancetype'%select{| and is expected to return an instance of its class type}0"
@@ -1287,9 +1287,9 @@ H0FF342784C44: '%select{指针|引用}1 到非 const 类型 %0 未显式指定�
 # '%select{precompiled header|module}0 uses __DATE__ or __TIME__'
 H2637E05CCFD6: '%select{预编译头|模块}0使用了__DATE__或__TIME__'
 # '%select{program scope|static local|extern}0 variable must reside in %1 address space'
-H8250A4383E97: '%select{程序作用域|静态局部|extern}0变量必须位于%1地址空间中'
+H8250A4383E97: '%select{程序作用域|静态局部|extern}0变量必须位于 %1 地址空间中'
 # '%select{property|instance variable}0 access cannot be qualified with %1'
-H8153C2BE3904: '%select{属性|实例变量}0的访问不能使用%1修饰符'
+H8153C2BE3904: '%select{属性|实例变量}0的访问不能使用 %1 修饰符'
 # "%select{public|private|project}1 umbrella header file not found in input: '%0'"
 HFB4B45B92460: "%select{公共|私有|项目}1 伞状头文件未在输入中找到: '%0'"
 # "%select{qualifier in |static |}0array size %select{||'[*] '}0is a C99 feature"
@@ -1297,13 +1297,13 @@ H5561702CDE0D: "%select{限定符在 |静态 |}0数组大小%select{||'[*] '}0�
 # "%select{qualifier in |static |}0array size %select{||'[*] '}0is a C99 feature, not permitted in C++"
 HD9EDD0C87400: "%select{限定符在 |静态 |}0数组大小%select{||'[*] '}0是C99特性，不被C++允许"
 # '%select{read of|read of|assignment to|increment of|decrement of|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>}0 volatile %select{temporary|object %2|member %2}1 is not allowed in a constant expression'
-H88BF34501395: '%select{读取|读取|对...的赋值|递增|递减|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>}0 volatile %select{临时对象|对象%2|成员%2}1在常量表达式中不允许'
+H88BF34501395: '%select{读取|读取|对...的赋值|递增|递减|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>}0 volatile %select{临时对象|对象 %2|成员 %2}1在常量表达式中不允许'
 # '%select{read of|read of|assignment to|increment of|decrement of|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>}0 volatile-qualified type %1 is not allowed in a constant expression'
-HFA8AACB1DC9D: '%select{读取|读取|对...的赋值|递增|递减|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>}0 %1的volatile限定类型在常量表达式中不允许'
+HFA8AACB1DC9D: '%select{读取|读取|对...的赋值|递增|递减|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>}0 %1 的volatile限定类型在常量表达式中不允许'
 # '%select{read of|read of|assignment to|increment of|decrement of|member call on|dynamic_cast of|typeid applied to|construction of subobject of|destruction of|read of}0 %select{object outside its lifetime|uninitialized object}1 is not allowed in a constant expression'
 H030F1EA383B2: '%select{读取|读取|对...的赋值|递增|递减|成员调用|dynamic_cast|typeid应用|子对象构造|析构|读取}0 %select{超出其生命周期的对象|未初始化对象}1在常量表达式中不允许'
 # '%select{read of|read of|assignment to|increment of|decrement of|member call on|dynamic_cast of|typeid applied to|construction of subobject of|destruction of|read of}0 member %1 of union with %select{active member %3|no active member}2 is not allowed in a constant expression'
-HAA36C87281CE: '%select{读取|读取|对...的赋值|递增|递减|成员调用|dynamic_cast|typeid应用|子对象构造|析构|读取}0 union成员%1在%select{有活动成员%3|无活动成员}2时不允许出现在常量表达式中'
+HAA36C87281CE: '%select{读取|读取|对...的赋值|递增|递减|成员调用|dynamic_cast|typeid应用|子对象构造|析构|读取}0 union成员 %1 在%select{有活动成员 %3|无活动成员}2时不允许出现在常量表达式中'
 # '%select{read of|read of|assignment to|increment of|decrement of|member call on|dynamic_cast of|typeid applied to|construction of|destruction of|read of}0 %select{temporary|variable}1 whose %plural{8:storage duration|:lifetime}0 has ended'
 H1E2EE7FC7CDC: '%select{读取|读取|对...的赋值|递增|递减|成员调用|dynamic_cast|typeid应用|构造|析构|读取}0 %select{临时对象|变量}1其%plural{8:存储持续期|:生命周期}0已结束'
 # '%select{read of|read of|assignment to|increment of|decrement of|member call on|dynamic_cast of|typeid applied to|construction of|destruction of|read of}0 dereferenced null pointer is not allowed in a constant expression'
@@ -1315,29 +1315,29 @@ H5DD079C28614: '%select{读取|读取|对...的赋值|递增|递减|成员调用
 # '%select{read of|read of|assignment to|increment of|decrement of|member call on|dynamic_cast of|typeid applied to|construction of|destruction of|read of}0 heap allocated object that has been deleted'
 H0F4326DA1EA9: '%select{读取|读取|对...的赋值|递增|递减|成员调用|dynamic_cast|typeid应用|构造|析构|读取}0 已被删除的堆分配对象在常量表达式中不允许'
 # '%select{read of|read of|assignment to|increment of|decrement of|member call on|dynamic_cast of|typeid applied to|construction of|destruction of|read of}0 mutable member %1 is not allowed in a constant expression'
-H08EBC2661AFA: '%select{读取|读取|对...的赋值|递增|递减|成员调用|dynamic_cast|typeid应用|构造|析构|读取}0 mutable成员%1在常量表达式中不允许'
+H08EBC2661AFA: '%select{读取|读取|对...的赋值|递增|递减|成员调用|dynamic_cast|typeid应用|构造|析构|读取}0 mutable成员 %1 在常量表达式中不允许'
 # "%select{read of|read of|assignment to|increment of|decrement of|member call on|dynamic_cast of|typeid applied to|construction of|destruction of|read of}0 object '%1' whose value is not known"
-H2547ED9973E0: "%select{读取|读取|对...的赋值|递增|递减|成员调用|dynamic_cast|typeid应用|构造|析构|读取}0 值未知的对象'%1'在常量表达式中不允许"
+H2547ED9973E0: "%select{读取|读取|对...的赋值|递增|递减|成员调用|dynamic_cast|typeid应用|构造|析构|读取}0 值未知的对象 '%1' 在常量表达式中不允许"
 # '%select{read of|read of|assignment to|increment of|decrement of|member call on|dynamic_cast of|typeid applied to|construction of|destruction of|read of}0 temporary is not allowed in a constant expression outside the expression that created the temporary'
 H1A04D5C0C6D4: '%select{读取|读取|对...的赋值|递增|递减|成员调用|dynamic_cast|typeid应用|构造|析构|读取}0 临时对象在创建它的表达式之外的常量表达式中不允许'
 # '%select{reading|writing}1 the value pointed to by %0 requires holding %select{any mutex|any mutex exclusively}1'
-H20B2C79559EA: '%select{读取|写入}1所指向的%0需要持有%select{任意互斥锁|独占互斥锁}1'
+H20B2C79559EA: '%select{读取|写入}1所指向的 %0 需要持有%select{任意互斥锁|独占互斥锁}1'
 # '%select{reading|writing}1 variable %0 requires holding %select{any mutex|any mutex exclusively}1'
-HAB41C50F5547: '%select{读取|写入}1变量%0需要持有%select{任意互斥锁|独占互斥锁}1'
+HAB41C50F5547: '%select{读取|写入}1变量 %0 需要持有%select{任意互斥锁|独占互斥锁}1'
 # "%select{reading|writing}3 the value pointed to by %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
-HA3CF53D5D321: "%select{读取|写入}3 %1所指向的值需要保持%0 %select{'%2'|'独占的%2'}3"
+HA3CF53D5D321: "%select{读取|写入}3 %1 所指向的值需要保持 %0 %select{'%2'|'独占的 %2'}3"
 # "%select{reading|writing}3 variable %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
-HBF61FE4FFCA3: "%select{读取|写入}3 变量%1需要保持%0 %select{'%2'|'独占的%2'}3"
+HBF61FE4FFCA3: "%select{读取|写入}3 变量 %1 需要保持 %0 %select{'%2'|'独占的 %2'}3"
 # "%select{reference|backing array for 'std::initializer_list'}2 %select{|subobject of }1member %0 %select{binds to|is}2 a temporary object whose lifetime is shorter than the lifetime of the constructed object"
-H31A36503387B: "%select{引用|'std::initializer_list'的后备数组}2 %select{|成员%0的子对象}1 %select{绑定到|是}2 一个临时对象，其生命周期比构造对象的生命周期短"
+H31A36503387B: "%select{引用|'std::initializer_list'的后备数组}2 %select{|成员 %0 的子对象}1 %select{绑定到|是}2 一个临时对象，其生命周期比构造对象的生命周期短"
 # "%select{reference|backing array for 'std::initializer_list'}2 %select{|subobject of }1member %0 %select{binds to|is}2 a temporary object whose lifetime would be shorter than the lifetime of the constructed object"
-H54C5751F42B3: "%select{引用|'std::initializer_list'的后备数组}2 %select{|成员%0的子对象}1 %select{绑定到|是}2 一个临时对象，其生命周期将比构造对象的生命周期短"
+H54C5751F42B3: "%select{引用|'std::initializer_list'的后备数组}2 %select{|成员 %0 的子对象}1 %select{绑定到|是}2 一个临时对象，其生命周期将比构造对象的生命周期短"
 # '%select{reference|pointer}0 member declared here'
 H8AC5A0A64CFD: '%select{引用|指针}0 成员在此声明'
 # '%select{reinterpret_cast|C-style cast}0 from %1 to %2 changes address space of nested pointers'
-HDAB148B74E30: '从%1到%2的%select{reinterpret_cast|C风格转换}0更改了嵌套指针的地址空间'
+HDAB148B74E30: '从 %1 到 %2 的%select{reinterpret_cast|C风格转换}0更改了嵌套指针的地址空间'
 # '%select{reinterpret_cast|dynamic_cast|%select{this conversion|cast that performs the conversions of a reinterpret_cast}1|cast from %1}0 is not allowed in a constant expression%select{| in C++ standards before C++20||}0'
-H1688ED0E5178: '%select{reinterpret_cast|dynamic_cast|%select{此转换|执行reinterpret_cast转换的转换}1|来自%1的转换}0 在常量表达式中不允许%select{|在C++20之前的C++标准中||}0'
+H1688ED0E5178: '%select{reinterpret_cast|dynamic_cast|%select{此转换|执行reinterpret_cast转换的转换}1|来自 %1 的转换}0 在常量表达式中不允许%select{|在C++20之前的C++标准中||}0'
 # '%select{remainder|division}0 by zero is undefined'
 HDDF6DBF3AFB2: '%select{余数|除法}0 除以零是未定义的'
 # '%select{returning|passing}0 a VL-dependent argument %select{from|to}0 a function with a different streaming-mode is undefined behaviour when the streaming and non-streaming vector lengths are different at runtime'
@@ -1345,25 +1345,25 @@ HD835E99E7B94: '%select{返回|传递}0 一个VL相关的参数%select{从|到}0
 # '%select{returning|passing}0 a VL-dependent argument %select{from|to}0 a locally streaming function is undefined behaviour when the streaming and non-streaming vector lengths are different at runtime'
 H78DE8F398FA2: '%select{返回|传递}0 一个VL相关的参数%select{从|到}0 一个本地流式函数，在流式和非流式向量长度运行时不同的情况下属于未定义行为'
 # '%select{return|parameter|variable|field|instance variable|synthesized instance variable}0 type %1 is an abstract class'
-H83DAE33A1A29: '%select{返回类型|参数类型|变量类型|字段类型|实例变量类型|合成实例变量类型}0 %1是抽象类'
+H83DAE33A1A29: '%select{返回类型|参数类型|变量类型|字段类型|实例变量类型|合成实例变量类型}0 %1 是抽象类'
 # "%select{self-|array |pointer }0comparison always evaluates to %select{a constant|true|false|'std::strong_ordering::equal'}1"
 H25C7EE9B164E: "%select{自我|数组 |指针 }0比较始终计算为%select{一个常量|true|false|'std::strong_ordering::equal'}1"
 # "%select{shader model|Vulkan environment|shader stage}0 '%1' in target '%2' is invalid for HLSL code generation"
-H559D5EF03AE6: "%select{着色器模型|Vulkan环境|着色器阶段}0 '%1' 在目标'%2'中对HLSL代码生成无效"
+H559D5EF03AE6: "%select{着色器模型|Vulkan环境|着色器阶段}0 '%1' 在目标 '%2' 中对HLSL代码生成无效"
 # "%select{shader model|Vulkan environment|shader stage}0 is required as %select{OS|environment}1 in target '%2' for HLSL code generation"
-H2955A7AC1204: "需要将%select{着色器模型|Vulkan环境|着色器阶段}0 指定为%select{操作系统|环境}1 在目标'%2'中进行HLSL代码生成"
+H2955A7AC1204: "需要将%select{着色器模型|Vulkan环境|着色器阶段}0 指定为%select{操作系统|环境}1 在目标 '%2' 中进行HLSL代码生成"
 # '%select{signed value|extra discriminator|blended pointer|blended integer}0 must have %select{pointer|integer|pointer or integer}1 type; type here is %2'
-HA4822404707C: '%select{有符号值|额外判别器|混合指针|混合整数}0 必须具有%select{指针|整数|指针或整数}1 类型；此处类型为%2'
+HA4822404707C: '%select{有符号值|额外判别器|混合指针|混合整数}0 必须具有%select{指针|整数|指针或整数}1 类型；此处类型为 %2'
 # "%select{signed |}0'size_t' literal is out of range of possible %select{signed |}0'size_t' values"
 HADACA5CF45B7: "'%select{有符号 |}0'size_t' 字面量超出可能%select{有符号 |}0'size_t' 值的范围"
 # '%select{signed|unsigned}0 _BitInt must have a bit size of at least %select{2|1}0'
-H866585566251: '%select{有符号|无符号}0 _BitInt 必须具有至少%select{2|1}0位大小'
+H866585566251: '%select{有符号|无符号}0 _BitInt 必须具有至少 %select{2|1}0 位大小'
 # '%select{signed|unsigned}0 _BitInt of bit sizes greater than %1 not supported'
-HB66515AEE2F3: '%select{有符号|无符号}0 _BitInt 的位大小超过%1不受支持'
+HB66515AEE2F3: '%select{有符号|无符号}0 _BitInt 的位大小超过 %1 不受支持'
 # "%select{source|destination}2 of '%select{%select{memcpy|wmemcpy}1|%select{memmove|wmemmove}1}0' is %3"
-H752C91AB4DE4: "'%select{%select{memcpy|wmemcpy}1|%select{memmove|wmemmove}1}0'的%select{源|目标}2 是%3"
+H752C91AB4DE4: "'%select{%select{memcpy|wmemcpy}1|%select{memmove|wmemmove}1}0'的%select{源|目标}2 是 %3"
 # "%select{statement after '#pragma omp %1' must be a for loop|expected %2 for loops after '#pragma omp %1'%select{|, but found only %4}3}0"
-H5AE78EDFB051: '%select{#pragma omp %1后的语句必须是一个for循环|期望在#pragma omp %1后有%2个for循环%select{|，但仅找到%4}3}0'
+H5AE78EDFB051: '%select{#pragma omp %1 后的语句必须是一个for循环|期望在#pragma omp %1 后有 %2 个for循环%select{|，但仅找到 %4}3}0'
 # '%select{statement|directive}0 outside teams construct here'
 HCEC20E30EFC9: '%select{语句|指令}0 在 teams 结构外部此处'
 # "%select{static data member is predetermined as shared|variable with static storage duration is predetermined as shared|loop iteration variable is predetermined as private|loop iteration variable is predetermined as linear|loop iteration variable is predetermined as lastprivate|constant variable is predetermined as shared|global variable is predetermined as shared|non-shared variable in a task construct is predetermined as firstprivate|variable with automatic storage duration is predetermined as private}0%select{|; perhaps you forget to enclose 'omp %2' directive into a parallel or another task region?}1"
@@ -1409,15 +1409,15 @@ HEDDF73011D6C: '%select{模板参数太少|模板参数太多}0 在模板模板�
 # '%select{too many|too few}0 elements in vector %select{initialization|operand}3 (expected %1 elements, have %2)'
 HEB48F48C2E39: '%select{太少|太多}0 元素在向量%select{初始化|操作数}3中（期望 %1 个，实际 %2 个）'
 # '%select{type tag|argument}0 index %1 is greater than the number of arguments specified'
-H7C0418F179E9: '%select{类型标记|参数}0 索引%1大于指定参数的数量'
+H7C0418F179E9: '%select{类型标记|参数}0 索引 %1 大于指定参数的数量'
 # '%select{typedef|type alias|type alias template}0 redefinition with different types%diff{ ($ vs $)|}1,2'
 H7F72DD3ED811: '%select{typedef|type alias|type alias template}0 类型重新定义%diff{ ($ vs $)|}1,2'
 # '%select{uninitialized use occurs|variable is captured by block}0 here'
 H80571A54148A: '%select{未初始化的使用发生|变量被块捕获}0 此处'
 # '%select{unknown|unsupported}0 machine mode %1'
-HB579643BB1CB: '%select{未知|不受支持}0 的机器模式%1'
+HB579643BB1CB: '%select{未知|不受支持}0 的机器模式 %1'
 # '%select{unsafe pointer operation|unsafe pointer arithmetic|unsafe buffer access|function introduces unsafe buffer manipulation|unsafe invocation of %1|field %1 prone to unsafe buffer manipulation}0'
-HD969AD0BDB13: '%select{不安全指针操作|不安全指针运算|不安全缓冲区访问|函数引入不安全缓冲区操作|调用%1不安全|字段%1易导致不安全缓冲区操作}0'
+HD969AD0BDB13: '%select{不安全指针操作|不安全指针运算|不安全缓冲区访问|函数引入不安全缓冲区操作|调用 %1 不安全|字段 %1 易导致不安全缓冲区操作}0'
 # "%select{unsupported|duplicate|unknown}0%select{| CPU| tune CPU}1 '%2' in the '%select{target|target_clones|target_version}3' attribute string;"
 H8412993B41A2: "%select{不支持|重复|未知}0%select{| CPU| tune CPU}1 '%2' 在 '%select{target|target_clones|target_version}3' 属性字符串中;"
 # "%select{unsupported|duplicate|unknown}0%select{| CPU| tune CPU}1 '%2' in the '%select{target|target_clones|target_version}3' attribute string; '%select{target|target_clones|target_version}3' attribute ignored"
@@ -1425,15 +1425,15 @@ H952DC46C8259: "%select{不支持|重复|未知}0%select{| CPU| tune CPU}1 '%2' 
 # '%select{using this character in an identifier|starting an identifier with this character}0 is incompatible with C99'
 H2BC4F8FF7FD4: '%select{在标识符中使用该字符|以该字符开头的标识符}0 不符合C99规范'
 # "%select{values of type|enum values with underlying type}2 '%0' should not be used as format arguments; add an explicit cast to %1 instead"
-H74FA7B9CE6BC: "%select{类型|基础类型为的枚举值}2 '%0'不应作为格式参数使用；请显式转换为%1类型"
+H74FA7B9CE6BC: "%select{类型|基础类型为的枚举值}2 '%0' 不应作为格式参数使用；请显式转换为 %1 类型"
 # '%select{value|type}0-dependent expression passed as an argument to debug command'
 HF8F02B43BB62: '%select{值|类型}0 依赖表达式被传递给调试命令'
 # '%select{variable|static data member}0 instantiated with function type %1'
-HE6193A7D74C4: '%select{变量|静态数据成员}0 实例化为函数类型%1'
+HE6193A7D74C4: '%select{变量|静态数据成员}0 实例化为函数类型 %1'
 # '%select{via initialization of|binding reference}0 variable %select{%2 |}1here'
 HB0440A5001E5: '%select{通过初始化|绑定引用}0 变量%select{%2 |}1此处'
 # "%select{virtual method|function pointer}0 cannot be inferred '%1'"
-H57712FD11644: "%select{虚方法|函数指针}0 无法推断'%1'"
+H57712FD11644: "%select{虚方法|函数指针}0 无法推断 '%1'"
 # '%select{void function|void method|constructor|destructor}1 %0 must not return a value'
 HE90DDC8579B5: '%select{void函数|void方法|构造函数|析构函数}1 %0 必须不返回值'
 # '%select{void function|void method|constructor|destructor}1 %0 should not return a value'
@@ -1441,21 +1441,21 @@ H917D4EA3DC61: '%select{void函数|void方法|构造函数|析构函数}1 %0 不
 # '%select{wide|Unicode}0 character literals may not contain multiple characters'
 HEBA1B65B6166: '%select{宽|Unicode}0 字符文字不能包含多个字符'
 # "%select{x86|x86-64}0 'interrupt' attribute only applies to functions that have %select{a 'void' return type|only a pointer parameter optionally followed by an integer parameter|a pointer as the first parameter|a %2 type as the second parameter}1"
-H6EAE552C7EA8: "%select{x86|x86-64}0 'interrupt' 属性仅适用于%select{返回类型为void的函数|仅带有可选后续整数参数的指针参数|第一个参数为指针|第二个参数为%2类型}1 的函数"
+H6EAE552C7EA8: "%select{x86|x86-64}0 'interrupt' 属性仅适用于%select{返回类型为void的函数|仅带有可选后续整数参数的指针参数|第一个参数为指针|第二个参数为 %2 类型}1 的函数"
 # "%select{|'%1-%2' }0diagnostics %select{with '%2' severity |}0%select{expected|seen}3 but not %select{seen|expected}3: %4"
 H6E1DC1644300: "%select{|'%1-%2' }0 诊断信息%select{以 '%2' 严重性 |}0%select{期望|检测到}3 但未%select{检测到|期望}3： %4"
 # '%select{|a template declaration|an explicit template specialization|an explicit template instantiation}0 can only %select{|declare|declare|instantiate}0 a single entity'
 HCEE3630F178B: '%select{|一个模板声明|一个显式模板特化|一个显式模板实例化}0 只能 %select{|声明|声明|实例化}0 单个实体'
 # "%select{|captured }1%0 parameter marked 'called_once' is never called"
-H5EDD8753404F: "%select{|被捕获的 }1%0 参数标记为'called_once'但从未被调用"
+H5EDD8753404F: "%select{|被捕获的 }1%0 参数标记为 'called_once' 但从未被调用"
 # '%select{|captured }1completion handler is never called'
 H31A1FA39F285: '%select{|被捕获的 }1完成处理程序从未被调用'
 # "%select{|change to 'snprintf' for explicit bounds checking | buffer pointer and size may not match|string argument is not guaranteed to be null-terminated|'va_list' is unsafe}0"
-H071DEF637982: "%select{|改为使用'snprintf'进行显式边界检查 | 缓冲区指针和大小可能不匹配|string参数不保证以空字符终止|'va_list'不安全}0"
+H071DEF637982: "%select{|改为使用 'snprintf' 进行显式边界检查 | 缓冲区指针和大小可能不匹配|string参数不保证以空字符终止|'va_list' 不安全}0"
 # '%select{|direct }0%select{method|property}1 declaration conflicts with previous %select{|direct }2declaration of %select{method|property}1 %3'
 H1D02391D3A58: '%select{|直接 }0%select{方法|属性}1 声明与之前的 %select{|直接 }2 声明冲突 %select{方法|属性}1 %3'
 # '%select{|empty }0%select{struct|union}1 has size 0 in C, %select{size 1|non-zero size}2 in C++'
-HEA8D8C4B49F9: '%select{|空 }0%select{结构体|联合体}1 在C中有大小0，在C++中%select{大小为1|非零大小}2'
+HEA8D8C4B49F9: '%select{|空 }0%select{结构体|联合体}1 在C中有大小 0，在C++中%select{大小为 1|非零大小}2'
 # "%select{|implicit }0use of 'this' pointer is only allowed within the evaluation of a call to a 'constexpr' member function"
 HE1347141F3D2: '%select{|隐式 }0使用"this"指针仅允许在constexpr成员函数调用的求值过程中使用'
 # '%select{|implicitly }1declared %select{private|protected}0 here'
@@ -1467,41 +1467,41 @@ H02CD4F5E389B: '%select{|递增的 }0枚举值超出int类型的范围与C23之�
 # '%select{|member|base class}0 %1 declared here'
 H83331E20A1A3: '%select{|成员|基类}0 %1 声明于此'
 # '%select{|member}0 using declaration %1 instantiates to an empty pack'
-H03EFD19ED92A: '%select{|成员}0 using声明%1 实例化为空包'
+H03EFD19ED92A: '%select{|成员}0 using声明 %1 实例化为空包'
 # '%select{|non-aggregate }0type %1 cannot be initialized with an initializer list'
-H94A9DAA06E2F: '%select{|非聚合 }0类型%1 不能用初始化列表初始化'
+H94A9DAA06E2F: '%select{|非聚合 }0类型 %1 不能用初始化列表初始化'
 # '%select{|overriding }1method cannot be unavailable on %0 when %select{the protocol method it implements|its overridden method}1 is available'
-H11BFB9C90008: '%select{|覆盖 }1方法在%0不可用时，当%select{实现的协议方法|覆盖的方法}1 是可用时不允许'
+H11BFB9C90008: '%select{|覆盖 }1方法在 %0 不可用时，当%select{实现的协议方法|覆盖的方法}1 是可用时不允许'
 # '%select{|overriding }4method %select{introduced after|deprecated before|obsoleted before}0 %select{the protocol method it implements|overridden method}4 on %1 (%2 vs. %3)'
-H3102E4185799: '%select{|覆盖 }4方法%select{在...之后引入|在...之前弃用|在...之前淘汰}0 %select{实现的协议方法|覆盖的方法}4 在%1 (%2 对比 %3)'
+H3102E4185799: '%select{|覆盖 }4方法%select{在...之后引入|在...之前弃用|在...之前淘汰}0 %select{实现的协议方法|覆盖的方法}4 在 %1 (%2 对比 %3)'
 # '%select{|pointer to |reference to }0incomplete type %1 is not allowed in exception specification'
-HBD4554E2864A: '%select{|指向|对...的引用}0 不完整类型%1 不允许出现在异常说明中'
+HBD4554E2864A: '%select{|指向|对...的引用}0 不完整类型 %1 不允许出现在异常说明中'
 # "%select{|previous }0'hint' clause with value '%1'"
-HBBFA3E1A9C6B: "%select{|之前的 }0'hint'子句值为'%1'"
+HBBFA3E1A9C6B: "%select{|之前的 }0'hint' 子句值为 '%1'"
 # "%select{|previous }0directive with no 'hint' clause specified"
-H8CE1C8734C39: "%select{|之前的 }0未指定'hint'子句的指令"
+H8CE1C8734C39: "%select{|之前的 }0未指定 'hint' 子句的指令"
 # '%select{|previous }0using declaration'
 H5AE3701DBB92: '%select{|之前的 }0using声明'
 # '%select{|previous }0using-enum declaration'
 H5BC63E8C8F5E: '%select{|之前的 }0using-enum声明'
 # '%select{|reference to }0sizeless type %1 is not allowed in exception specification'
-H3E89611A15B6: '%select{|对 }0大小缺失的类型%1的引用在异常规格中不允许'
+H3E89611A15B6: '%select{|对 }0大小缺失的类型 %1 的引用在异常规格中不允许'
 # '%select{|second }0%1 token is here'
-H00E98F1D44F7: '%select{|第二个 }0%1标记在此处'
+H00E98F1D44F7: '%select{|第二个 }0%1 标记在此处'
 # '%select{|static_cast|reinterpret_cast|dynamic_cast|C-style cast|functional-style cast|}0 from %1 to %2 uses deleted function%select{|: %4}3'
-HD806C936F5D9: '%select{|static_cast|reinterpret_cast|dynamic_cast|C风格转换|函数式转换|}0从%1到%2的转换使用了已删除的函数%select{|: %4}3'
+HD806C936F5D9: '%select{|static_cast|reinterpret_cast|dynamic_cast|C风格转换|函数式转换|}0从 %1 到 %2 的转换使用了已删除的函数%select{|: %4}3'
 # '%select{|success |failure }0memory order argument to atomic operation is invalid'
 HFAC869D2863E: '%select{|成功 |失败 }0原子操作的内存顺序参数无效'
 # "%select{|umbrella }0header '%1' not found"
-H3FDB64D57A92: "%select{|umbrella }0头文件'%1'未找到"
+H3FDB64D57A92: "%select{|umbrella }0头文件 '%1' 未找到"
 # '%select{|unsafe_unretained|strong|weak}1 property %0 may not also be declared %select{|__unsafe_unretained|__strong|__weak|__autoreleasing}2'
 HC9D6BEED9F9F: '%select{|unsafe_unretained|strong|weak}1 属性 %0 可能也不能被声明为 %select{|__unsafe_unretained|__strong|__weak|__autoreleasing}2'
 # '%select{||reinterpret_cast||C-style cast||}0 from scalar %1 to vector %2 of different size'
-HFF11D1B4EA50: '%select{||reinterpret_cast||C风格转换||}0从标量%1到不同大小的向量%2'
+HFF11D1B4EA50: '%select{||reinterpret_cast||C风格转换||}0从标量 %1 到不同大小的向量 %2'
 # '%select{||reinterpret_cast||C-style cast||}0 from vector %1 to scalar %2 of different size'
-H4BC2B3E593E1: '%select{||reinterpret_cast||C风格转换||}0从向量%1到不同大小的标量%2'
+H4BC2B3E593E1: '%select{||reinterpret_cast||C风格转换||}0从向量 %1 到不同大小的标量 %2'
 # '%select{||reinterpret_cast||C-style cast||}0 from vector %1 to vector %2 of different size'
-H855233AE0D42: '%select{||reinterpret_cast||C风格转换||}0从向量%1到不同大小的向量%2'
+H855233AE0D42: '%select{||reinterpret_cast||C风格转换||}0从向量 %1 到不同大小的向量 %2'
 # "%select{|||||virtual function called on|dynamic_cast applied to|typeid applied to|construction of|destruction of}0 object '%1' whose dynamic type is not constant"
 H292A692F3948: "%select{|||||虚函数调用|dynamic_cast 应用于|typeid 应用于|构造|析构}0 对象 '%1' 其动态类型不是常量"
 # "'##' cannot appear at end of __VA_OPT__ argument"
@@ -1513,7 +1513,7 @@ H2F2411264E60: "'##'不能出现在__VA_OPT__参数开头"
 # "'##' cannot appear at start of macro expansion"
 H49669D0F3359: "'##'不能出现在宏展开开头"
 # "'#include <filename>' attaches the declarations to the named module '%0', which is not usually intended; consider moving that directive before the module declaration"
-HE8759FB5FF70: "'#include <filename>'将声明附加到名为%0的模块，这通常不是预期行为；建议将该指令移动到模块声明之前"
+HE8759FB5FF70: "'#include <filename>'将声明附加到名为 %0 的模块，这通常不是预期行为；建议将该指令移动到模块声明之前"
 # "'#pragma %0' can only appear at file scope"
 HCE0F9341D433: "'#pragma %0'只能出现在文件作用域"
 # "'#pragma %0' can only appear at file scope or at the start of a compound statement"
@@ -1615,7 +1615,7 @@ H0985DFE3C8AA: "'%0' 类型转换在不使用 ARC 时没有效果"
 # "'%0' clause is specified here"
 H573F42F97FF4: "'%0' 子句在此处指定"
 # "'%0' clause not allowed on a 'kernels loop' construct that has a '%1' clause with a%select{n| 'num'}2 argument"
-HA63B4E6AC69A: "'%0' 子句不允许用于带有参数为%select{n| 'num'}2的'%1'子句的'kernels loop'结构"
+HA63B4E6AC69A: "'%0' 子句不允许用于带有参数为%select{n| 'num'}2的 '%1' 子句的'kernels loop'结构"
 # "'%0' clause requires 'dispatch' context selector"
 H94FAB67C930A: "'%0' 子句需要 'dispatch' 上下文选择器"
 # "'%0' clause specifies a loop count greater than the number of available loops"
@@ -1685,87 +1685,87 @@ H55337290EE76: "'%0' 是 C23 的关键字"
 # "'%0' is a keyword in C99"
 H305C2462E219: "'%0' 是 C99 的关键字"
 # "'%0' is bound to current loop, GCC binds it to the enclosing loop"
-H6C2FAF9A98CF: "'%0'绑定到当前循环，而GCC将其绑定到外部循环"
+H6C2FAF9A98CF: "'%0' 绑定到当前循环，而GCC将其绑定到外部循环"
 # "'%0' is ignored since it is only supported for HIP"
-HAF6605CCA46F: "'%0'被忽略，因为它仅在HIP中支持"
+HAF6605CCA46F: "'%0' 被忽略，因为它仅在HIP中支持"
 # "'%0' is incompatible with C standards before C11"
-H0DA1AA64E023: "'%0'与C11之前的C标准不兼容"
+H0DA1AA64E023: "'%0' 与C11之前的C标准不兼容"
 # "'%0' is incompatible with C standards before C23"
-HDD86BE78B3D0: "'%0'与C23之前的C标准不兼容"
+HDD86BE78B3D0: "'%0' 与C23之前的C标准不兼容"
 # "'%0' is incompatible with C standards before C2y"
 H1CC83438FCCD: "'%0' 与C2y之前的C标准不兼容"
 # "'%0' is invalid in friend declarations"
-H3D161449A142: "'%0'在friend声明中无效"
+H3D161449A142: "'%0' 在friend声明中无效"
 # "'%0' is not a valid Unicode character name"
-H469DC75B6244: "'%0'不是有效的Unicode字符名称"
+H469DC75B6244: "'%0' 不是有效的Unicode字符名称"
 # "'%0' is not a valid builtin name for %1"
-H4BF3E4DBB43C: "'%0'不是%1的有效内建名称"
+H4BF3E4DBB43C: "'%0' 不是 %1 的有效内建名称"
 # "'%0' is not a valid context property for the context selector '%1' and the context set '%2'; property ignored"
-HEB6F750CA90C: "'%0'不是上下文选择器'%1'和上下文集合'%2'的有效属性；属性被忽略"
+HEB6F750CA90C: "'%0' 不是上下文选择器 '%1' 和上下文集合 '%2' 的有效属性；属性被忽略"
 # "'%0' is not a valid context selector for the context set '%1'; selector ignored"
-H6CA470A4E352: "'%0'不是上下文集合'%1'的有效选择器；选择器被忽略"
+H6CA470A4E352: "'%0' 不是上下文集合 '%1' 的有效选择器；选择器被忽略"
 # "'%0' is not a valid context set in a `declare variant`; set ignored"
-HA1E62D28111D: "'%0'在`declare variant`中不是有效的上下文集合；集合被忽略"
+HA1E62D28111D: "'%0' 在`declare variant`中不是有效的上下文集合；集合被忽略"
 # "'%0' is not a valid object format flag"
-H0558CE31CE90: "'%0'不是有效的目标格式标志"
+H0558CE31CE90: "'%0' 不是有效的目标格式标志"
 # "'%0' is not permitted on a declaration of a type"
-H43ABF8D7D74B: "'%0'不允许用于类型声明"
+H43ABF8D7D74B: "'%0' 不允许用于类型声明"
 # "'%0' is not supported in C++ for OpenCL"
-HDCEA34FAF8C7: "'%0'在C++的OpenCL中不受支持"
+HDCEA34FAF8C7: "'%0' 在C++的OpenCL中不受支持"
 # "'%0' is only allowed on variable declarations"
-H6BFADFD542E9: "'%0'仅允许用于变量声明"
+H6BFADFD542E9: "'%0' 仅允许用于变量声明"
 # "'%0' is only available in %1"
-H468F8034CF09: "'%0'仅在%1中可用"
+H468F8034CF09: "'%0' 仅在 %1 中可用"
 # "'%0' is used without '-mstack-protector-guard-offset', and there is no default"
-H8812B24333D0: "'%0'未与'-mstack-protector-guard-offset'选项一起使用，且没有默认值"
+H8812B24333D0: "'%0' 未与'-mstack-protector-guard-offset'选项一起使用，且没有默认值"
 # "'%0' keyword is a C++11 extension"
-H23175F3671E1: "'%0'关键字是C++11的扩展"
+H23175F3671E1: "'%0' 关键字是C++11的扩展"
 # "'%0' keyword is incompatible with C++98"
-HCFDB7E16EAB8: "'%0'关键字与C++98不兼容"
+HCFDB7E16EAB8: "'%0' 关键字与C++98不兼容"
 # "'%0' keyword not permitted with interface types"
-HFAA4A308281C: "'%0'关键字不允许与接口类型一起使用"
+HFAA4A308281C: "'%0' 关键字不允许与接口类型一起使用"
 # "'%0' may overflow; destination buffer in argument %1 has size %2, but the corresponding specifier may require size %3"
-H45D6462C38BC: "'%0'可能发生溢出；参数%1中的目标缓冲区大小为%2，但对应的说明符可能需要大小%3"
+H45D6462C38BC: "'%0' 可能发生溢出；参数 %1 中的目标缓冲区大小为 %2，但对应的说明符可能需要大小 %3"
 # "'%0' not supported, please use -iquote instead"
-HD03640F49183: "'%0'不受支持，请改用 -iquote"
+HD03640F49183: "'%0' 不受支持，请改用 -iquote"
 # "'%0' only applies to %select{function|pointer|Objective-C object or block pointer}1 types; type here is %2"
-H76B771A1DA3E: "'%0'仅适用于%select{函数|指针|Objective-C对象或块指针}1类型；此处的类型是%2"
+H76B771A1DA3E: "'%0' 仅适用于%select{函数|指针|Objective-C对象或块指针}1类型；此处的类型是 %2"
 # "'%0' only applies to medium and large code models"
-H2B43B16BADDB: "'%0'仅适用于中等和大型代码模型"
+H2B43B16BADDB: "'%0' 仅适用于中等和大型代码模型"
 # "'%0' option requires target HLSL Version >= 2018%select{| and shader model >= 6.2}1, but HLSL Version is '%2'%select{| and shader model is '%3'}1"
-H73FD169C1664: "'%0'选项要求目标HLSL版本 >= 2018%select{|且着色器模型 >= 6.2}1，但HLSL版本是'%2'%select{|且着色器模型是'%3'}1"
+H73FD169C1664: "'%0' 选项要求目标HLSL版本 >= 2018%select{|且着色器模型 >= 6.2}1，但HLSL版本是 '%2'%select{|且着色器模型是 '%3'}1"
 # "'%0' parameter can only be used with swiftcall%select{ or swiftasynccall|}1 calling convention%select{|s}1"
-H7F6C0A7A9011: "'%0'参数只能与swiftcall%select{或swiftasynccall|}1调用约定%select{|s}1一起使用"
+H7F6C0A7A9011: "'%0' 参数只能与swiftcall%select{或swiftasynccall|}1调用约定%select{|s}1一起使用"
 # "'%0' parameter must have pointer%select{| to unqualified pointer}1 type; type here is %2"
-HA49C073BB7A8: "'%0'参数必须具有指针%select{|到无限定符指针}1类型；此处的类型是%2"
+HA49C073BB7A8: "'%0' 参数必须具有指针%select{|到无限定符指针}1类型；此处的类型是 %2"
 # "'%0' previously encountered here"
-HC082D10D967F: "'%0'之前在这里遇到过"
+HC082D10D967F: "'%0' 之前在这里遇到过"
 # "'%0' qualifier is not allowed on a constructor"
-HD3C37F48AA10: "'%0'限定符不能用于构造函数"
+HD3C37F48AA10: "'%0' 限定符不能用于构造函数"
 # "'%0' qualifier is not allowed on a destructor"
-H63A821EC7A98: "'%0'限定符不能用于析构函数"
+H63A821EC7A98: "'%0' 限定符不能用于析构函数"
 # "'%0' qualifier may not appear after the virtual specifier '%1'"
-HC82C66448381: "'%0'限定符不能出现在virtual说明符'%1'之后"
+HC82C66448381: "'%0' 限定符不能出现在virtual说明符 '%1' 之后"
 # "'%0' qualifier may not be applied to a reference"
-H39DF4A724F57: "'%0'限定符不能应用于引用"
+H39DF4A724F57: "'%0' 限定符不能应用于引用"
 # "'%0' qualifier on function type %1 has no effect"
-HCA4F5C288E32: "'%0'限定符对函数类型%1没有影响"
+HCA4F5C288E32: "'%0' 限定符对函数类型 %1 没有影响"
 # "'%0' qualifier on function type %1 has no effect and is a Clang extension"
-HA82B1E90695B: "'%0'限定符对函数类型%1没有影响，并且是Clang的扩展"
+HA82B1E90695B: "'%0' 限定符对函数类型 %1 没有影响，并且是Clang的扩展"
 # "'%0' qualifier on omitted return type %1 has no effect"
-H226C520C0A5C: "'%0'限定符对省略的返回类型%1没有影响"
+H226C520C0A5C: "'%0' 限定符对省略的返回类型 %1 没有影响"
 # "'%0' qualifier on reference type %1 has no effect"
-H9D5F7EA85F79: "'%0'限定符对引用类型%1没有影响"
+H9D5F7EA85F79: "'%0' 限定符对引用类型 %1 没有影响"
 # "'%0' qualifier%s1 on base class type %2 %plural{1:has|:have}1 no effect"
-HB4BF74C2E9A3: "'%0'限定符%s1在基类类型%2 %plural{1:没有|:没有}1影响"
+HB4BF74C2E9A3: "'%0' 限定符%s1在基类类型 %2 %plural{1:没有|:没有}1影响"
 # "'%0' region encountered before requires directive with '%1' clause"
-HAC48A5EE380D: "'%0'区域在包含'%1'子句的requires指令之前被遇到"
+HAC48A5EE380D: "'%0' 区域在包含 '%1' 子句的requires指令之前被遇到"
 # "'%0' required by '%1'"
-H149191A7D780: "'%0'由'%1'要求"
+H149191A7D780: "'%0' 由 '%1' 要求"
 # "'%0' required for precompiled header not found"
-HBDA853057C16: "用于预编译头的'%0'未找到"
+HBDA853057C16: "用于预编译头的 '%0' 未找到"
 # "'%0' size argument is too large; destination buffer has size %1, but size argument is %2"
-H1B04445BBECB: "'%0'的大小参数过大；目标缓冲区的大小为%1，但大小参数是%2"
+H1B04445BBECB: "'%0' 的大小参数过大；目标缓冲区的大小为 %1，但大小参数是 %2"
 # "'%0' specifier is not allowed outside a class definition"
 H496E8612120E: "'%0' 规定符不允许在类定义外部使用"
 # "'%0' statement cannot be used in OpenMP for loop"
@@ -1773,7 +1773,7 @@ HB1E296AE95BC: "'%0' 语句不能在OpenMP for循环中使用"
 # "'%0' statement cannot be used in OpenMP simd region"
 H1C587C7353B1: "'%0' 语句不能在OpenMP simd区域中使用"
 # "'%0' type not found; include <omp.h>"
-H4CF50F4E769F: "未找到'%0'类型；请包含<omp.h>"
+H4CF50F4E769F: "未找到 '%0' 类型；请包含<omp.h>"
 # "'%0' type qualifier%s1 on return type %plural{1:has|:have}1 no effect"
 H065A9C128711: "'%0' 类型限定符%s1 在返回类型 %plural{1:没有|:没有}1 效果"
 # "'%0' type specifier is incompatible with C++98"
@@ -1783,17 +1783,17 @@ H08EBA7A5907F: "'%0' 变量必须具有全局存储"
 # "'%0' will always be truncated; specified size is %1, but format string expands to at least %2"
 H0AA6DDAAABA2: "'%0' 将始终被截断；指定的大小为 %1，但格式字符串展开到至少 %2"
 # "'%0' will always evaluate to 'true' in a manifestly constant-evaluated expression"
-H75D7A83FFEC6: "'%0' 在显式常量求值表达式中始终会求值为'true'"
+H75D7A83FFEC6: "'%0' 在显式常量求值表达式中始终会求值为 'true'"
 # "'%0' will always overflow; destination buffer has size %1, but format string expands to at least %2"
 H6C8DA523F6B3: "'%0' 将始终溢出；目标缓冲区大小为 %1，但格式字符串展开到至少 %2"
 # "'%0' will always overflow; destination buffer has size %1, but size argument is %2"
-H6A8E065AE173: "'%0' 将始终溢出；目标缓冲区的大小为%1，但尺寸参数是%2"
+H6A8E065AE173: "'%0' 将始终溢出；目标缓冲区的大小为 %1，但尺寸参数是 %2"
 # "'%0' will always overflow; destination buffer has size %1, but the source string has length %2 (including NUL byte)"
-H4E1F13141ECB: "'%0' 将始终溢出；目标缓冲区的大小为%1，但源字符串长度为%2（包含NUL字节）"
+H4E1F13141ECB: "'%0' 将始终溢出；目标缓冲区的大小为 %1，但源字符串长度为 %2（包含NUL字节）"
 # "'%0' will return the size of the pointer, not the array itself"
 H10D34141626D: "'%0' 将返回指针的大小，而不是数组本身"
 # "'%0' within '%1'"
-HFD060F45F3E4: "'%0' 在'%1' 内"
+HFD060F45F3E4: "'%0' 在 '%1' 内"
 # "'%0': selected processor lacks floating point registers"
 H5E83058CA4FE: "'%0'：所选处理器缺少浮点寄存器"
 # "'%0': unable to pass LLVM bit-code files to linker"
@@ -1805,15 +1805,15 @@ H25C074B573CF: "'%0'：无法与此工具一起使用模块文件"
 # "'%0(%select{source|sink:vec}1)' clause%select{|s}1 cannot be mixed with '%0(%select{sink:vec|source}1)' clause%select{s|}1"
 H081C849E3FF9: "'%0(%select{source|sink:vec}1)' 子句%select{|s}1 不能与 '%0(%select{sink:vec|source}1)' 子句%select{s|}1 混用"
 # "'%1' attribute on property %0 does not match the property inherited from %2"
-H0392738DA622: "'%1' 属性与属性%0从%2继承的属性不匹配"
+H0392738DA622: "'%1' 属性与属性 %0 从 %2 继承的属性不匹配"
 # "'%1' cannot be used in %select{a constructor|a destructor|the 'main' function|a constexpr function|a function with a deduced return type|a varargs function|a consteval function}0"
 HB2DCA2D92D0E: "'%1' 不能用于 %select{构造函数|析构函数|main函数|constexpr函数|具有推导返回类型的函数|可变参数函数|consteval函数}0"
 # "'%select{#|#@}0' is not followed by a macro parameter"
 HFFC615C42B6A: "'%select{#|#@}0' 后未跟随宏参数"
 # "'%select{%select{memcpy|wmemcpy}1|%select{memmove|wmemmove}1}0' not supported: %select{size to copy (%4) is not a multiple of size of element type %3 (%5)|source is not a contiguous array of at least %4 elements of type %3|destination is not a contiguous array of at least %4 elements of type %3}2"
-HEE3F2A4E1A36: "'%select{%select{memcpy|wmemcpy}1|%select{memmove|wmemmove}1}0' 不受支持：%select{要复制的大小（%4）不是元素类型%3（%5）的倍数|源不是至少%4个%3元素的连续数组|目标不是至少%4个%3元素的连续数组}2"
+HEE3F2A4E1A36: "'%select{%select{memcpy|wmemcpy}1|%select{memmove|wmemmove}1}0' 不受支持：%select{要复制的大小（%4）不是元素类型 %3（%5）的倍数|源不是至少 %4 个 %3 元素的连续数组|目标不是至少 %4 个 %3 元素的连续数组}2"
 # "'%select{*|.*}0' specified field %select{width|precision}0 is missing a matching 'int' argument"
-H0D1F0E4F63B2: "'%select{*|.*}0' 指定的字段 %select{宽度|精度}0 缺少匹配的'int'参数"
+H0D1F0E4F63B2: "'%select{*|.*}0' 指定的字段 %select{宽度|精度}0 缺少匹配的 'int' 参数"
 # "'%select{--|++}0' on an object of complex type is a C2y extension"
 HDA93C21904C8: "'%select{--|++}0' 对复数类型对象是C2y扩展"
 # "'%select{--|++}0' on an object of complex type is incompatible with C standards before C2y"
@@ -1829,7 +1829,7 @@ H9A9CB5F0CECC: "'%select{\\|@}0%1' 命令用于未附加到函数或方法声明
 # "'%select{\\|@}0%select{classdesign|coclass|dependency|helper|helperclass|helps|instancesize|ownership|performance|security|superclass}1' command should not be used in a comment attached to a non-container declaration"
 H63CA64568B3F: "'%select{\\|@}0%select{classdesign|coclass|dependency|helper|helperclass|helps|instancesize|ownership|performance|security|superclass}1' 命令不应用于附加到非容器声明的注释中"
 # "'%select{\\|@}0%select{class|interface|protocol|struct|union}1' command should not be used in a comment attached to a non-%select{class|interface|protocol|struct|union}2 declaration"
-H2B2D23C85C31: "'%select{\\|@}0%select{class|interface|protocol|struct|union}1' 命令不应用于附加到非%select{class|interface|protocol|struct|union}2声明的注释中"
+H2B2D23C85C31: "'%select{\\|@}0%select{class|interface|protocol|struct|union}1' 命令不应用于附加到非 %select{class|interface|protocol|struct|union}2 声明的注释中"
 # "'%select{\\|@}0%select{function|functiongroup|method|methodgroup|callback}1' command should be used in a comment attached to %select{a function|a function|an Objective-C method|an Objective-C method|a pointer to function}2 declaration"
 H30965075CCD3: "'%select{\\|@}0%select{function|functiongroup|method|methodgroup|callback}1' 命令应用于附加到%select{函数|函数|Objective-C方法|Objective-C方法|函数指针}2声明的注释中"
 # "'%select{\\|@}0param' command used in a comment that is not attached to a function declaration"
@@ -1837,7 +1837,7 @@ HA6D99227D713: "'%select{\\|@}0param' 命令用于未附加到函数声明的注
 # "'%select{\\|@}0tparam' command used in a comment that is not attached to a template declaration"
 H78D96F6B0A65: "'%select{\\|@}0tparam' 命令用于未附加到模板声明的注释中"
 # "'%select{auto|decltype(auto)}0' in return type deduced as %1 here but deduced as %2 in earlier return statement"
-HDFEF08FDDF8E: "'%select{auto|decltype(auto)}0' 返回类型在此处推导为%1，但在之前的return语句中推导为%2"
+HDFEF08FDDF8E: "'%select{auto|decltype(auto)}0' 返回类型在此处推导为 %1，但在之前的return语句中推导为 %2"
 # "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' argument cannot refer to a union member"
 HF50BCD9CECE6: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' 参数不能引用联合成员"
 # "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' argument must be a simple declaration reference"
@@ -1845,7 +1845,7 @@ HF6AC15305460: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null
 # "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' cannot be applied to a union member"
 H01022C27C2BB: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' 不能应用于联合成员"
 # "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' only applies to pointers%select{ or C99 flexible array members|||}0%select{|; did you mean to use 'counted_by'?}1"
-H077E0A5BF4C4: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' 仅适用于指针%select{或C99柔性数组成员|||}0%select{|；是否应使用'counted_by'?}1"
+H077E0A5BF4C4: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' 仅适用于指针%select{或C99柔性数组成员|||}0%select{|；是否应使用 'counted_by'?}1"
 # "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' requires a non-boolean integer type argument"
 H69D52A4DAF87: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' 需要一个非布尔整数类型的参数"
 # "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}1' field %0 isn't within the same struct as the annotated %select{pointer|flexible array}2"
@@ -1855,7 +1855,7 @@ HEFA740A9E276: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null
 # "'%select{if|switch}0' initialization statements are a C++17 extension"
 HBFF569602D2E: "'%select{if|switch}0' 初始化语句是 C++17 扩展"
 # "'%select{make_unsigned|make_signed}0' is only compatible with non-%select{bool|_BitInt(1)}1 integers and enum types, but was given %2%select{| whose underlying type is %4}3"
-H89BC3FB5059E: "'%select{make_unsigned|make_signed}0' 仅兼容非%select{bool|_BitInt(1)}1 整数和枚举类型，但传入了 %2%select{| 其基础类型为 %4}3"
+H89BC3FB5059E: "'%select{make_unsigned|make_signed}0' 仅兼容非 %select{bool|_BitInt(1)}1 整数和枚举类型，但传入了 %2%select{| 其基础类型为 %4}3"
 # "'%select{memcpy|wmemcpy}0' between overlapping memory regions"
 HF4936F4E6501: "'%select{memcpy|wmemcpy}0' 在重叠内存区域之间操作"
 # "'%select{pure|const}0' attribute on function returning 'void'; attribute ignored"
@@ -2009,47 +2009,47 @@ H4E940DC3AE07: "'__thread' 位于 '%0' 之前"
 # "'abi_tag' %0 missing in original declaration"
 H1628165A1258: "原始声明中缺少 'abi_tag' %0"
 # "'abi_tag' attribute on %select{non-inline|anonymous}0 namespace ignored"
-HDBC2CCB057F1: "%select{非内联|匿名}0命名空间的'abi_tag'属性被忽略"
+HDBC2CCB057F1: "%select{非内联|匿名}0命名空间的 'abi_tag' 属性被忽略"
 # "'abstract' keyword is a Microsoft extension"
-HA16E3E3ED791: "'abstract'关键字是Microsoft扩展"
+HA16E3E3ED791: "'abstract' 关键字是Microsoft扩展"
 # "'adjust_arg' argument %0 used in multiple clauses"
-H05E9C9F203D8: "'adjust_arg'参数%0在多个子句中被使用"
+H05E9C9F203D8: "'adjust_arg' 参数 %0 在多个子句中被使用"
 # "'align_value' attribute requires integer constant"
-H6853424EF803: "'align_value'属性需要整型常量"
+H6853424EF803: "'align_value' 属性需要整型常量"
 # "'alignas' is incompatible with C++98"
-H0BBFE28F35BF: "'alignas'与C++98不兼容"
+H0BBFE28F35BF: "'alignas' 与C++98不兼容"
 # "'aligned' attribute requires integer constant"
-H1ADA356A8681: "'aligned'属性需要整型常量"
+H1ADA356A8681: "'aligned' 属性需要整型常量"
 # "'alignof' on an incomplete array type is a C2y extension"
-HFD6D41C433A2: "'alignof'用于不完整数组类型是C2y扩展"
+HFD6D41C433A2: "'alignof' 用于不完整数组类型是C2y扩展"
 # "'alignof' on an incomplete array type is incompatible with C standards before C2y"
-HF644B202EC9A: "'alignof'用于不完整数组类型与C2y之前的标准不兼容"
+HF644B202EC9A: "'alignof' 用于不完整数组类型与C2y之前的标准不兼容"
 # "'append_args' is not allowed with varargs functions"
-H99449471B7D4: "不可与变长参数函数同时使用'append_args'"
+H99449471B7D4: "不可与变长参数函数同时使用 'append_args'"
 # "'assign' property of object type may become a dangling reference; consider using 'unsafe_unretained'"
-H7256F2B86929: "'assign'对象类型属性可能导致悬垂引用；建议使用'unsafe_unretained'"
+H7256F2B86929: "'assign' 对象类型属性可能导致悬垂引用；建议使用 'unsafe_unretained'"
 # "'atomic capture' with a compound statement only supports two statements"
 H0E46970C2D96: "'atomic capture'配合复合语句仅支持两个语句"
 # "'auto' as a functional-style cast is incompatible with C++ standards before C++23"
-HD4DCD08E6C51: "作为函数式类型转换的'auto'与C++23之前的标准不兼容"
+HD4DCD08E6C51: "作为函数式类型转换的 'auto' 与C++23之前的标准不兼容"
 # "'auto' deduced as 'id' in declaration of %0"
-HD22AA217F352: "'auto'在%0的声明中推导为'id'类型"
+HD22AA217F352: "'auto' 在 %0 的声明中推导为 'id' 类型"
 # "'auto' return without trailing return type; deduced return types are a C++14 extension"
-H2CC514506858: "无显式返回类型的'auto'返回值；类型推导是C++14扩展"
+H2CC514506858: "无显式返回类型的 'auto' 返回值；类型推导是C++14扩展"
 # "'auto' storage class specifier is not permitted in C++11, and will not be supported in future releases"
-H51939B968318: "'auto'存储类说明符在C++11中已被弃用，未来版本将不再支持"
+H51939B968318: "'auto' 存储类说明符在C++11中已被弃用，未来版本将不再支持"
 # "'auto' storage class specifier is redundant and incompatible with C++11"
-HFAD8EB4C5407: "'auto'存储类说明符是冗余的，并与C++11不兼容"
+HFAD8EB4C5407: "'auto' 存储类说明符是冗余的，并与C++11不兼容"
 # "'auto' type specifier is a %select{C++11|HLSL 202y}0 extension"
-H96C499C3C66C: "'auto'类型说明符是%select{C++11|HLSL 202y}0扩展"
+H96C499C3C66C: "'auto' 类型说明符是 %select{C++11|HLSL 202y}0 扩展"
 # "'auto' type specifier is incompatible with C++98"
-HA4F3AA6BB021: "'auto'类型说明符与C++98不兼容"
+HA4F3AA6BB021: "'auto' 类型说明符与C++98不兼容"
 # "'auto' variable template instantiation is not allowed"
-H7677E31876EE: "不允许对'auto'变量模板进行实例化"
+H7677E31876EE: "不允许对 'auto' 变量模板进行实例化"
 # "'begin' and 'end' returning different types (%0 and %1) is a C++17 extension"
-H440F964925D8: "'begin'和'end'返回不同类型（%0和%1）是C++17扩展"
+H440F964925D8: "'begin' 和 'end' 返回不同类型（%0 和 %1）是C++17扩展"
 # "'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17"
-HCE5BB9C433E6: "'begin'和'end'返回不同类型（%0和%1）与C++17之前的标准不兼容"
+HCE5BB9C433E6: "'begin' 和 'end' 返回不同类型（%0 和 %1）与C++17之前的标准不兼容"
 # "'break' is bound to loop, GCC binds it to switch"
 HB56827FEFDD0: "'break' 与循环绑定，GCC 将其与 switch 绑定"
 # "'break' statement not in loop or switch statement"
@@ -2091,29 +2091,29 @@ HFAB40415D777: "'consteval' 规定与 C++20 之前的 C++ 标准不兼容"
 # "'constexpr' can only be used in variable declarations"
 HCCD21640DBE9: "'constexpr' 仅可在变量声明中使用"
 # "'constexpr' non-static member function will not be implicitly 'const' in C++14; add 'const' to avoid a change in behavior"
-H23AE1DDB6BF2: "'constexpr'非静态成员函数在C++14中将不会隐式为'const'；添加const以避免行为变化"
+H23AE1DDB6BF2: "'constexpr' 非静态成员函数在C++14中将不会隐式为 'const'；添加const以避免行为变化"
 # "'constexpr' on lambda expressions is a C++17 extension"
-H99E246301B16: "lambda表达式上的'constexpr'是C++17扩展"
+H99E246301B16: "lambda表达式上的 'constexpr' 是C++17扩展"
 # "'constexpr' specifier is incompatible with C++98"
-H26D17B863D82: "'constexpr'说明符与C++98不兼容"
+H26D17B863D82: "'constexpr' 说明符与C++98不兼容"
 # "'constinit' specifier added after initialization of variable"
-H941EB6451F6C: "'constinit'说明符在变量初始化后添加"
+H941EB6451F6C: "'constinit' 说明符在变量初始化后添加"
 # "'constinit' specifier is incompatible with C++ standards before C++20"
-HA94D78D91751: "'constinit'说明符与C++20之前的C++标准不兼容"
+HA94D78D91751: "'constinit' 说明符与C++20之前的C++标准不兼容"
 # "'constinit' specifier missing on initializing declaration of %0"
-H55C3572EEC7C: "%0的初始化声明缺少'constinit'说明符"
+H55C3572EEC7C: "%0 的初始化声明缺少 'constinit' 说明符"
 # "'continue' statement not in loop statement"
-HCD539EA88B8F: "'continue'语句不在循环语句中"
+HCD539EA88B8F: "'continue' 语句不在循环语句中"
 # "'copy' attribute must be specified for the block property when -fobjc-gc-only is specified"
-H87791A0AEA62: "当指定-fobjc-gc-only时，块属性必须指定'copy'属性"
+H87791A0AEA62: "当指定-fobjc-gc-only时，块属性必须指定 'copy' 属性"
 # "'counted_by' cannot refer to the flexible array member %0"
-H5B04880F56A4: "'counted_by'不能引用柔性数组成员%0"
+H5B04880F56A4: "'counted_by' 不能引用柔性数组成员 %0"
 # "'counted_by' on arrays only applies to C99 flexible array members"
-HB17E489D7021: "'counted_by'仅适用于C99柔性数组成员"
+HB17E489D7021: "'counted_by' 仅适用于C99柔性数组成员"
 # "'cpu_dispatch' function redeclared with different CPUs"
-HCA2FB0047F16: "'cpu_dispatch'函数用不同CPU重新声明"
+HCA2FB0047F16: "'cpu_dispatch' 函数用不同CPU重新声明"
 # "'decltype' type specifier is incompatible with C++98"
-H06E59DDEED89: "'decltype'类型说明符与C++98不兼容"
+H06E59DDEED89: "'decltype' 类型说明符与C++98不兼容"
 # "'decltype(auto)' can only be used as a return type in a function declaration"
 H5356DF2FE6D3: "'decltype(auto)'只能用作函数声明的返回类型"
 # "'decltype(auto)' cannot be combined with other type specifiers"
@@ -2125,11 +2125,11 @@ H7E1DB4CB833F: "'decltype(auto)'类型说明符是C++14扩展"
 # "'decltype(auto)' type specifier is incompatible with C++ standards before C++14"
 HA38CAC8829B9: "'decltype(auto)'类型说明符与C++14之前的C++标准不兼容"
 # "'default' statement not in switch statement"
-H1133498536DD: "'default'语句不在switch语句中"
+H1133498536DD: "'default' 语句不在switch语句中"
 # "'defined' cannot appear within this context"
-HDAE80537A1D3: "'defined'不能出现在此上下文中"
+HDAE80537A1D3: "'defined' 不能出现在此上下文中"
 # "'defined' cannot be used as a macro name"
-HB4BA3900B80E: "'defined'不能用作宏名称"
+HB4BA3900B80E: "'defined' 不能用作宏名称"
 # "'delete%select{|[]}0' applied to a pointer that was allocated with 'new%select{[]|}0'; did you mean 'delete%select{[]|}0'?"
 H84CC0C534191: "'delete%select{|[]}0' 应用于由 'new%select{[]|}0' 分配的指针；是否应改为 'delete%select{[]|}0'？"
 # "'delete' applied to a pointer-to-array type %0 treated as 'delete[]'"
@@ -2159,7 +2159,7 @@ H4954093357D9: "'explicit' 仅可在类定义内部指定"
 # "'explicit' is not permitted on top-level modules"
 HDAE06689A152: "顶级模块中不允许使用 'explicit'"
 # "'extern' variable has an initializer"
-HB91B40E25B4C: "'extern'变量有初始值设定项"
+HB91B40E25B4C: "'extern' 变量有初始值设定项"
 # "'extern' variable may not be referenced by '%0' clause on an OpenACC 'declare' directive"
 H270234BE5B42: "外部变量可能无法被 OpenACC 'declare' 指令的 '%0' 子句引用"
 # "'flush' directive with memory order clause '%0' cannot have the list"
@@ -2251,45 +2251,45 @@ HC1CD8F78BDE1: "'mutable' 只能应用于成员变量"
 # "'mutable' cannot be applied to functions"
 H9B6452717014: "'mutable' 不能应用于函数"
 # "'mutable' cannot be applied to references"
-H7CCDA0B2596A: "'mutable'不能应用于引用"
+H7CCDA0B2596A: "'mutable' 不能应用于引用"
 # "'mutable' on a reference type is a Microsoft extension"
-H6E975C04AF4E: "引用类型上的'mutable'是Microsoft扩展"
+H6E975C04AF4E: "引用类型上的 'mutable' 是Microsoft扩展"
 # "'mutexinoutset' modifier not allowed in 'depend' clause on 'taskwait' directive"
-H54D9DFD0A59D: "'taskwait'指令的'depend'子句中不能使用'mutexinoutset'修饰符"
+H54D9DFD0A59D: "'taskwait' 指令的 'depend' 子句中不能使用 'mutexinoutset' 修饰符"
 # "'new' cannot allocate an array of %0 with no explicit ownership"
-H01CEEA4215DD: "'new'不能分配未显式指定所有权的%0类型数组"
+H01CEEA4215DD: "'new' 不能分配未显式指定所有权的 %0 类型数组"
 # "'new' cannot allocate object of variably modified type %0"
-HB68377C1CB34: "'new'不能分配可变长度类型%0的对象"
+HB68377C1CB34: "'new' 不能分配可变长度类型 %0 的对象"
 # "'new' cannot allocate objects of type %0 in address space '%1'"
-H8F2EE8209986: "'new'不能在'%1'地址空间中分配类型%0的对象"
+H8F2EE8209986: "'new' 不能在 '%1' 地址空间中分配类型 %0 的对象"
 # "'new' expression with placement arguments refers to non-placement 'operator delete'"
-H9A938FDFCB36: "带有placement参数的'new'表达式指向非placement的'operator delete'"
+H9A938FDFCB36: "带有placement参数的 'new' 表达式指向非placement的'operator delete'"
 # "'nocf_check' attribute ignored; use -fcf-protection to enable the attribute"
-HCD98AFA044EC: "'nocf_check'属性被忽略；请使用-fcf-protection选项启用该属性"
+HCD98AFA044EC: "'nocf_check' 属性被忽略；请使用-fcf-protection选项启用该属性"
 # "'noderef' can only be used on an array or pointer type"
-H265BDBEEC1EC: "'noderef'只能用于数组或指针类型"
+H265BDBEEC1EC: "'noderef' 只能用于数组或指针类型"
 # "'noexcept' can only be used in a compound requirement (with '{' '}' around the expression)"
-H88CA64B4E3F6: "'noexcept'只能用于复合需求（需用'{' '}'包裹表达式）"
+H88CA64B4E3F6: "'noexcept' 只能用于复合需求（需用'{' '}'包裹表达式）"
 # "'nonmonotonic' modifier can only be specified with 'dynamic' or 'guided' schedule kind"
-H60F2BCD19874: "'nonmonotonic'修饰符只能与'dynamic'或'guided'调度类型一起使用"
+H60F2BCD19874: "'nonmonotonic' 修饰符只能与 'dynamic' 或 'guided' 调度类型一起使用"
 # "'nonnull' attribute applied to function with no pointer arguments"
-H0D4CBB499E30: "'nonnull'属性应用于无指针参数的函数"
+H0D4CBB499E30: "'nonnull' 属性应用于无指针参数的函数"
 # "'nonnull' attribute when used on parameters takes no arguments"
-H8544A5398585: "用在参数上的'nonnull'属性不需要参数"
+H8544A5398585: "用在参数上的 'nonnull' 属性不需要参数"
 # "'nothrow' attribute conflicts with exception specification; attribute ignored"
-HA43C7748DBD1: "'nothrow'属性与异常规范冲突；属性被忽略"
+HA43C7748DBD1: "'nothrow' 属性与异常规范冲突；属性被忽略"
 # "'nowait' clause is here"
-H4C9748BD1A0B: "'nowait'子句在此处"
+H4C9748BD1A0B: "'nowait' 子句在此处"
 # "'nullptr' is a C23 extension"
-H0CCA94E13259: "'nullptr'是C23扩展"
+H0CCA94E13259: "'nullptr' 是C23扩展"
 # "'nullptr' is incompatible with C++98"
-HA3F1CF3D3055: "'nullptr'与C++98不兼容"
+HA3F1CF3D3055: "'nullptr' 与C++98不兼容"
 # "'objc_bridge(id)' is only allowed on structs and typedefs of void pointers"
 H19339C3149E3: "'objc_bridge(id)' 仅允许用于 void 指针类型的结构体和 typedef"
 # "'objc_class_stub' attribute cannot be specified on a class that does not have the 'objc_subclassing_restricted' attribute"
-H131E98846FD9: "未声明'objc_subclassing_restricted'属性的类不能使用'objc_class_stub'属性"
+H131E98846FD9: "未声明 'objc_subclassing_restricted' 属性的类不能使用 'objc_class_stub' 属性"
 # "'objc_designated_initializer' attribute only applies to init methods of interface or class extension declarations"
-H0C4330D28BB6: "'objc_designated_initializer'属性仅适用于接口或类扩展声明的初始化方法"
+H0C4330D28BB6: "'objc_designated_initializer' 属性仅适用于接口或类扩展声明的初始化方法"
 # "'objc_direct' attribute cannot be applied to %select{methods|properties}0 declared in an Objective-C protocol"
 H0E0D013ED449: "'objc_direct' 属性不能应用于 Objective-C 协议中声明的 %select{方法|属性}0"
 # "'objc_externally_retained' can only be applied to local variables %select{of retainable type|with strong ownership}0"
@@ -2329,7 +2329,7 @@ H8DB05E11AD0A: "在旧版 GCC 和 Clang 中，'packed' 属性会忽略单字节�
 # "'reduction' clause cannot be used with 'nogroup' clause"
 H186A32581806: "'reduction' 子句不能与 'nogroup' 子句一起使用"
 # "'reduction' clause not allowed with '#pragma omp loop bind(teams)'"
-H4981CB6A6643: "不允许在'#pragma omp loop bind(teams)'中使用'reduction'子句"
+H4981CB6A6643: "不允许在'#pragma omp loop bind(teams)'中使用 'reduction' 子句"
 # "'reduction' clause with 'inscan' modifier is used here"
 HE04EBCC11985: "带有 'inscan' 修饰符的 'reduction' 子句在此处使用"
 # "'reduction' clause with 'task' modifier allowed only on non-simd parallel or worksharing constructs"
@@ -2371,45 +2371,45 @@ HE55B1E186F37: "字面量的 'size_t' 后缀是 C++23 扩展"
 # "'size_t' suffix for literals is a C++23 feature"
 HFE4E8B889F8C: "字面量的 'size_t' 后缀是 C++23 特性"
 # "'size_t' suffix for literals is incompatible with C++ standards before C++23"
-H01C26A9D5D7B: "'size_t'后缀的字面量与C++23之前的C++标准不兼容"
+H01C26A9D5D7B: "'size_t' 后缀的字面量与C++23之前的C++标准不兼容"
 # "'static' can only be specified inside the class definition"
-HC2C3574A2AC5: "'static'只能在类定义内部指定"
+HC2C3574A2AC5: "'static' 只能在类定义内部指定"
 # "'static' function %0 declared in header file should be declared 'static inline'"
-HAC6B8325923D: "在头文件中声明的'static'函数%0应声明为'static inline'"
+HAC6B8325923D: "在头文件中声明的 'static' 函数 %0 应声明为'static inline'"
 # "'static' may not be used with an unspecified variable length array size"
-H8C886B8B17D3: "'static'不能与未指定的可变长度数组大小一起使用"
+H8C886B8B17D3: "'static' 不能与未指定的可变长度数组大小一起使用"
 # "'static' may not be used without an array size"
-H3CD973765C05: "'static'在没有数组大小时不能使用"
+H3CD973765C05: "'static' 在没有数组大小时不能使用"
 # "'static' member function %0 overrides a virtual function in a base class"
-H917973A36E2C: "'static'成员函数%0覆盖了基类中的虚函数"
+H917973A36E2C: "'static' 成员函数 %0 覆盖了基类中的虚函数"
 # "'static_assert' declarations are incompatible with C++98"
-HEBCFD6945359: "'static_assert'声明与C++98标准不兼容"
+HEBCFD6945359: "'static_assert' 声明与C++98标准不兼容"
 # "'static_assert' with a user-generated message is a C++26 extension"
-HFCA41F0C6554: "带有用户生成消息的'static_assert'是C++26扩展"
+HFCA41F0C6554: "带有用户生成消息的 'static_assert' 是C++26扩展"
 # "'static_assert' with a user-generated message is incompatible with C++ standards before C++26"
-H71F257CCE8FF: "带有用户生成消息的'static_assert'与C++26之前的C++标准不兼容"
+H71F257CCE8FF: "带有用户生成消息的 'static_assert' 与C++26之前的C++标准不兼容"
 # "'static_assert' with no message is a C++17 extension"
-H89070CD2F991: "无消息的'static_assert'是C++17扩展"
+H89070CD2F991: "无消息的 'static_assert' 是C++17扩展"
 # "'static_assert' with no message is incompatible with C++ standards before C++17"
-HFE8F37E6AE5C: "无消息的'static_assert'与C++17之前的C++标准不兼容"
+HFE8F37E6AE5C: "无消息的 'static_assert' 与C++17之前的C++标准不兼容"
 # "'std::allocator<...>::deallocate' used to delete a null pointer"
 HF2B279909DBC: "'std::allocator<...>::deallocate'被用来删除空指针"
 # "'std::source_location::__impl' must be standard-layout and have only two 'const char *' fields '_M_file_name' and '_M_function_name', and two integral fields '_M_line' and '_M_column'"
-HCA27D3915F0B: "'std::source_location::__impl'必须是标准布局类型，并且只有两个'const char *'类型的字段'_M_file_name'和'_M_function_name'，以及两个整数类型的字段'_M_line'和'_M_column'"
+HCA27D3915F0B: "'std::source_location::__impl'必须是标准布局类型，并且只有两个'const char *'类型的字段 '_M_file_name' 和 '_M_function_name'，以及两个整数类型的字段 '_M_line' 和 '_M_column'"
 # "'std::source_location::__impl' was not found; it must be defined before '__builtin_source_location' is called"
-HD0F806FB73A8: "'std::source_location::__impl'未找到；它必须在调用'__builtin_source_location'之前被定义"
+HD0F806FB73A8: "'std::source_location::__impl'未找到；它必须在调用 '__builtin_source_location' 之前被定义"
 # "'super' is only valid in a method body"
-HB06D73D4C0E7: "'super'仅在方法体内有效"
+HB06D73D4C0E7: "'super' 仅在方法体内有效"
 # "'swift_async' completion handler parameter must have block type returning 'void', type here is %0"
-H9874890FB098: "'swift_async'完成处理程序参数必须具有返回'void'的块类型，此处类型为%0"
+H9874890FB098: "'swift_async' 完成处理程序参数必须具有返回 'void' 的块类型，此处类型为 %0"
 # "'swift_error_result' parameter must follow 'swift_context' parameter"
-HFA5F4F66F83B: "'swift_error_result'参数必须跟在'swift_context'参数之后"
+HFA5F4F66F83B: "'swift_error_result' 参数必须跟在 'swift_context' 参数之后"
 # "'swift_indirect_result' parameters must be first parameters of function"
-H624EF03C7676: "'swift_indirect_result'参数必须是函数的第一个参数"
+H624EF03C7676: "'swift_indirect_result' 参数必须是函数的第一个参数"
 # "'switch' missing 'default' label"
-H855B85E209CE: "'switch'缺少'default'标签"
+H855B85E209CE: "'switch' 缺少 'default' 标签"
 # "'sycl_kernel' attribute only applies to a function template with at least two template parameters"
-H5AFFA7408711: "'sycl_kernel'属性仅适用于至少包含两个模板参数的函数模板"
+H5AFFA7408711: "'sycl_kernel' 属性仅适用于至少包含两个模板参数的函数模板"
 # "'sycl_kernel_entry_point' attribute cannot be added to a function after the function is defined"
 H018E12D5A5B2: "'sycl_kernel_entry_point' 属性不能在函数定义后添加到该函数"
 # "'sycl_kernel_entry_point' attribute cannot be applied to a %select{non-static member function|variadic function|deleted function|defaulted function|constexpr function|consteval function|function declared with the 'noreturn' attribute|coroutine|function defined with a function try block}0"
@@ -2493,15 +2493,15 @@ HDCEB40407EDC: "在具有固定参数的函数中使用 'va_start'"
 # "'vec_step' requires built-in scalar or vector type, %0 invalid"
 H2D0A081561E0: "'vec_step' 需要内建标量或向量类型，%0 无效"
 # "'virtual' can only appear on non-static member functions"
-HB1449ED6BD56: "'virtual'只能出现在非静态成员函数上"
+HB1449ED6BD56: "'virtual' 只能出现在非静态成员函数上"
 # "'virtual' can only be specified inside the class definition"
-HC2C042A27D12: "'virtual'只能在类定义内部指定"
+HC2C042A27D12: "'virtual' 只能在类定义内部指定"
 # "'virtual' cannot be specified on member function templates"
-H345B16C9EDA3: "'virtual'不能用于成员函数模板上"
+H345B16C9EDA3: "'virtual' 不能用于成员函数模板上"
 # "'void' as parameter must not have type qualifiers"
-H3B7FE1A42F0E: "作为参数的'void'不能带有类型限定符"
+H3B7FE1A42F0E: "作为参数的 'void' 不能带有类型限定符"
 # "'void' must be the first and only parameter if specified"
-H7DDAB71DFE28: "如果指定了'void'，它必须是唯一的且第一个参数"
+H7DDAB71DFE28: "如果指定了 'void'，它必须是唯一的且第一个参数"
 # "'||' of a value and its negation always evaluates to true"
 H067D990351EF: "一个值与其否定的'||'运算结果始终为真"
 # "'~' in destructor name should be after nested name specifier"
@@ -2517,11 +2517,11 @@ H902BD058678C: '(集成式汇编器) 生成不可用于增量链接器的可重�
 # '(integrated-as) Relax all machine instructions'
 H523BAD847EDC: '(集成式汇编器) 放宽所有机器指令'
 # "(skipping %0 'operator->'%s0 in backtrace)"
-H3980AA6C4367: "(跳过回溯中的%0 'operator->'%s0)"
+H3980AA6C4367: "(跳过回溯中的 %0 'operator->'%s0)"
 # '(skipping %0 call%s0 in backtrace; use -fconstexpr-backtrace-limit=0 to see all)'
-HD7D8BC5DDF54: '(跳过回溯中的%0个调用%s0；使用-fconstexpr-backtrace-limit=0显示所有内容)'
+HD7D8BC5DDF54: '(跳过回溯中的 %0 个调用%s0；使用-fconstexpr-backtrace-limit=0显示所有内容)'
 # '(skipping %0 context%s0 in backtrace; use -ftemplate-backtrace-limit=0 to see all)'
-H1BB10F671BF7: '(跳过回溯中的%0个上下文%s0；使用-ftemplate-backtrace-limit=0显示所有内容)'
+H1BB10F671BF7: '(跳过回溯中的 %0 个上下文%s0；使用-ftemplate-backtrace-limit=0显示所有内容)'
 # '*no default*'
 H01EF8BE8DE07: '*无默认值*'
 # '--rtlib=libgcc requires --unwindlib=libgcc'
@@ -2587,9 +2587,9 @@ HD52B23C67DCF: '指定的目标 %0 覆盖了 /arm64EC；选项被忽略'
 # '32-bit targets are not supported when building for Mac Catalyst'
 H2B5ECA150DDF: '构建 Mac Catalyst 时，不支持 32 位目标'
 # '90th percentile durations'
-HCFF900413C06: '第90百分位持续时间'
+HCFF900413C06: '第 90 百分位持续时间'
 # '99th percentile durations'
-H401BE67F4D43: '第99百分位持续时间'
+H401BE67F4D43: '第 99 百分位持续时间'
 # ": Did you mean '"
 HF9464896A916: ": 您指的是 '"
 # ': Not enough positional command line arguments specified!\n'
@@ -2721,7 +2721,7 @@ H4D671F64A81C: '<source0> [... <sourceN>]'
 # '<source>'
 HE6634DF59D09: '<source>'
 # "<start line>:<end line> - format a range of\nlines (both 1-based).\nMultiple ranges can be formatted by specifying\nseveral -lines arguments.\nCan't be used with -offset and -length.\nCan only be used with one input file."
-HDEA3B9BD2A49: '<起始行>:<结束行> - 格式化行范围（均为1-based计数）。\n可以通过多个 -lines 参数指定多个范围。\n不能与 -offset 和 -length 一起使用。\n只能用于单个输入文件。'
+HDEA3B9BD2A49: '<起始行>:<结束行> - 格式化行范围（均为 1-based计数）。\n可以通过多个 -lines 参数指定多个范围。\n不能与 -offset 和 -length 一起使用。\n只能用于单个输入文件。'
 # '<symbol-file>'
 H6E5CDBA6FB29: '<符号文件>'
 # '<test profile file>'
@@ -2735,9 +2735,9 @@ HCEE927C66E78: '<权重>,<文件名>'
 # '<xray fdr mode log>'
 H4907FD73C66B: '<XRay FDR模式日志>'
 # '<xray log file 1>'
-HB4D281AAED36: '<XRay日志文件1>'
+HB4D281AAED36: '<XRay日志文件 1>'
 # '<xray log file 2>'
-H1C142C095FCF: '<XRay日志文件2>'
+H1C142C095FCF: '<XRay日志文件 2>'
 # '<xray log file>'
 HE9A7E93A5C35: '<XRay日志文件>'
 # '<xray trace>'
@@ -2897,7 +2897,7 @@ H8EA7CFE7591E: '用于检测系统中AMDGPU设备存在的工具。\n\n该工具
 # 'A tool to detect the presence of NVIDIA devices on the system. \n\nThe tool will output each detected GPU architecture separated by a\nnewline character. If multiple GPUs of the same architecture are found\na string will be printed for each\n'
 H813C62D59D1D: '用于检测系统中NVIDIA设备存在的工具。\n\n该工具将以换行符分隔每个检测到的GPU架构进行输出。如果发现相同架构的多个GPU，则为每个GPU打印一条字符串\n'
 # 'A tool to format C/C++/Java/JavaScript/JSON/Objective-C/Protobuf/C# code.\n\nIf no arguments are specified, it formats the code from standard input\nand writes the result to the standard output.\nIf <file>s are given, it reformats the files. If -i is specified\ntogether with <file>s, the files are edited in-place. Otherwise, the\nresult is written to the standard output.\n'
-HBD33E3D62435: '用于格式化C/C++/Java/JavaScript/JSON/Objective-C/Protobuf/C#代码的工具。\n\n如果未指定任何参数，它将从标准输入读取代码并输出到标准输出。如果指定了<file>s，则会重新格式化这些文件。如果同时指定了 -i 和<file>s，文件将被就地编辑。否则，结果将写入标准输出。\n'
+HBD33E3D62435: '用于格式化C/C++/Java/JavaScript/JSON/Objective-C/Protobuf/C#代码的工具。\n\n如果未指定任何参数，它将从标准输入读取代码并输出到标准输出。如果指定了 <file>s，则会重新格式化这些文件。如果同时指定了 -i 和 <file>s，文件将被就地编辑。否则，结果将写入标准输出。\n'
 # 'A tool to generate an optimization report from YAML optimization record files.\n'
 HACA86A981224: '用于从YAML优化记录文件生成优化报告的工具。\n'
 # 'A utility for bundling several object files into a single binary.\nThe output binary can then be embedded into the host section table\nto create a fatbinary containing offloading code.\n'
@@ -3025,7 +3025,7 @@ H652422606A7D: '别名分析'
 # 'ANALYSIS_FP_COMMUTE'
 H5B6E5D0BD096: '浮点运算交换分析'
 # 'API notes replacement type %0 has a different size from original type %1'
-HB87A25B6CDE7: 'API注释中的替换类型%0与原始类型%1的大小不同'
+HB87A25B6CDE7: 'API注释中的替换类型 %0 与原始类型 %1 的大小不同'
 # 'ARC %select{unused|__unsafe_unretained|__strong|__weak|__autoreleasing}0 lifetime qualifier on return type is ignored'
 H4E4E8ED8984D: 'ARC忽略返回类型上的%select{未使用的|__unsafe_unretained|__strong|__weak|__autoreleasing}0生命周期限定符'
 # 'ARC DAG->DAG Pattern Instruction Selection'
@@ -3035,13 +3035,13 @@ H275EE97FB8AE: 'ARC 最终化分支'
 # 'ARC forbids %select{implementation|synthesis}0 of %1'
 HC91D535AD424: 'ARC禁止%select{实现|合成}0 %1'
 # 'ARC forbids explicit message send of %0'
-H35558B925DCC: 'ARC禁止显式发送%0消息'
+H35558B925DCC: 'ARC禁止显式发送 %0 消息'
 # 'ARC forbids flexible array members with retainable object type'
 HBA6CEB1E81A4: 'ARC禁止使用可保留对象类型的柔性数组成员'
 # 'ARC forbids synthesizing a property of an Objective-C object with unspecified ownership or storage attribute'
 H8E9C79FD3192: 'ARC禁止合成一个未指定所有权或存储属性的Objective-C对象属性'
 # 'ARC forbids use of %0 in a @selector'
-H9E100CA24C33: 'ARC禁止在@selector中使用%0'
+H9E100CA24C33: 'ARC禁止在@selector中使用 %0'
 # 'ARM Branch Targets'
 H320FDCF5D874: 'ARM 分支目标'
 # 'ARM EHABI exceptions'
@@ -3061,7 +3061,7 @@ HE7AFE256FA69: 'ARM 块布局'
 # 'ARM constant island placement and branch shortening pass'
 H12503A372FDC: 'ARM 常量岛放置和分支缩短pass'
 # 'ARM fix for Cortex-A57 AES Erratum 1742098'
-HFB722C2D2741: 'ARM 修复Cortex-A57 AES错误1742098'
+HFB722C2D2741: 'ARM 修复Cortex-A57 AES错误 1742098'
 # 'ARM load / store optimization pass'
 HFAD45B23E308: 'ARM 加载/存储优化pass'
 # 'ARM pre- register allocation load / store optimization pass'
@@ -3073,11 +3073,11 @@ H7DDE5DF1D5E8: 'ARM sls 安全强化pass'
 # 'AST and IR generation'
 H9BC428E8F3F3: '抽象语法树（AST）和中间表示（IR）生成'
 # "AST file '%0' was compiled for the %1 '%2' but the current translation unit is being compiled for target '%3'"
-HCADF9CC20080: "AST文件'%0'是为%1 '%2'编译的，但当前翻译单元的目标是'%3'"
+HCADF9CC20080: "AST文件 '%0' 是为 %1 '%2' 编译的，但当前翻译单元的目标是 '%3'"
 # "AST file '%0' was not built as a module"
-HF2D0BB327E40: "AST文件'%0'未作为模块构建"
+HF2D0BB327E40: "AST文件 '%0' 未作为模块构建"
 # "AST file '%2' was compiled with module cache path '%0', but the path is currently '%1'"
-H5B70E03C1FF3: "AST文件'%2'是使用模块缓存路径'%0'编译的，但当前路径是'%1'"
+H5B70E03C1FF3: "AST文件 '%2' 是使用模块缓存路径 '%0' 编译的，但当前路径是 '%1'"
 # 'AVR DAG->DAG Instruction Selection'
 H8D3BB39761E3: 'AVR DAG->DAG 指令选择'
 # 'AVR Shift Expansion'
@@ -3085,7 +3085,7 @@ HB0A514A46417: 'AVR 移位扩展'
 # 'AVR pseudo instruction expansion pass'
 H957B71DEFB30: 'AVR 伪指令扩展pass'
 # "AVX vector %select{return|argument}0 of type %1 without '%2' enabled changes the ABI"
-HA1797A0B7AA1: 'AVX向量%select{return|argument}0的类型%1在未启用%2时会改变ABI'
+HA1797A0B7AA1: 'AVX向量 %select{return|argument}0 的类型 %1 在未启用 %2 时会改变ABI'
 # 'Abbreviation for -input-style=delimited -pretty -log=verbose. Intended to simplify lit tests'
 H80629E8FC6D8: '缩写形式：-input-style=delimited -pretty -log=verbose。用于简化lit测试'
 # 'Abort if an isl error is encountered'
@@ -3133,7 +3133,7 @@ HD58C1F70322E: '向汇编文件添加包含BTI的.note.gnu.property注释'
 # 'Add .note.gnu.property with BTI to assembly files (AArch64 only)'
 H497BB320D249: '在汇编文件中添加包含BTI的.note.gnu.property节（仅AArch64）'
 # 'Add <dir> to system include search path, as if in %INCLUDE%'
-H8CB70533A0CD: '将<dir>添加到系统包含搜索路径，如同在%INCLUDE%中定义'
+H8CB70533A0CD: '将 <dir> 添加到系统包含搜索路径，如同在%INCLUDE%中定义'
 # 'Add AMDGPU function attributes'
 H4A9EBA76009C: '添加AMDGPU函数属性'
 # 'Add AMDGPU uniform metadata'
@@ -3221,7 +3221,7 @@ HA6F738C6C497: '添加目录到内部系统包含搜索路径并隐含extern "C"
 # "Add directory to the internal system include search path; these are assumed to not be user-provided and are used to model system and standard headers' paths."
 H76AF34D02BE9: '添加目录到内部系统包含搜索路径；这些路径不被视为用户提供的，并用于模拟系统和标准头文件的路径。'
 # 'Add dirs in env var <var> to include search path with warnings suppressed'
-HFB17BE810349: '在环境变量<var>中添加目录到包含搜索路径并抑制警告'
+HFB17BE810349: '在环境变量 <var> 中添加目录到包含搜索路径并抑制警告'
 # 'Add extra TOC register dependencies'
 HB5EA8815333D: '添加额外的TOC寄存器依赖项'
 # 'Add informational comments to the .ll file'
@@ -3269,7 +3269,7 @@ HE9D3E5D77A09: '要加载到正在执行的程序中的附加共享对象'
 # 'Address of the invoked server.'
 H6E702787A95D: '被调用服务器的地址'
 # 'Address of the invoked server. Defaults to 0.0.0.0:50051'
-H54519DAF9B40: '被调用服务器的地址。默认为0.0.0.0:50051'
+H54519DAF9B40: '被调用服务器的地址。默认为 0.0.0.0:50051'
 # 'Address sinking in CGP using GEPs.'
 HC7C32F638F6D: '使用GEPs在CGP中进行地址下沉'
 # "AddressSanitizer doesn't support linking with debug runtime libraries yet"
@@ -3401,13 +3401,13 @@ HD5F8D2C37C5D: '-format的别名'
 # 'Align ARM NEON spills in prolog and epilog'
 HA6EB49748CD3: '在函数序言和尾言中对齐ARM NEON的寄存器溢出'
 # 'Align branches within 32-byte boundaries to mitigate the performance impact of the Intel JCC erratum.'
-H5A28F46326DE: '在32字节边界对齐分支，以减轻Intel JCC缺陷的性能影响'
+H5A28F46326DE: '在 32 字节边界对齐分支，以减轻Intel JCC缺陷的性能影响'
 # 'Align constant islands in code'
 H461BA6D2D6E3: '在代码中对齐常量区域'
 # 'Align doubles to two words in structs (x86 only)'
 HEDC15B5DDF59: '在结构体中将双精度对齐为两个字（仅x86）'
 # 'Align selected branches (fused, jcc, jmp) within 32-byte boundary'
-H61C864267E04: '在32字节边界对齐选定的分支（融合、jcc、jmp）'
+H61C864267E04: '在 32 字节边界对齐选定的分支（融合、jcc、jmp）'
 # "Align selected instructions to mitigate negative performance impact of Intel's micro code update for errata skx102.  May break assumptions about labels corresponding to particular instructions, and should be used with caution."
 H4F2747860017: '对选定指令进行对齐以缓解Intel微代码更新（针对errata skx102）的负面影响。可能会破坏标签与特定指令对应关系的假设，需谨慎使用。'
 # 'Aligned allocation/deallocation functions are unavailable'
@@ -3559,7 +3559,7 @@ H02FFF4B1AF5A: '允许分支使用非仿射条件'
 # 'Allow non affine conditions for loops'
 H7C67DD81E47E: '允许循环使用非仿射条件'
 # 'Allow non-power-of-2 vectorization.'
-HA2D0D7F2C7BF: '允许非2的幂次向量化。'
+HA2D0D7F2C7BF: '允许非 2 的幂次向量化。'
 # 'Allow non-solo packetization of volatile memory references'
 H5792B0D4B6CC: '允许易失性内存引用的非独立分组'
 # 'Allow operation with no registered dialects'
@@ -3871,7 +3871,7 @@ HA13DECB16694: '假设异常对象的析构函数不会抛出（non-throwing）'
 # 'Assume that execution stops at trap instruction'
 HFD7E94900060: '假设程序在遇到陷阱指令时会终止执行'
 # 'Assume that externally defined data is in the small data if it meets the -G <size> threshold (MIPS)'
-H79ED681B6E82: '假设符合-G <size>阈值（MIPS）的外部定义数据位于小数据区中'
+H79ED681B6E82: '假设符合-G <size> 阈值（MIPS）的外部定义数据位于小数据区中'
 # 'Assume that kernels are launched with uniform block sizes (default true for CUDA/HIP and false otherwise)'
 HA763A763DA9A: '假设内核以统一块大小启动（默认为CUDA/HIP启用，其他情况禁用）'
 # 'Assume that no thread in a parallel region will encounter a parallel region.'
@@ -3917,7 +3917,7 @@ H1898E5AD9AA7: '无论数组临时对象大小如何，都尝试在栈上分配'
 # 'Attempt to drop solution if it is less profitable'
 H339D061FB39B: '尝试丢弃利润较低的解决方案'
 # 'Attempt to match the ABI of Clang <version>'
-H0603A0819A4F: '尝试匹配Clang <version>的ABI'
+H0603A0819A4F: '尝试匹配Clang <version> 的ABI'
 # 'Attempt to vectorize for this register size in bits'
 HC4E22D3921AE: '尝试为此寄存器大小（以位为单位）进行向量化'
 # 'Attempt to vectorize horizontal reductions'
@@ -3931,7 +3931,7 @@ H6A8CFBBE8142: '即使没有采样命中，也给所有函数的范围分配零�
 # 'Auto-generates preprocessed source files and a reproduction script'
 H2B36EB61E3F1: '自动生成预处理源文件和复现脚本'
 # 'Automatically put hot code on 2MB page(s) (hugify) at runtime. No manual call to hugify is needed in the binary (which is what --hot-text relies on).'
-H0155A65DE424: '在运行时将热点代码放在2MB页面（hugify）上。无需在二进制文件中手动调用hugify（这是--hot-text所依赖的）。'
+H0155A65DE424: '在运行时将热点代码放在 2MB页面（hugify）上。无需在二进制文件中手动调用hugify（这是--hot-text所依赖的）。'
 # 'Auxiliary target triple.'
 H7C66B9F24C8E: '辅助目标三元组。'
 # 'Average inst/cycle when no target itinerary exists.'
@@ -4037,7 +4037,7 @@ HE94155328C5F: 'TLS偏移量的立即数位大小'
 # 'Bitstream'
 HA8A9704FB47E: '比特流'
 # 'Bitwidth of the index type for the host (warning this should be 64 until the GPU layering is fixed)'
-H1A2F700B75FE: '主机索引类型的位宽（警告：在GPU分层修复之前应为64）'
+H1A2F700B75FE: '主机索引类型的位宽（警告：在GPU分层修复之前应为 64）'
 # 'Block Frequency Analysis'
 H0F710FC006A0: '块频率分析'
 # 'Block frequency percentage a loop exit block needs over the original exit to be considered the new exit.'
@@ -4051,7 +4051,7 @@ H394C581D41AA: '自底向上感知寄存器压力的列表调度，试图平衡�
 # 'Bottom-up register reduction list scheduling'
 H669DA6589497: '自底向上寄存器缩减列表调度'
 # 'Bound on stack depth while inlining (4 by default)'
-H517AFAFA9D42: '内联时栈深度的上限（默认4）'
+H517AFAFA9D42: '内联时栈深度的上限（默认 4）'
 # 'Bound the dependence analysis by a maximal amount of computational steps (0 means no bound)'
 H649A261EB1B0: '通过最大计算步骤数限制依赖分析（0表示无限制）'
 # 'Bound the scheduler by maximal amountof computational steps. '
@@ -4075,7 +4075,7 @@ HD9D1E732D541: '在控制流图中分解关键边'
 # 'Break large PHI nodes for DAGISel'
 HCF5413A8839F: '分解DAGISel的大型PHI节点'
 # 'Break post-RA scheduling anti-dependencies: "critical", "all", or "none"'
-H75472E865DE3: "断开寄存器分配后调度的反依赖关系：'critical'、'all'或'none'"
+H75472E865DE3: "断开寄存器分配后调度的反依赖关系：'critical'、'all' 或 'none'"
 # 'BreakFalseDeps'
 H5FF559A5250F: '消除虚假依赖'
 # 'Breakdown the count by function name taking into consideration the filepath info from the DebugLoc of the remark.'
@@ -4085,7 +4085,7 @@ H55D8DD7267D8: '按函数名细分计数。'
 # 'Bucket number per loop for PPC loop chain common'
 H095EE2A27794: '每个循环的PPC循环链公共桶数量'
 # 'Buffer the last N characters of debug output until program termination. [default 0 -- immediate print-out]'
-HEA243B6BB971: '在程序终止前缓冲调试输出的最后N个字符。[默认0 —— 立即输出]'
+HEA243B6BB971: '在程序终止前缓冲调试输出的最后N个字符。[默认 0 —— 立即输出]'
 # "BugPoint Test Pass - Intentionally 'misoptimize' CallInsts"
 H89AAE42B7AE6: "BugPoint 测试 Pass - 故意对 CallInsts '误优化'"
 # 'BugPoint Test Pass - Intentionally crash on CallInsts'
@@ -4199,29 +4199,29 @@ H3E3A7818BD1C: '绕过负载切片的效益模型'
 # 'C does not support default arguments'
 H9634D9BB0DF6: 'C不支持默认参数'
 # 'C requires #line number to be less than %0, allowed as extension'
-H2FF7FD761591: 'C要求#line的行号小于%0，作为扩展允许'
+H2FF7FD761591: 'C要求#line的行号小于 %0，作为扩展允许'
 # 'C requires a comma prior to the ellipsis in a variadic function type'
 HF2B9DE1954B1: 'C需要在可变函数类型中的省略号前有逗号'
 # "C++ ABI '%0' is not supported on target triple '%1'"
-H00336F051C87: "C++ ABI '%0'在目标三元组'%1'上不受支持"
+H00336F051C87: "C++ ABI '%0' 在目标三元组 '%1' 上不受支持"
 # 'C++ ABI to use. This will override the target C++ ABI.'
 H9B471B29FD3A: '使用的C++ ABI。此选项将覆盖目标C++ ABI'
 # 'C++ implementation file name'
 HE4F416D1C66F: 'C++ 实现文件名称'
 # 'C++ operator %0 (aka %1) used as a macro name'
-H2A2A24E029F0: 'C++运算符%0（别名%1）被用作宏名'
+H2A2A24E029F0: 'C++运算符 %0（别名 %1）被用作宏名'
 # 'C++ standard library to use'
 HEE4D104DB34B: '使用的C++标准库'
 # 'C++11 only allows consecutive left square brackets when introducing an attribute'
 H2040F8CA0C12: 'C++11仅允许在引入属性时连续使用左方括号'
 # 'C++98 requires an accessible copy constructor for class %2 when binding a reference to a temporary; was %select{private|protected}0'
-H89F3A4330FF6: 'C++98要求当绑定到临时对象时，类%2需要可访问的拷贝构造函数；当前是%select{private|protected}0'
+H89F3A4330FF6: 'C++98要求当绑定到临时对象时，类 %2 需要可访问的拷贝构造函数；当前是 %select{private|protected}0'
 # 'C99 forbids casting nonscalar type %0 to the same type'
-H26E6559D43AC: 'C99禁止将非标量类型%0显式转换为自身'
+H26E6559D43AC: 'C99禁止将非标量类型 %0 显式转换为自身'
 # 'C99 forbids conditional expressions with only one void side'
 HD3A412BC601A: 'C99 禁止只带有单个 void 类型操作数的条件表达式'
 # 'CF object of type %0 is bridged to %1, which is not an Objective-C class'
-H41EE49AD057C: '类型%0的CF对象被桥接到非Objective-C类%1'
+H41EE49AD057C: '类型 %0 的CF对象被桥接到非Objective-C类 %1'
 # 'CFGuard'
 H6826B8A9825A: 'CFGuard保护'
 # 'CFI Verify Options'
@@ -4267,7 +4267,7 @@ H4386F29D7C1C: "CUDA 特殊函数 '%0' 必须有标量返回类型"
 # 'CUDA version %0 is only partially supported'
 HABB5F3AD45B9: 'CUDA 版本 %0 仅部分支持'
 # 'CUDA version%0 is newer than the latest%select{| partially}1 supported version %2'
-HC8470F3A3C10: 'CUDA 版本%0 比最新%select{| 部分}1 支持的版本 %2 更新'
+HC8470F3A3C10: 'CUDA 版本 %0 比最新%select{| 部分}1 支持的版本 %2 更新'
 # 'CXX Dump Options'
 HEC70FF6EBB76: 'CXX转储选项'
 # 'CXX Map Options'
@@ -4447,7 +4447,7 @@ H66FA420C1EB1: '代码大小和延迟'
 # 'CodeGen (expected to match llc)'
 HD2FDC55840F0: '代码生成（应与llc匹配）'
 # "Codegen optimization level (0, 1, 2 or 3, default = '2')"
-H0604F43896B4: "代码生成优化级别（0、1、2或3，默认='2'）"
+H0604F43896B4: "代码生成优化级别（0、1、2或 3，默认='2'）"
 # 'Collect access count histograms'
 HEFDB6DB25681: '收集访问计数直方图'
 # 'Collect control flow of function'
@@ -4541,7 +4541,7 @@ H10812CD37717: '比较选项'
 # 'Compare all elements.'
 HD1160DBAE7C6: '比较所有元素。'
 # 'Compare bits 62 and 61 of address (TBI should be disabled)'
-HC1881DEFBF5A: '比较地址的第62和61位（应禁用TBI）'
+HC1881DEFBF5A: '比较地址的第 62 和 61位（应禁用TBI）'
 # 'Compare with the result of XPAC (requires Armv8.3-a)'
 HBA5A269FECBF: '与XPAC的结果进行比较（需要Armv8.3-a）'
 # 'Compare with the result of XPACLRI'
@@ -4643,7 +4643,7 @@ HE778B3B33793: '控制将memcpy转换为尾部条件循环（WLSTP）'
 # 'Control emission of Swift async extended frame info'
 H02D3442EBA23: '控制Swift异步扩展帧信息的生成'
 # "Control how the assembler should align branches with NOP. If the boundary's size is not 0, it should be a power of 2 and no less than 32. Branches will be aligned to prevent from being across or against the boundary of specified size. The default value 0 does not align branches."
-H8B5A4A325A23: '控制汇编器如何使用NOP对齐分支。如果边界大小不为0，则必须为2的幂次且不小于32。分支将被对齐以避免跨越或逆向指定大小的边界。默认值0不进行分支对齐。'
+H8B5A4A325A23: '控制汇编器如何使用NOP对齐分支。如果边界大小不为 0，则必须为 2 的幂次且不小于 32。分支将被对齐以避免跨越或逆向指定大小的边界。默认值 0 不进行分支对齐。'
 # 'Control jump table emission on Hexagon target'
 H6602FAB1D723: '控制Hexagon目标的跳转表生成。'
 # 'Control lookup table emission on Hexagon target'
@@ -4659,7 +4659,7 @@ H27887A938BFF: '控制要执行的phi节点折叠量（默认值=2）'
 # 'Control the maximal conditional load/store that we are willing to speculatively execute to eliminate conditional branch (default = 6)'
 HEA5F4A80FEFE: '控制愿意推测执行的最大条件加载/存储以消除条件分支（默认值=6）'
 # 'Control the maximal total instruction cost that we are willing to speculatively execute to fold a 2-entry PHI node into a select (default = 4)'
-H57D2DDD9FD2C: '控制愿意推测执行的最大总指令成本以将2条目PHI节点折叠为选择（默认值=4）'
+H57D2DDD9FD2C: '控制愿意推测执行的最大总指令成本以将 2 条目PHI节点折叠为选择（默认值=4）'
 # 'Control the number of bonus instructions (default = 1)'
 H7BC9F590620F: '控制额外指令的数量（默认值=1）'
 # 'Control the rules which are enabled. These options all take a comma separated list of rules to disable and may be specified by number or number range (e.g. 1-10).'
@@ -4803,7 +4803,7 @@ H01E9364CFCA0: '创建带有图形变化的网站'
 # 'Create a website with graphical changes in quiet mode'
 H70CA1F4FAB9C: '在静默模式下创建带有图形变化的网站'
 # 'Create cfi directives that assume the code might be more than 2gb away'
-H558862C2332B: '创建假设代码可能相距超过2GB的cfi指令'
+H558862C2332B: '创建假设代码可能相距超过 2GB的cfi指令'
 # 'Create debug DLL'
 H983B4E5552B9: '创建调试 DLL'
 # 'Create empty files if bundles are missing when unbundling.\n'
@@ -4837,7 +4837,7 @@ HF9A83C7746B5: '在内存等待时消除危险'
 # 'Cutoff for generating "extract" instructions'
 HF67D76A2F279: '生成"extract"指令的阈值'
 # 'Cutoff percentages (times 10000) for generating detailed summary'
-HF12B62925337: '生成详细摘要的百分比阈值（乘以10000）'
+HF12B62925337: '生成详细摘要的百分比阈值（乘以 10000）'
 # 'Cutoff value about how many symbols in profile symbol list will be used. This is very useful for performance debugging'
 H866011BDFA50: '符号数目阈值，用于确定在性能分析符号列表中使用的符号数量。这对性能调试非常有用'
 # 'Cycle Info Analysis'
@@ -4973,7 +4973,7 @@ H0675076F20CF: '平台和JIT类型默认值'
 # 'Default max threads per block for kernel launch bounds for HIP'
 HDE6E6DE6B0D5: 'HIP内核启动边界中每个块的默认最大线程数'
 # 'Default mispredict rate (initialized to 25%).'
-HA90859109DC8: '默认误预测率（初始化为25%）。'
+HA90859109DC8: '默认误预测率（初始化为 25%）。'
 # 'Default register allocator'
 HF2112AFDE4A0: '默认寄存器分配器'
 # 'Default threshold (max size of unrolled loop), used in all but O3 optimizations'
@@ -4985,7 +4985,7 @@ HD7B0D94624F9: '延迟显示CUDA/HIP相关的主机/设备诊断信息'
 # "Define '__STDC__' to '1' in MSVC Compatibility mode"
 HE12E4DC30513: '在MSVC兼容模式下将"__STDC__"定义为"1"'
 # 'Define <macro> to <value> (or 1 if <value> omitted)'
-HC9C0FAB29C48: '将宏<macro>定义为<value>（若省略<value>则定义为1）'
+HC9C0FAB29C48: '将宏 <macro> 定义为 <value>（若省略 <value> 则定义为 1）'
 # 'Define __STDC__'
 H403D03CBAA5E: '定义__STDC__'
 # 'Define a value for a symbol'
@@ -5007,7 +5007,7 @@ H97F94F0D6F64: '定义每个调试位置的检查数量阈值以强制更新来�
 # 'Define where potential integer overflows in generated expressions should be tracked.'
 H76CDAC079D12: '定义在生成的表达式中应跟踪的整数溢出位置。'
 # 'Defined the specified macros to their specified definition. The syntax is <macro>=<definition>'
-H8B59655A675D: '将指定的宏定义为指定的定义。语法是<macro>=<definition>'
+H8B59655A675D: '将指定的宏定义为指定的定义。语法是 <macro>=<definition>'
 # 'Defines a symbol to be an integer constant'
 H876930F92D82: '将符号定义为整数常量'
 # 'Defines the __DEPRECATED macro'
@@ -5527,7 +5527,7 @@ H1147057C0FDD: '禁用合并到combines中'
 # 'Disable merging of globals'
 H0911384E3022: '禁用全局变量的合并'
 # 'Disable minimum alignment of 1 for arguments passed by value on stack'
-HAF9C1AF67E2F: '禁用对栈上按值传递的参数的最小对齐1'
+HAF9C1AF67E2F: '禁用对栈上按值传递的参数的最小对齐 1'
 # 'Disable mitigations for Load Value Injection (LVI)'
 HE89F1385E864: '禁用对Load Value Injection (LVI)的缓解措施'
 # 'Disable module-based external API notes support'
@@ -5707,7 +5707,7 @@ H9E100408BFFF: '禁用生成汇编伪指令'
 # 'Disable the expand reduction intrinsics pass from running'
 H040AA8C3CBF5: '禁用展开约简固有函数传递的运行'
 # 'Disable the generation of 4-operand madd.s, madd.d and related instructions.'
-HB91438C02652: '禁用生成4操作数madd.s、madd.d及相关指令。'
+HB91438C02652: '禁用生成 4 操作数madd.s、madd.d及相关指令。'
 # 'Disable the generation of low-overhead loops'
 H1104A5C142EF: '禁用生成低开销循环'
 # 'Disable the integrated assembler'
@@ -6017,7 +6017,7 @@ H1F6F59A37FC5: '不假设C++运算符new不会返回NULL'
 # 'Do not assume that any loop is finite.'
 H5580E1E87EBF: '不假设任何循环是有限的。'
 # 'Do not assume that externally defined data is in the small data if it meets the -G <size> threshold (MIPS)'
-HAD54547B8D0E: '不假设符合-G<size>阈值的外部定义数据位于小数据区 (MIPS)'
+HAD54547B8D0E: '不假设符合-G<size> 阈值的外部定义数据位于小数据区 (MIPS)'
 # 'Do not automatically generate or update the global module index'
 H6DB4D9D7E3EF: '不自动生成或更新全局模块索引'
 # 'Do not automatically import modules for error recovery'
@@ -6159,7 +6159,7 @@ H5B1E0C37199B: '不输出任何.gcov文件'
 # 'Do not override toolchain to compile HIP source to relocatable'
 H67099DA33091: '不覆盖工具链以将HIP源代码编译为可重定位目标'
 # 'Do not place constants in the .rodata section instead of the .sdata if they meet the -G <size> threshold (MIPS)'
-H21A91E9ACB5C: '不将符合-G<size>阈值的常量放入.rodata节段而非.sdata节（MIPS）'
+H21A91E9ACB5C: '不将符合-G<size> 阈值的常量放入.rodata节段而非.sdata节（MIPS）'
 # 'Do not preserve comments in inline assembly'
 H942DAB64A211: '不在内联汇编中保留注释'
 # 'Do not prevent DecoderTable duplications caused by HwModes'
@@ -6569,7 +6569,7 @@ H01B54D632FED: '转储镜像节头'
 # 'Dump input on failure'
 H6F31E933D50C: '失败时转储输入'
 # "Dump input to stderr, adding annotations representing\ncurrently enabled diagnostics.  When there are multiple\noccurrences of this option, the <value> that appears earliest\nin the list below has precedence.  The default is 'fail'.\n"
-H768FAF2A8E36: "将输入附加注释输出到stderr，这些注释表示当前启用的诊断。\n当存在此选项的多个出现时，列表中最早出现的<value>具有优先权。\n默认值为'fail'。\n"
+H768FAF2A8E36: "将输入附加注释输出到stderr，这些注释表示当前启用的诊断。\n当存在此选项的多个出现时，列表中最早出现的 <value> 具有优先权。\n默认值为 'fail'。\n"
 # 'Dump list of actions to perform'
 HD3BA4698DD33: '转储要执行的操作列表'
 # 'Dump low level bitcode trace'
@@ -6625,15 +6625,15 @@ H8E456C399A58: '转储符号及其源代码位置'
 # 'Dump templight information to stdout'
 H1AD586FAA55A: '将templight信息输出到标准输出'
 # 'Dump the DBI Stream Headers (Stream 2)'
-H129FA94CBB86: '转储DBI流头（流2）'
+H129FA94CBB86: '转储DBI流头（流 2）'
 # 'Dump the FIR created by lowering and exit'
 H91B777999917: '转储由下层转换生成的FIR并退出'
 # 'Dump the HLFIR created by lowering and exit'
 H2BFC1CB7ACAA: '转储由下层转换生成的HLFIR并退出'
 # 'Dump the IPI Stream (Stream 5)'
-H0EC59D4B528C: '转储IPI流（流5）'
+H0EC59D4B528C: '转储IPI流（流 5）'
 # 'Dump the PDB Stream (Stream 1)'
-H4577B257A885: '转储PDB流（流1）'
+H4577B257A885: '转储PDB流（流 1）'
 # 'Dump the PDB String Table'
 H46D5A974F1C3: '转储PDB字符串表'
 # 'Dump the Publics Stream'
@@ -6641,7 +6641,7 @@ H9A8FF0F8500C: '转储公共符号流'
 # "Dump the SCCs in the ThinLTO index's callgraph"
 H05F63DC7879B: '转储ThinLTO索引调用图中的强连通分量'
 # 'Dump the TPI Stream (Stream 3)'
-H838873B9AC8D: '转储TPI流（流3）'
+H838873B9AC8D: '转储TPI流（流 3）'
 # 'Dump the compiler configuration options'
 H3D1A24CE8D0E: '转储编译器配置选项'
 # 'Dump the cooked character stream in -E mode'
@@ -6697,9 +6697,9 @@ HE0360B0DDF0D: '动态链接sanitizer运行时'
 # 'EABI GNU'
 H7E2A3B789B36: 'EABI GNU'
 # 'EABI version 4'
-H3C615C59EEA1: 'EABI 版本4'
+H3C615C59EEA1: 'EABI 版本 4'
 # 'EABI version 5'
-HDD2C36FB7B3F: 'EABI 版本5'
+HDD2C36FB7B3F: 'EABI 版本 5'
 # 'Eagerly compute live intervals for all physreg units.'
 H8BDCB87E4D2E: '积极计算所有物理寄存器单元的活跃区间。'
 # 'Eagerly invalidate more analyses in default pipelines'
@@ -6871,7 +6871,7 @@ H83A96897A283: '生成可动态打印运行时检查结果的代码'
 # 'Emit codegen data into the object file. LLD for MachO (currently) merges them into default.cgdata.'
 HE5A9DF802056: '将代码生成数据写入目标文件。目前LLD的MachO版本会将它们合并到default.cgdata中。'
 # 'Emit codegen data into the object file. LLD for MachO (currently) merges them into the specified <path>.'
-HB514733CE70A: '将代码生成数据写入目标文件。目前LLD的MachO版本会将它们合并到指定的<path>中。'
+HB514733CE70A: '将代码生成数据写入目标文件。目前LLD的MachO版本会将它们合并到指定的 <path> 中。'
 # 'Emit colored output (default=autodetect)'
 H1C348B34C157: '生成彩色输出（默认=自动检测）'
 # 'Emit compiler path and command line into CodeView debug information'
@@ -6965,7 +6965,7 @@ H92226FB5F865: '生成特殊的调试信息以启用PGO配置文件生成'
 # 'Emit special instrumentation for accesses to volatiles'
 H807EB1BCE795: '为volatile变量的访问生成特殊插桩'
 # 'Emit the GNU .debug_macro format with DWARF <5'
-H05986F777FFF: '当DWARF版本小于5时生成GNU的.debug_macro格式'
+H05986F777FFF: '当DWARF版本小于 5 时生成GNU的.debug_macro格式'
 # 'Emit the XCOFF traceback table'
 H2AD67289821E: '生成XCOFF跟踪表'
 # 'Emit the basic block address map section'
@@ -6995,7 +6995,7 @@ H85639A20AE92: '启用-Weverything'
 # 'Enable -Wsystem-headers'
 HCF6CBF83669C: '启用-Wsystem-headers'
 # 'Enable -Wsystem-headers when building <module>'
-H7BD118FCCA2F: '在构建<module>时启用-Wsystem-headers'
+H7BD118FCCA2F: '在构建 <module> 时启用-Wsystem-headers'
 # 'Enable -time-passes memory tracking (this may be slow)'
 HCD77711AC848: '启用-time-passes内存跟踪（这可能会很慢）'
 # 'Enable .XOR. as a synonym of .NEQV.'
@@ -7007,9 +7007,9 @@ H2EC78B18E661: '在全局指令选择中启用/禁用SVE可扩展向量'
 # 'Enable / disable promotion of unnamed_addr constants into constant pools'
 HFAE28EE53BD3: '启用/禁用将unnamed_addr常量提升到常量池'
 # 'Enable 16-bit types and disable min precision types.Available in HLSL 2018 and shader model 6.2.'
-HAAC77E9561C2: '启用16位类型并禁用最小精度类型。适用于HLSL 2018和着色器模型6.2。'
+HAAC77E9561C2: '启用 16 位类型并禁用最小精度类型。适用于HLSL 2018和着色器模型 6.2。'
 # 'Enable <feature> in module map requires declarations'
-H5C8DA92AFFD8: '在模块映射需要声明时启用<feature>'
+H5C8DA92AFFD8: '在模块映射需要声明时启用 <feature>'
 # 'Enable AArch64 SME memory operations to lower to librt functions'
 H2DE7C9221C4E: '启用AArch64 SME内存操作以降级到librt函数'
 # 'Enable AArch64 logical imm instruction optimization'
@@ -7023,7 +7023,7 @@ H9BDDE4ABB4D1: '启用AMDGPUAttributorPass'
 # 'Enable ARC-style weak references in Objective-C'
 H9B793CE9E824: '启用Objective-C中的ARC风格弱引用'
 # 'Enable ARM 2-addr to 3-addr conv'
-HFA9A2110C825: '启用ARM从2地址到3地址的转换'
+HFA9A2110C825: '启用ARM从 2 地址到 3 地址的转换'
 # 'Enable ARM load/store optimization pass'
 HF1C1057F91DB: '启用ARM的加载/存储优化passes'
 # 'Enable AddressSanitizer'
@@ -7077,7 +7077,7 @@ H3B25285FD614: '启用假定没有±无穷大的浮点数学优化'
 # 'Enable FP math optimizations that assume no NaNs'
 H9640D97F95AD: '启用假定没有NaN的浮点数学优化'
 # 'Enable FP math optimizations that assume the sign of 0 is insignificant'
-HE827F0FDD8E0: '启用假定0的符号不重要的浮点数学优化'
+HE827F0FDD8E0: '启用假定 0 的符号不重要的浮点数学优化'
 # 'Enable Fast Math processing'
 H2F61C44B4052: '启用快速数学处理'
 # 'Enable Freestanding (disable builtins / TLI) during LTO'
@@ -7131,9 +7131,9 @@ H98BCB50602AD: '启用内核MemorySanitizer插桩'
 # 'Enable LSR phi elimination'
 H6F6B88180DCF: '启用LSR phi消除'
 # "Enable LTO in 'full' mode"
-HDE2B72E90D39: "以'full'模式启用LTO"
+HDE2B72E90D39: "以 'full' 模式启用LTO"
 # "Enable LTO in 'full' mode for offload compilation"
-H1AD130930D3D: "为外置编译启用'full'模式的LTO"
+H1AD130930D3D: "为外置编译启用 'full' 模式的LTO"
 # 'Enable Loongson Advanced SIMD Extension (LASX).'
 H8708BF686447: '启用Loongson高级SIMD扩展（LASX）'
 # 'Enable Loongson SIMD Extension (LSX).'
@@ -7207,7 +7207,7 @@ H4E40230CBB89: '启用ThinLTO缓存'
 # 'Enable Unroll And Jam Pass'
 HC78C6B520033: '启用展开并压缩Pass'
 # 'Enable V8+ mode, allowing use of 64-bit V9 instructions in 32-bit code'
-H51CF3B974577: '启用V8+模式，允许在32位代码中使用64位V9指令'
+H51CF3B974577: '启用V8+模式，允许在 32 位代码中使用 64 位V9指令'
 # 'Enable VGPR liverange optimizations for if-else structure'
 H7A56B298E40B: '启用if-else结构的VGPR存活范围优化'
 # 'Enable VOPD, dual issue of VALU in wave32'
@@ -7275,7 +7275,7 @@ HB288E3CF4716: '启用sanitizer覆盖中的基本块跟踪'
 # 'Enable binary and hex Motorola integers (%110 and $ABC)'
 H929D942FA2B2: '启用二进制和十六进制Motorola整数（%110和$ABC）'
 # 'Enable binary and hex masm integers (0b110 and 0ABCh)'
-H299555A297D6: '启用二进制和十六进制masm整数（0b110和0ABCh）'
+H299555A297D6: '启用二进制和十六进制masm整数（0b110和 0ABCh）'
 # 'Enable binary output on terminals'
 HB1EFC8602261: '在终端启用二进制输出'
 # 'Enable bottleneck analysis (disabled by default)'
@@ -7459,7 +7459,7 @@ H181E6C00680E: '启用对模块文件内容进行哈希处理'
 # 'Enable heap memory profiling'
 H80510263BC9C: '启用堆内存分析'
 # 'Enable heap memory profiling and dump results into <directory>'
-H29A449A8CDB1: '启用堆内存分析并将结果转储到<directory>'
+H29A449A8CDB1: '启用堆内存分析并将结果转储到 <directory>'
 # 'Enable hexagon-qdsp6 backward compatibility'
 HC33E9FDD1F01: '启用hexagon-qdsp6向下兼容'
 # 'Enable hot-cold splitting pass'
@@ -7485,7 +7485,7 @@ H636968D53932: '在极端情况下启用LICM中的不精确性，以换取更快
 # 'Enable incremental processing extensions such as processing statements on the global scope.'
 H6BA53F1C325A: '启用增量处理扩展（如在全局作用域处理语句等）'
 # 'Enable inline 8-bit counters in sanitizer coverage'
-H519F01E8620F: '在sanitizer覆盖中启用内联8位计数器'
+H519F01E8620F: '在sanitizer覆盖中启用内联 8 位计数器'
 # 'Enable inline bool flag in sanitizer coverage'
 HC8EAB045EC47: '在sanitizer覆盖中启用内联bool标志'
 # 'Enable inline deferral during PGO'
@@ -7789,7 +7789,7 @@ H4AAD4C1AF839: '为所有函数启用堆栈保护程序'
 # 'Enable stack protectors for some functions vulnerable to stack smashing. Compared to -fstack-protector, this uses a stronger heuristic that includes functions containing arrays of any size (and any type), as well as any calls to alloca or the taking of an address from a local variable'
 H01F993B30A66: '启用堆栈保护程序以防御某些易受堆栈溢出攻击的函数。与-fstack-protector相比，该选项使用更强的启发式方法，包括包含任意大小（以及任意类型）数组的函数，以及任何alloca调用或本地变量地址的获取'
 # "Enable stack protectors for some functions vulnerable to stack smashing. This uses a loose heuristic which considers functions vulnerable if they contain a char (or 8bit integer) array or constant sized calls to alloca , which are of greater size than ssp-buffer-size (default: 8 bytes). All variable sized calls to alloca are considered vulnerable. A function with a stack protector has a guard value added to the stack frame that is checked on function exit. The guard value must be positioned in the stack frame such that a buffer overflow from a vulnerable variable will overwrite the guard value before overwriting the function's return address. The reference stack guard value is stored in a global variable."
-H216044E73536: '启用堆栈保护程序以防御某些易受堆栈溢出攻击的函数。该选项使用宽松启发式方法，若函数包含大于ssp-buffer-size（默认：8字节）大小的char（或8位整数）数组或固定大小的alloca调用，则视为易受攻击。所有变长alloca调用均视为易受攻击。带有堆栈保护程序的函数会在堆栈帧中添加一个保护值，并在函数退出时进行验证。保护值的位置需确保缓冲区溢出会先覆盖该值而非函数返回地址。参考堆栈保护值存储于全局变量中。'
+H216044E73536: '启用堆栈保护程序以防御某些易受堆栈溢出攻击的函数。该选项使用宽松启发式方法，若函数包含大于ssp-buffer-size（默认：8字节）大小的char（或 8 位整数）数组或固定大小的alloca调用，则视为易受攻击。所有变长alloca调用均视为易受攻击。带有堆栈保护程序的函数会在堆栈帧中添加一个保护值，并在函数退出时进行验证。保护值的位置需确保缓冲区溢出会先覆盖该值而非函数返回地址。参考堆栈保护值存储于全局变量中。'
 # 'Enable static hinting of branches on ppc'
 H1318D7CF750E: '启用在PPC上对分支进行静态提示'
 # 'Enable statistics output from program (available with Asserts)'
@@ -7833,7 +7833,7 @@ HC28B60B42675: '启用“全局”指令选择器'
 # "Enable the 'blocks' language feature"
 H8A0F69B5F85C: '启用"blocks"语言特性'
 # "Enable the 'modules' language feature"
-H047278B48AFB: "启用'modules'语言特性"
+H047278B48AFB: "启用 'modules' 语言特性"
 # 'Enable the AArch64 branch target pass'
 H288D5F3BECED: '启用AArch64分支目标Pass'
 # 'Enable the AIX Extended Altivec ABI.'
@@ -7885,7 +7885,7 @@ HA94181FC4D28: '启用实验性新常量解释器'
 # 'Enable the extended Altivec ABI on AIX. Use volatile and nonvolatile vector registers'
 H6369C2DE5BEE: '在AIX上启用扩展的Altivec ABI。使用volatile和非volatile向量寄存器'
 # 'Enable the generation of 4-operand madd.s, madd.d and related instructions.'
-H2954D704DCA6: '启用生成4操作数的madd.s、madd.d及相关指令'
+H2954D704DCA6: '启用生成 4 操作数的madd.s、madd.d及相关指令'
 # 'Enable the generation of WLS loops'
 HB0BD6C355304: '启用WLS循环生成'
 # 'Enable the generation of masked gathers and scatters'
@@ -8071,7 +8071,7 @@ H19C598762536: '启用VTune性能分析支持。'
 # 'Enable warnings for deprecated constructs and define __DEPRECATED'
 H141A6A5BBE2F: '为弃用的构造启用警告并定义__DEPRECATED'
 # 'Enable warnings for undefined macros with a prefix in the comma separated list <arg>'
-HCD611C0CC9C3: '为逗号分隔列表<arg>中带有前缀的未定义宏启用警告'
+HCD611C0CC9C3: '为逗号分隔列表 <arg> 中带有前缀的未定义宏启用警告'
 # 'Enable whole program visibility'
 HED7D14DA2E46: '启用整个程序的可见性。'
 # 'Enable whole program visibility during LTO'
@@ -8237,7 +8237,7 @@ H1F5EDB8C4566: '如果不可预测的值来自同一循环，则提前退出'
 # 'Exit with an error when an instruction is unsupported for any reason (default)'
 HDA0C7DD7EA63: '当指令不支持时以错误退出（默认）'
 # 'Expand 64-bit division in AMDGPUCodeGenPrepare'
-HEA34070476C9: '在AMDGPUCodeGenPrepare中展开64位除法'
+HEA34070476C9: '在AMDGPUCodeGenPrepare中展开 64 位除法'
 # 'Expand Atomic instructions'
 H30D3E9ACF190: '展开原子指令'
 # 'Expand certain fp instructions'
@@ -8333,7 +8333,7 @@ HF76D682A9D15: '将 HwModes 特定指令提取到新的 DecoderTables 中，显�
 # 'Extract at most one loop into a new function'
 H2D39B07FBC4D: '提取最多一个循环到新函数'
 # 'Extract from <file>.'
-H4A68D5BEAE14: '从<file>中提取'
+H4A68D5BEAE14: '从 <file> 中提取'
 # 'Extract loops into new functions'
 H053EB2868DBF: '将循环提取到新函数中'
 # 'FAILURE'
@@ -8353,7 +8353,7 @@ H3E3C2FB702A6: 'FIX-IT 无法在宏中应用建议的代码更改'
 # 'Factor for the unroll threshold to account for code simplifications still taking place'
 HBD6D5665E545: '用于考虑代码简化仍在进行时的展开阈值因子'
 # 'Factor to apply to what qualifies as a long branch to reserve a pair of scalar registers. If this value is 0 the long branch registers are never reserved. As this value grows the greater chance the branch distance will fall within the threshold and the registers will be marked to be reserved. We lean towards always reserving a register for  long jumps'
-H106A273943F9: '若值为0则长分支寄存器永不保留。随着该值增大，分支距离越可能在阈值内，寄存器会被标记为保留。我们倾向于总是为长跳转保留寄存器'
+H106A273943F9: '若值为 0 则长分支寄存器永不保留。随着该值增大，分支距离越可能在阈值内，寄存器会被标记为保留。我们倾向于总是为长跳转保留寄存器'
 # "Fail if an object couldn't be found for a binary ID in the profile"
 H4235E7E596D5: '如果在概要文件中找不到对象，则失败'
 # 'Fail if any profile is invalid.'
@@ -8471,7 +8471,7 @@ H4D2FE19AC654: '在目录DIR或基于文件FILE的路径中查找对象'
 # 'Find subclasses of a class.'
 HC1D51E00B82D: '查找一个类的子类。'
 # 'Fix copies between 32 and 16 bit registers by extending to 32 bit'
-H2E54AD53EEA9: '通过扩展到32位来修复32位和16位寄存器之间的复制'
+H2E54AD53EEA9: '通过扩展到 32 位来修复 32 位和 16 位寄存器之间的复制'
 # 'Fix function entry count in profile use.'
 H99125FC0562C: '修正配置文件使用中的函数入口计数。'
 # 'Fix mismatching bitcasts for WebAssembly'
@@ -8541,9 +8541,9 @@ H5C641C769774: '在合并时，使用提供的未剥离二进制文件关联原�
 # 'For partially supported constructs, emit `[first]private` variables as clauses on the MLIR ops.'
 H6182FD8E07DA: '对于部分支持的结构，将`[first]private`变量作为MLIR操作的子句输出'
 # 'For paths in debug info, remap directory <old> to <new>. If multiple options match a path, the last option wins'
-H3D3679C30C18: '在调试信息中，将目录<old>重映射为<new>。如果多个选项匹配同一路径，则最后一个选项生效'
+H3D3679C30C18: '在调试信息中，将目录 <old> 重映射为 <new>。如果多个选项匹配同一路径，则最后一个选项生效'
 # 'For sample profiles, list function names (with calling context for csspgo) for overlapped functions with similarities below the cutoff (percentage times 10000).'
-H463D2852BF2F: '对于采样配置文件，列出相似度低于阈值（百分比乘以10000）的重叠函数名称（包含csspgo的调用上下文）'
+H463D2852BF2F: '对于采样配置文件，列出相似度低于阈值（百分比乘以 10000）的重叠函数名称（包含csspgo的调用上下文）'
 # 'For shared library loaded with the main program, change local-dynamic access(es) to initial-exec access(es) at the function level (AIX 64-bit only).'
 HD94E43E648D1: '针对与主程序一起加载的共享库，在函数级别将local-dynamic访问模式更改为initial-exec访问模式（仅限AIX 64位）'
 # 'For show, read and extract profile metadata from debug info and show the functions it found. For merge, use the provided debug info to correlate the raw profile.'
@@ -8563,7 +8563,7 @@ H9FFDA74D3CE8: '与/winsysroot配合使用时，默认使用最新找到的'
 # 'Force a peel count regardless of profiling information.'
 H6BA57EBF2817: '强制指定循环展开次数，无论配置文件信息如何'
 # 'Force a specific generic_v<N> flag to be added. For testing purposes only.'
-H12597D7C787F: '强制添加特定的generic_v<N>标志。仅用于测试目的'
+H12597D7C787F: '强制添加特定的generic_v<N> 标志。仅用于测试目的'
 # 'Force align the stack to the minimum alignment'
 H6ABD893EDD1A: '强制将栈对齐到最小对齐值'
 # 'Force all edges in the function summary to cold'
@@ -8583,7 +8583,7 @@ H8477BA8471BC: '强制所有向量内存访问对齐（仅RISC-V）'
 # 'Force all waitcnt instrs to be emitted as s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)'
 H687C328A88F2: '强制将所有waitcnt指令生成为s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)'
 # 'Force all waitcnt load counters to wait until 0'
-H896788DC2080: '强制所有waitcnt加载计数器等待直到0'
+H896788DC2080: '强制所有waitcnt加载计数器等待直到 0'
 # 'Force allowance of nested hardware loops'
 HAD8E45F66910: '允许嵌套硬件循环'
 # 'Force analysis to continue in the presence of unsupported instructions'
@@ -8603,7 +8603,7 @@ H5694C07468F1: '强制代码生成假设舍入模式可以动态变化'
 # 'Force disable the lazy-loading on-demand of metadata when loading bitcode for importing.'
 H2329A45D867C: '强制禁用加载bitcode时元数据的按需惰性加载'
 # 'Force double to be <n> bits'
-H6A3CAE57D5DB: '强制double为<n>位'
+H6A3CAE57D5DB: '强制double为 <n> 位'
 # 'Force each unsigned fixed point type to have an extra bit of padding to align their scales with those of signed fixed point types'
 H2DB086248971: '强制每个无符号定点类型都有一个额外的填充位，使其量程与有符号定点类型对齐'
 # 'Force emit s_waitcnt expcnt(0) instrs'
@@ -8635,11 +8635,11 @@ HE0B08266ED91: '强制解释模式：禁用JIT'
 # 'Force linking the clang builtins runtime library'
 H602A2DB51D2C: '强制链接clang内建运行时库'
 # 'Force long double to be 128 bits'
-HF5330D6B0F62: '强制long double为64位'
+HF5330D6B0F62: '强制long double为 64 位'
 # 'Force long double to be 64 bits'
-HF1CEF43473D8: '强制long double为128位'
+HF1CEF43473D8: '强制long double为 128 位'
 # 'Force long double to be 80 bits, padded to 128 bits for storage'
-H2FBC78A0A1C7: '强制long double为80位，存储时填充至128位'
+H2FBC78A0A1C7: '强制long double为 80 位，存储时填充至 128 位'
 # 'Force machine combiner to use a specific strategy for machine trace metrics evaluation.'
 H8D7274D95AD0: '强制机器组合器使用特定策略评估机器轨迹指标。'
 # 'Force matrix instruction fusion even if not profitable.'
@@ -8661,11 +8661,11 @@ H7A397BF735D5: '无论目标查询如何，强制拆分存储。'
 # 'Force the (profiled-guided) size optimizations. '
 HA4B424DB2FF9: '强制执行（基于分析的）尺寸优化。'
 # 'Force the alignment of all blocks in the function in log2 format (e.g 4 means align on 16B boundaries).'
-HB1C496FAEC2F: '以log2格式强制对齐函数中的所有块（例如4表示对齐到16字节边界）。'
+HB1C496FAEC2F: '以log2格式强制对齐函数中的所有块（例如 4 表示对齐到 16 字节边界）。'
 # "Force the alignment of all blocks that have no fall-through predecessors (i.e. don't add nops that are executed). In log2 format (e.g 4 means align on 16B boundaries)."
-HEC173CEDA264: '强制对齐所有没有穿透前驱的块（即不添加会被执行的nop）。以log2格式（例如4表示对齐到16字节边界）。'
+HEC173CEDA264: '强制对齐所有没有穿透前驱的块（即不添加会被执行的nop）。以log2格式（例如 4 表示对齐到 16 字节边界）。'
 # 'Force the alignment of all functions in log2 format (e.g. 4 means align on 16B boundaries).'
-HAC694582BD7C: '以log2格式强制对齐所有函数（例如4表示对齐到16字节边界）。'
+HAC694582BD7C: '以log2格式强制对齐所有函数（例如 4 表示对齐到 16 字节边界）。'
 # 'Force the interpretation of -stream as a string, even if it is a valid integer'
 HD1DE45392158: '即使-stream是有效整数，也强制将其解释为字符串'
 # 'Force the static analyzer to analyze functions defined in header files'
@@ -8777,19 +8777,19 @@ H9F1BE3BC2E20: '在有利时融合FP运算'
 # 'GC Lowering'
 HB5C53C8FC4DB: 'GC 下降处理'
 # 'GCC does not allow %0 attribute in this position on a function definition'
-H6258B157AA4F: 'GCC 不允许在此位置在函数定义上使用%0属性'
+H6258B157AA4F: 'GCC 不允许在此位置在函数定义上使用 %0 属性'
 # 'GCC does not allow an attribute in this position on a function declaration'
 H6328F86D9296: 'GCC 不允许在此位置在函数声明上使用属性'
 # 'GCC does not allow the %0 attribute to be written on a type'
-HAF18361FDD0D: 'GCC 不允许将%0属性应用于类型'
+HAF18361FDD0D: 'GCC 不允许将 %0 属性应用于类型'
 # "GCC does not allow the 'cleanup' attribute argument to be anything other than a simple identifier"
-HB0EE895D3D5D: "GCC 要求'cleanup'属性参数只能是简单标识符"
+HB0EE895D3D5D: "GCC 要求 'cleanup' 属性参数只能是简单标识符"
 # 'GCC does not allow variable declarations in for loop initializers before C99'
 HD212EAC451BD: '在C99之前，GCC 不允许在for循环初始化器中声明变量'
 # 'GCC encoding (only meaningful for -sample)'
 H893D2EDBC511: 'GCC 编码（仅在 -sample 时有意义）'
 # 'GCC requires a function with the %0 attribute to be variadic'
-H4044A123EF83: 'GCC 要求带有%0属性的函数必须是可变参数函数'
+H4044A123EF83: 'GCC 要求带有 %0 属性的函数必须是可变参数函数'
 # 'GCN Create VOPD Instructions'
 HD50B13295BAC: 'GCN创建VOPD指令'
 # 'GCN DPP Combine'
@@ -8807,9 +8807,9 @@ H5DF13110207F: 'GNU向量条件操作数不能是%select{void|throw表达式}0'
 # 'GNU-style inline assembly is disabled'
 H2E56E6455BF0: '已禁用GNU风格的内联汇编'
 # 'GNUstep Objective-C runtime version %0 incompatible with target binary format'
-HBFB3FAB065B9: 'GNUstep Objective-C运行时版本%0与目标二进制格式不兼容'
+HBFB3FAB065B9: 'GNUstep Objective-C运行时版本 %0 与目标二进制格式不兼容'
 # "GPU arch %0 is supported by CUDA versions between %1 and %2 (inclusive), but installation at %3 is %4; use '--cuda-path' to specify a different CUDA install, pass a different GPU arch with '--cuda-gpu-arch', or pass '--no-cuda-version-check'"
-HA444373A0822: "GPU架构%0在CUDA %1到%2版本（含）中受支持，但%3处的安装版本为%4；请使用'--cuda-path'指定其他CUDA安装路径，或通过'--cuda-gpu-arch'指定不同GPU架构，或使用'--no-cuda-version-check'禁用版本检查"
+HA444373A0822: "GPU架构 %0 在CUDA %1 到 %2 版本（含）中受支持，但 %3 处的安装版本为 %4；请使用'--cuda-path'指定其他CUDA安装路径，或通过'--cuda-gpu-arch'指定不同GPU架构，或使用'--no-cuda-version-check'禁用版本检查"
 # 'Gang up loads and stores generated by inlining of memcpy'
 HE535C0271E93: '通过内联memcpy生成的合并加载和存储操作'
 # 'Gate the invocation of the tracing callbacks on a global variable. Currently only supported for trace-pc-guard and trace-cmp.'
@@ -8937,7 +8937,7 @@ H86F657FC95B7: '生成常规关键字属性列表及其参数信息'
 # 'Generate a partial profile (only meaningful for -extbinary)'
 H8B3C403992F1: '生成部分配置文件（仅对-extbinary有意义）'
 # 'Generate a pch file for all code up to and including <filename>'
-H3A6818A5EE16: '为所有直到并包含<filename>的代码生成预编译头文件'
+H3A6818A5EE16: '为所有直到并包含 <filename> 的代码生成预编译头文件'
 # 'Generate a recursive AST visitor for clang attributes'
 HD2CD27931B90: '为clang属性生成递归AST访问器'
 # 'Generate a sparse profile (only meaningful for -instr)'
@@ -9059,7 +9059,7 @@ HE7EB6B773956: '为从该模块生成的目标文件中的类型生成调试信�
 # 'Generate debug info with external references to clang modules or precompiled headers'
 HAD4093E5621B: '生成带有对 clang 模块或预编译头的外部引用的调试信息'
 # 'Generate debugging info in the 64-bit DWARF format'
-H70C04792FFA2: '以64位DWARF格式生成调试信息'
+H70C04792FFA2: '以 64 位DWARF格式生成调试信息'
 # 'Generate declarations for Offload API implementation functions'
 H36074FE5A628: '生成Offload API实现函数的声明'
 # 'Generate definitions of Clang Syntax Tree node clasess'
@@ -9087,19 +9087,19 @@ HABD4DCD38172: '生成提取指令'
 # 'Generate function to translate named character references to UTF-8 sequences'
 H2212027837CC: '生成将命名字符引用转换为UTF-8序列的函数'
 # 'Generate hot text symbols. Apply this option to a precompiled binary that manually calls into hugify, such that at runtime hugify call will put hot code into 2M pages. This requires relocation.'
-HE07FCEA6613B: '为预编译二进制文件生成热代码符号。需要手动调用hugify时使用此选项，这样在运行时hugify调用会将热代码放入2M页面。此操作需要重定位支持。'
+HE07FCEA6613B: '为预编译二进制文件生成热代码符号。需要手动调用hugify时使用此选项，这样在运行时hugify调用会将热代码放入 2M页面。此操作需要重定位支持。'
 # 'Generate instrumented code to collect context sensitive execution counts into <directory>/default.profraw (overridden by LLVM_PROFILE_FILE env var)'
-H10A2DF54F49A: '生成收集上下文敏感的执行计数的工具化代码，结果保存到<directory>/default.profraw（可被LLVM_PROFILE_FILE环境变量覆盖）'
+H10A2DF54F49A: '生成收集上下文敏感的执行计数的工具化代码，结果保存到 <directory>/default.profraw（可被LLVM_PROFILE_FILE环境变量覆盖）'
 # 'Generate instrumented code to collect context sensitive execution counts into default.profraw (overridden by LLVM_PROFILE_FILE env var)'
 HCBAB6F9C9B4D: '生成收集上下文敏感的执行计数的工具化代码，结果保存到default.profraw（可被LLVM_PROFILE_FILE环境变量覆盖）'
 # 'Generate instrumented code to collect coverage info for cold functions into <directory>/default.profraw (overridden by LLVM_PROFILE_FILE env var)'
-H389023BECF0C: '生成收集冷函数覆盖信息的工具化代码，结果保存到<directory>/default.profraw（可被LLVM_PROFILE_FILE环境变量覆盖）'
+H389023BECF0C: '生成收集冷函数覆盖信息的工具化代码，结果保存到 <directory>/default.profraw（可被LLVM_PROFILE_FILE环境变量覆盖）'
 # "Generate instrumented code to collect coverage info for cold functions into default.profraw file (overridden by '=' form of option or LLVM_PROFILE_FILE env var)"
 H40F8D1777D6C: '生成收集冷函数覆盖信息的工具化代码，结果保存到default.profraw文件（可被等号形式的选项或LLVM_PROFILE_FILE环境变量覆盖）'
 # 'Generate instrumented code to collect execution counts into <directory>/default.profraw (overridden by LLVM_PROFILE_FILE env var)'
-H884AE4DB8A23: '生成收集执行计数的工具化代码，结果保存到<directory>/default.profraw（可被LLVM_PROFILE_FILE环境变量覆盖）'
+H884AE4DB8A23: '生成收集执行计数的工具化代码，结果保存到 <directory>/default.profraw（可被LLVM_PROFILE_FILE环境变量覆盖）'
 # 'Generate instrumented code to collect execution counts into <file> (overridden by LLVM_PROFILE_FILE env var)'
-HF1CDB71BC3BA: '生成收集执行计数的工具化代码，结果保存到<file>（可被LLVM_PROFILE_FILE环境变量覆盖）'
+HF1CDB71BC3BA: '生成收集执行计数的工具化代码，结果保存到 <file>（可被LLVM_PROFILE_FILE环境变量覆盖）'
 # 'Generate instrumented code to collect execution counts into default.profraw (overridden by LLVM_PROFILE_FILE env var)'
 HEDA64E6D9E58: '生成收集执行计数的工具化代码，结果保存到default.profraw（可被LLVM_PROFILE_FILE环境变量覆盖）'
 # "Generate instrumented code to collect execution counts into default.profraw file (overridden by '=' form of option or LLVM_PROFILE_FILE env var)"
@@ -9177,13 +9177,13 @@ H05167BC54E72: '生成软件浮点库调用'
 # 'Generate source-level debug information'
 HAEF3BF8D74CD: '生成源级调试信息'
 # 'Generate source-level debug information with dwarf version 2'
-HD2B80CB88FC9: '使用DWARF版本2生成源级调试信息'
+HD2B80CB88FC9: '使用DWARF版本 2 生成源级调试信息'
 # 'Generate source-level debug information with dwarf version 3'
-HA4075062488F: '使用DWARF版本3生成源级调试信息'
+HA4075062488F: '使用DWARF版本 3 生成源级调试信息'
 # 'Generate source-level debug information with dwarf version 4'
-H248AE385BE0D: '使用DWARF版本4生成源级调试信息'
+H248AE385BE0D: '使用DWARF版本 4 生成源级调试信息'
 # 'Generate source-level debug information with dwarf version 5'
-HE4BA3B14D0D7: '使用DWARF版本5生成源级调试信息'
+HE4BA3B14D0D7: '使用DWARF版本 5 生成源级调试信息'
 # 'Generate source-level debug information with the default dwarf version'
 H938AF5B9960A: '使用默认DWARF版本生成源级调试信息'
 # 'Generate the clang parsed attribute helpers'
@@ -9215,7 +9215,7 @@ H5EEF255AAE70: '通用选项'
 # 'Generic memory optimizations'
 H800F1622EB9A: '通用内存优化'
 # 'Get the symbol definition from <line> <start-column> <end-column>'
-H9C96E5C80114: '从第<line>行的<start-column>到<end-column>列获取符号定义'
+H9C96E5C80114: '从第 <line> 行的<start-column>到<end-column>列获取符号定义'
 # 'Give each function an independent TBAA tree (default)'
 H7A952E99A7FC: '为每个函数分配独立的TBAA树（默认）'
 # 'Give global C++ operator new and delete declarations hidden visibility'
@@ -9233,7 +9233,7 @@ HE9E6E34AE2B8: '为每个基本块段分配唯一名称'
 # 'Give unique names to every section'
 HAE1CB86AEAE6: '为每个段分配唯一名称'
 # 'Global Pointer Addressing Size.  The default size is 8.'
-H7DA66DD4C059: '全局指针寻址大小。默认值为8。'
+H7DA66DD4C059: '全局指针寻址大小。默认值为 8。'
 # 'Global Value Numbering'
 H7BB46D78F883: '全局值编号'
 # 'Global merge function pass'
@@ -9271,23 +9271,23 @@ H4C1B608415FC: 'HIP版本格式为major.minor.patch'
 # 'HLSL Version'
 HB3FA8D10C87C: 'HLSL版本'
 # "HLSL code generation is unsupported for target '%0'"
-HE92A9C826849: "不支持为目标'%0'生成HLSL代码"
+HE92A9C826849: "不支持为目标 '%0' 生成HLSL代码"
 # 'HLSL only. Disables all standard includes containing non-native compiler types and functions.'
 H1F13E0FA5ECA: '仅HLSL。禁用包含非本机编译器类型和函数的所有标准包含文件'
 # 'HLSL resource needs to have [[hlsl::resource_class()]] attribute'
 HAC100FF02618: 'HLSL资源需要具有[[hlsl::resource_class()]]属性'
 # "HTML end tag '%0' is forbidden"
-H685A0F5F60EA: "HTML结束标签'%0'是被禁止的"
+H685A0F5F60EA: "HTML结束标签 '%0' 是被禁止的"
 # 'HTML end tag does not match any start tag'
 H04F1BAAABD62: 'HTML结束标签与任何开始标签不匹配'
 # 'HTML output'
 H9222F90CA7BE: 'HTML 输出'
 # "HTML start tag '%0' closed by '%1'"
-H5D28040DFF0A: "HTML开始标签'%0'被'%1'关闭"
+H5D28040DFF0A: "HTML开始标签 '%0' 被 '%1' 关闭"
 # "HTML start tag prematurely ended, expected attribute name or '>'"
 HB396911AC86C: "HTML开始标签提前结束，期望属性名或'>'"
 # "HTML tag '%0' requires an end tag"
-HC3A525011E51: "HTML标签'%0'需要结束标签"
+HC3A525011E51: "HTML标签 '%0' 需要结束标签"
 # 'HTML tag started here'
 H3CB5C9051AF3: 'HTML标签从这里开始'
 # 'HWASan shadow mapping dynamic offset location'
@@ -9315,7 +9315,7 @@ H9EF1510D3F11: '为可能存在负载值注入（LVI）漏洞的内联汇编代�
 # 'Harden interprocedurally by passing our state in and out of functions in the high bits of the stack pointer.'
 HD67DA497275B: '通过在函数调用时将状态存储在栈指针高位字节中，实现过程间强化，以缓解推测性存储攻击。该设计旨在抵御Spectre v1.2类型的攻击。'
 # 'Harden the value loaded *after* it is loaded by flushing the loaded bits to 1. This is hard to do in general but can be done easily for GPRs.'
-HC7A0E024F604: '在加载后通过将加载的位刷新为1来强化该值。一般来说这很难实现，但对于通用寄存器（GPRs）来说很容易做到。'
+HC7A0E024F604: '在加载后通过将加载的位刷新为 1 来强化该值。一般来说这很难实现，但对于通用寄存器（GPRs）来说很容易做到。'
 # 'Hardware Loop Insertion'
 HD9C10B054698: '硬件循环插入'
 # 'Hardware multiplier use mode for MSP430'
@@ -9451,7 +9451,7 @@ HD50D41502699: 'cgscc内联重放文件的格式'
 # "How cgscc inline replay treats sites that don't come from the replay. Original: defers to original advisor, AlwaysInline: inline all sites not in replay, NeverInline: inline no sites not in replay"
 H6F8523C009E8: 'cgscc内联重放如何处理来自重放的调用点以外的站点。Original：遵循原始建议器，AlwaysInline：内联所有不在重放中的站点，NeverInline：不内联任何不在重放中的站点'
 # "How many functions in a module could be used for MergeFunctions to pass a basic correctness check. '0' disables this check. Works only with '-debug' key."
-H65C2FF1A291C: "在模块中可用于MergeFunctions通过基本正确性检查的函数数量。'0'禁用此检查。仅与'-debug'键一起使用"
+H65C2FF1A291C: "在模块中可用于MergeFunctions通过基本正确性检查的函数数量。'0' 禁用此检查。仅与'-debug'键一起使用"
 # 'How many idle instructions we would like before certain undef register reads'
 HAF5EEC679340: '在某些未定义寄存器读取之前希望有多少空闲指令'
 # 'How many kernel arguments to preload onto SGPRs'
@@ -9485,13 +9485,13 @@ H9ADEB68395C9: '在处理输入前需要注册的IRDL文件'
 # 'IRTranslator LLVM IR -> MI'
 HA8BDC735DCBC: 'IRTranslator LLVM IR -> 机器指令'
 # 'ISO C does not allow indirection on operand of type %0'
-HC4C25916B558: 'ISO C不允许对类型%0的操作数进行间接访问'
+HC4C25916B558: 'ISO C不允许对类型 %0 的操作数进行间接访问'
 # "ISO C does not support '~' for complex conjugation of %0"
-H592FB210723A: "ISO C不支持使用'~'对%0进行复数共轭"
+H592FB210723A: "ISO C不支持使用'~'对 %0 进行复数共轭"
 # "ISO C forbids forward references to 'enum' types"
-H3A2E43246AF1: "ISO C禁止向前引用'enum'类型"
+H3A2E43246AF1: "ISO C禁止向前引用 'enum' 类型"
 # "ISO C forbids taking the address of an expression of type 'void'"
-H5DC6DC421D10: "ISO C不允许为类型'void'的表达式取地址"
+H5DC6DC421D10: "ISO C不允许为类型 'void' 的表达式取地址"
 # "ISO C requires a named parameter before '...'"
 HAAD7320B82D0: 'ISO C要求在"..."之前有一个命名参数'
 # 'ISO C requires a translation unit to contain at least one declaration'
@@ -9501,11 +9501,11 @@ H51664244F36F: 'ISO C++认为此析构函数名查找存在歧义'
 # 'ISO C++ does not allow %select{an attribute list|%0}1 to appear here'
 H6EEF885F4392: 'ISO C++不允许在此处出现%select{属性列表|%0}1'
 # 'ISO C++ does not allow %select{const_cast|static_cast|reinterpret_cast|dynamic_cast|C-style cast|functional-style cast|}0 from %1 to %2 because it casts away qualifiers, even though the source and destination types are unrelated'
-HA24736A782D5: 'ISO C++不允许在此处使用%select{const_cast|static_cast|reinterpret_cast|dynamic_cast|C-style cast|functional-style cast|}0从%1到%2进行转换，因为该转换会丢弃限定符，即使源类型和目标类型无关'
+HA24736A782D5: 'ISO C++不允许在此处使用%select{const_cast|static_cast|reinterpret_cast|dynamic_cast|C-style cast|functional-style cast|}0从 %1 到 %2 进行转换，因为该转换会丢弃限定符，即使源类型和目标类型无关'
 # "ISO C++ does not permit the 'bool' keyword after 'concept'"
-HED15AAEA01CD: "ISO C++禁止在'concept'之后使用'bool'关键字"
+HED15AAEA01CD: "ISO C++禁止在 'concept' 之后使用 'bool' 关键字"
 # "ISO C++ forbids forward references to 'enum' types"
-H565E6A76B7E7: "ISO C++禁止向前引用'enum'类型"
+H565E6A76B7E7: "ISO C++禁止向前引用 'enum' 类型"
 # "ISO C++ only allows ':' in member enumeration declaration to introduce a fixed underlying type, not an anonymous bit-field"
 HD765E30339DE: "ISO C++仅允许在成员枚举声明中使用':'来引入固定的基础类型，而不是匿名位字段"
 # 'ISO C++ requires a definition in this translation unit for %select{function|variable}0 %q1 because its type does not have linkage'
@@ -9515,13 +9515,13 @@ HF7272CADD93F: 'ISO C++ 要求字段设计符按声明顺序指定；字段 %1 �
 # "ISO C++ requires the name after '::~' to be found in the same scope as the name before '::~'"
 H1B12535D9EA0: "ISO C++ 要求'::~'之后的名称与'::~'之前的名称处于同一作用域"
 # "ISO C++ specifies that qualified reference to %0 is a constructor name rather than a %select{template name|type}1 in this context, despite preceding %select{'typename'|'template'}2 keyword"
-H0AEAB31369D3: "ISO C++ 规定在此上下文中，对%0的限定引用是一个构造函数名称而非%select{模板名称|类型}1，尽管前面有%select{'typename'|'template'}2关键字"
+H0AEAB31369D3: "ISO C++ 规定在此上下文中，对 %0 的限定引用是一个构造函数名称而非%select{模板名称|类型}1，尽管前面有%select{'typename'|'template'}2关键字"
 # 'ISO C++ standards before C++17 do not allow new expression for type %0 to use list-initialization'
-H36A45BAF91C7: 'ISO C++17之前的版本不允许类型%0的new表达式使用列表初始化'
+H36A45BAF91C7: 'ISO C++17之前的版本不允许类型 %0 的new表达式使用列表初始化'
 # 'ISO C++11 does not allow access declarations; use using declarations instead'
 H949947FDD999: 'ISO C++11 不允许使用访问声明；请改用using声明'
 # 'ISO C++11 does not allow conversion from string literal to %0'
-HDCEA926F7FF8: 'ISO C++11 不允许将字符串字面量转换为%0'
+HDCEA926F7FF8: 'ISO C++11 不允许将字符串字面量转换为 %0'
 # 'ISO C++11 requires a parenthesized pack declaration to have a name'
 H70DD46DED2FB: 'ISO C++11 要求括号化的打包声明必须具有名称'
 # "ISO C++17 does not allow 'register' storage class specifier"
@@ -9533,9 +9533,9 @@ HDA1158B635F1: 'ISO C++17 不允许使用动态异常规格说明'
 # 'ISO C++17 does not allow incrementing expression of type bool'
 H8CE1E8E6EA54: 'ISO C++17 不允许对bool类型的表达式进行递增操作'
 # "ISO C++20 considers use of overloaded operator '%0' (with operand types %1 and %2) to be ambiguous despite there being a unique best viable function%select{ with non-reversed arguments|}3"
-HE2B331A9C128: 'ISO C++20 认为此处使用重载的运算符"%0"（操作数类型为%1和%2）存在歧义，尽管存在一个具有非反转参数的唯一最佳可行函数%select{ |}3'
+HE2B331A9C128: 'ISO C++20 认为此处使用重载的运算符 "%0"（操作数类型为 %1 和 %2）存在歧义，尽管存在一个具有非反转参数的唯一最佳可行函数%select{ |}3'
 # "ISO C++20 requires return type of selected 'operator==' function for rewritten '%1' comparison to be 'bool', not %0"
-H96DD21560E53: 'ISO C++20 要求重写后的"%1"比较所选的"operator=="函数的返回类型应为"bool"，而非%0'
+H96DD21560E53: 'ISO C++20 要求重写后的 "%1" 比较所选的"operator=="函数的返回类型应为"bool"，而非 %0'
 # 'ISO C90 does not allow subscripting non-lvalue array'
 HB75A7925DCA5: 'ISO C90 不允许对非常量左值数组进行下标访问'
 # 'ISO C99 requires whitespace after the macro name'
@@ -9583,7 +9583,7 @@ H11412975A779: '如果设置此选项，则不实际进行格式修改'
 # "If set, don't error out on the specified warning type."
 H94EED0D743F6: '如果设置此选项，则不对指定的警告类型报错'
 # 'If set, fail with exit code 1 on incomplete format.'
-H3940587B501D: '如果设置此选项，则在格式不完整时退出并返回代码1'
+H3940587B501D: '如果设置此选项，则在格式不完整时退出并返回代码 1'
 # 'If set, overrides the include sorting behavior\ndetermined by the SortIncludes style flag'
 HA0F9A020C51D: '如果设置此选项，则覆盖由SortIncludes风格标志确定的包含排序行为'
 # 'If set, overrides the qualifier alignment style\ndetermined by the QualifierAlignment style flag'
@@ -9607,9 +9607,9 @@ HDF4D3E04985A: '如果配置文件密度低于给定阈值，则建议提高采�
 # 'If the runtime tripcount for the loop is lower than the threshold, the loop is considered as flat and will be less aggressively unrolled.'
 HAC4BCB57FDE7: '如果循环的运行时迭代次数低于阈值，则认为该循环为平坦循环，并减少其展开的激进程度'
 # 'If the sample profile is accurate, we will mark all un-sampled branches and calls as having 0 samples. Otherwise, treat them conservatively as unknown. '
-H815D8C5F471D: '如果采样配置文件准确，则将所有未采样的分支和调用标记为0样本。否则，将其保守处理为未知'
+H815D8C5F471D: '如果采样配置文件准确，则将所有未采样的分支和调用标记为 0 样本。否则，将其保守处理为未知'
 # 'If the sample profile is accurate, we will mark all un-sampled callsite and function as having 0 samples. Otherwise, treat un-sampled callsites and functions conservatively as unknown. '
-H196C3B85DE70: '如果采样配置文件准确，则将所有未采样的调用点和函数标记为0样本。否则，将未采样的调用点和函数保守处理为未知'
+H196C3B85DE70: '如果采样配置文件准确，则将所有未采样的调用点和函数标记为 0 样本。否则，将未采样的调用点和函数保守处理为未知'
 # "If the size of a function is smaller than the threshold, assume it can be inlined by PGO early inliner and it won't be adjusted based on sample profile."
 HE6D98DD47634: '如果函数大小小于阈值，则假设其可被PGO早期内联优化处理，且不会根据采样配置文件进行调整'
 # 'If the total count of context profile is smaller than the threshold, it will be merged into context-less base profile.'
@@ -9723,15 +9723,15 @@ H4B98027DD134: '在Lint pass中遇到错误时终止。'
 # 'In the OpenMP data clauses treat `a(N)` as `a(N:N)`.'
 H1CA9E31B3F5D: '在OpenMP数据子句中将`a(N)`视为`a(N:N)`。'
 # 'In the dump requested by -dump-input, print <N> input lines\nbefore and <N> input lines after any lines specified by\n-dump-input-filter.  When there are multiple occurrences of\nthis option, the largest specified <N> has precedence.  The\ndefault is 5.\n'
-HEB48ED43B50E: '在由-dump-input请求的转储中，打印指定行之前和之后各<N>行输入行。如果该选项出现多次，则最大的<N>值优先。默认值为5。\n'
+HEB48ED43B50E: '在由-dump-input请求的转储中，打印指定行之前和之后各 <N> 行输入行。如果该选项出现多次，则最大的 <N> 值优先。默认值为 5。\n'
 # "In the dump requested by -dump-input, print only input lines of\nkind <value> plus any context specified by -dump-input-context.\nWhen there are multiple occurrences of this option, the <value>\nthat appears earliest in the list below has precedence.  The\ndefault is 'error' when -dump-input=fail, and it's 'all' when\n-dump-input=always.\n"
-H9104E1DEC417: '仅打印类型为<value>的输入行以及由-dump-input-context指定的上下文。如果该选项出现多次，则列表中出现最早的<value>值优先。当-dump-input=fail时，默认值为"error"；当-dump-input=always时，默认值为"all"。\n'
+H9104E1DEC417: '仅打印类型为 <value> 的输入行以及由-dump-input-context指定的上下文。如果该选项出现多次，则列表中出现最早的 <value> 值优先。当-dump-input=fail时，默认值为"error"；当-dump-input=always时，默认值为"all"。\n'
 # 'In the report, sort the timers in each group in wall clock time order'
 H2F13A69F022D: '在报告中，按各组中的实时时钟时间对计时器进行排序'
 # 'Include BLOCKINFO details in low level dump'
 H27C5E3DE841C: '在低级转储中包含BLOCKINFO详细信息'
 # "Include PTX for the following GPU architecture (e.g. sm_35) or 'all'. May be specified more than once."
-H2031AC36E8FB: "包含以下GPU架构（例如sm_35）的PTX，或'all'。可以多次指定该选项。"
+H2031AC36E8FB: "包含以下GPU架构（例如sm_35）的PTX，或 'all'。可以多次指定该选项。"
 # 'Include Parameters in templates.'
 H8654E7CEAC51: '在模板中包含参数。'
 # 'Include all attributes.'
@@ -9839,17 +9839,17 @@ H228DE039DDE2: '对always_inline函数的内联处理程序'
 # 'Inner loop block size threshold to analyze in unroll for AMDGPU'
 H2139A958B6DF: 'AMDGPU在展开时分析内部循环块大小的阈值'
 # 'Inplace edit <file>s'
-H1E18B41D725B: '原地编辑<file>文件'
+H1E18B41D725B: '原地编辑 <file> 文件'
 # 'Inplace edit <file>s, if specified.'
-H469713E2DE1D: '如果指定了，则原地编辑<file>文件'
+H469713E2DE1D: '如果指定了，则原地编辑 <file> 文件'
 # 'Input JSON stream encoding'
 HDA67A1195E8E: '输入JSON流编码'
 # 'Input file. Can be specified multiple times for multiple input files.'
 H5D0C7337A0AA: '输入文件。可以多次指定以指定多个输入文件'
 # "Input file. The format is an array of contexts.\nEach context is a dictionary with the following keys:\n'Guid', mandatory. The value is a 64-bit integer.\n'Counters', mandatory. An array of 32-bit ints. These are the counter values.\n'Contexts', optional. An array containing arrays of contexts. The context array at a position 'i' is the set of callees at that callsite index. Use an empty array to indicate no callees."
-H53610FB0F715: "输入文件。格式是一个上下文数组。\n每个上下文是一个包含以下键的字典：\n'Guid'，必填。值为64位整数。\n'Counters'，必填。一个32位整数数组。这些是计数器值。\n'Contexts'，可选。包含上下文数组的数组。位置'i'的上下文数组是该调用站点索引处的被调用者集合。使用空数组表示无被调用者。"
+H53610FB0F715: "输入文件。格式是一个上下文数组。\n每个上下文是一个包含以下键的字典：\n'Guid'，必填。值为 64 位整数。\n'Counters'，必填。一个 32 位整数数组。这些是计数器值。\n'Contexts'，可选。包含上下文数组的数组。位置 'i' 的上下文数组是该调用站点索引处的被调用者集合。使用空数组表示无被调用者。"
 # "Input language ('ir' or 'mir')"
-HAAA3662FD097: "输入语言（'ir'或'mir'）"
+HAAA3662FD097: "输入语言（'ir' 或 'mir'）"
 # 'Input lines with annotations'
 H7B5B0A60C876: '带有注解的输入行'
 # 'Input lines with starting points of annotations'
@@ -10167,7 +10167,7 @@ H7F636BA87B45: '词法作用域级别（文件=0，编译单元=1）。'
 # 'Libraries to link dynamically'
 H9E0097DC803F: '动态链接的库'
 # "Like 'ExecutorNative' if ORC runtime provided, otherwise like 'GenericIR'"
-H4792AD158E44: "如果提供了Orc运行时则类似于'ExecutorNative'，否则类似于'GenericIR'"
+H4792AD158E44: "如果提供了Orc运行时则类似于 'ExecutorNative'，否则类似于 'GenericIR'"
 # 'Like -MD, but also implies -E and writes to stdout by default'
 H09E4A86636C3: '类似于 -MD，但同时也隐含 -E 并默认写入 stdout'
 # 'Like -MMD, but also implies -E and writes to stdout by default'
@@ -10233,7 +10233,7 @@ HEAF5A10A6293: '限制每个块的SLP调度区域大小'
 # 'Limit the size of the seed bundle to cap compilation time.'
 H4DFB40A73CC1: '限制种子包的大小以控制编译时间。'
 # 'Limits the range of tokens in -check file on which various features are tested. Example --check-lines=3-7 restricts testing to lines 3 to 7 (inclusive) or --check-lines=5 to restrict to one line. Default is testing entire file.'
-H2A6188976AA0: '限制-check文件中测试各项功能的行范围。示例：--check-lines=3-7 将测试限制在3到7行（含），或--check-lines=5 限制为单行。默认测试整个文件。'
+H2A6188976AA0: '限制-check文件中测试各项功能的行范围。示例：--check-lines=3-7 将测试限制在 3 到 7行（含），或--check-lines=5 限制为单行。默认测试整个文件。'
 # 'Linalg ODS Gen from YAML'
 H78D204B7569D: 'Linalg ODS Gen from YAML'
 # 'Line kind to use when printing lines.'
@@ -10317,7 +10317,7 @@ HDDDE0A8181A8: '活跃变量分析'
 # 'Load MIR Sample Profile'
 HE68192F483EE: '加载MIR样本配置文件'
 # 'Load a pch file and use it instead of all code up to and including <filename>'
-H2B4B69D546AF: '加载预编译头文件并用它替代所有代码（直至并包含<filename>）'
+H2B4B69D546AF: '加载预编译头文件并用它替代所有代码（直至并包含 <filename>）'
 # 'Load all members of static archives'
 H37DC6D24F9AF: '加载静态库中的所有成员'
 # 'Load all members of static archives that implement Objective-C classes or categories, or Swift structs, classes or extensions'
@@ -10621,7 +10621,7 @@ H346589ED29E7: '将x8寄存器设为调用保存寄存器（仅限AArch64）'
 # 'Make the x9 register call-saved (AArch64 only)'
 H2A86BF8B5845: '将x9寄存器设为调用保存寄存器（仅限AArch64）'
 # 'Make time trace capture verbose event details (e.g. source filenames). This can increase the size of the output by 2-3 times'
-HAFFB278A14B8: '启用时间追踪捕获的详细事件信息（例如源文件名）。这可能会使输出体积增大2-3倍'
+HAFFB278A14B8: '启用时间追踪捕获的详细事件信息（例如源文件名）。这可能会使输出体积增大 2-3倍'
 # 'Mangling number exceeds limit (65535)'
 HB23269E224B2: '编码的数字超过限制（65535）'
 # 'Manifest Attributor internal string attributes.'
@@ -10785,7 +10785,7 @@ H85D97309D239: '内联成本使用的alloca最大尺寸'
 # 'Maximum allowed iterations to unroll under pragma unroll full.'
 H369A26E92574: '在#pragma unroll full指令下允许展开的最大迭代次数。'
 # 'Maximum amount of memory to use. 0 disables check. Defaults to 400MB (800MB under valgrind, 0 with sanitizers).'
-HD9F29E050069: '允许使用的最大内存容量。0表示禁用检查。默认为400MB（在valgrind下为800MB，使用sanitizers时为0）。'
+HD9F29E050069: '允许使用的最大内存容量。0表示禁用检查。默认为 400MB（在valgrind下为 800MB，使用sanitizers时为 0）。'
 # 'Maximum amount of nodes to process while searching SCEVUnknown Phi strongly connected components'
 H733D2DA20417: '在搜索SCEVUnknown Phi强连通分量时处理节点的最大数量'
 # 'Maximum amount of shared memory to use.'
@@ -10877,7 +10877,7 @@ H9FAF3F7149E1: '启用分支漏斗的每个调用点允许的最大调用目标�
 # 'Maximum number of conditions in MC/DC coverage'
 H6395D2BBFABE: 'MC/DC覆盖率中条件的最大数量'
 # 'Maximum number of cycles in the timeline view, or 0 for unlimited. Defaults to 80 cycles'
-H17E412044F75: '时间线视图中的最大周期数或0表示无限制，默认80周期'
+H17E412044F75: '时间线视图中的最大周期数或 0 表示无限制，默认 80 周期'
 # 'Maximum number of dataflow edges to traverse when evaluating the benefit of commuting operands'
 H635DA15AA164: '评估交换操作数收益时遍历的数据流边最大数量'
 # 'Maximum number of dependences collected by loop-access analysis (default = 100)'
@@ -10915,7 +10915,7 @@ HB7E5E43FBE1D: '优化器跟踪的指针状态最大数量'
 # 'Maximum number of replacements'
 H6F2E3DB8E40F: '替换的最大数量'
 # "Maximum number of results to stream as a response to single request. Limit is to keep the server from being DOS'd. Defaults to 10000."
-H8CFDD20881AA: '单个请求响应中流式传输的结果最大数量。限制是为了防止服务器遭受DOS攻击。默认值为10000。'
+H8CFDD20881AA: '单个请求响应中流式传输的结果最大数量。限制是为了防止服务器遭受DOS攻击。默认值为 10000。'
 # 'Maximum number of rows to keep in constraint system'
 H99BCC72F0CE0: '约束系统中保留的行数最大值'
 # 'Maximum number of simplification steps in HLIR'
@@ -10927,9 +10927,9 @@ HAFD4B8816F42: 'MC/DC覆盖率中测试向量的最大数量'
 # 'Maximum number of threads (for emulation thread-local storage)'
 H0870E5A4F08E: '最大线程数（用于模拟线程局部存储）'
 # 'Maximum number of threads to use to process chunks. Set to 1 to disable parallelism.'
-H35B2504140C1: '用于处理块的最大线程数。设置为1可禁用并行处理。'
+H35B2504140C1: '用于处理块的最大线程数。设置为 1 可禁用并行处理。'
 # 'Maximum number of times to run the full set of delta passes (default=5)'
-H2DC8A9AE4C6B: '运行完整delta passes集的次数最大值（默认为5）'
+H2DC8A9AE4C6B: '运行完整delta passes集的次数最大值（默认为 5）'
 # 'Maximum number of undroppable users for instruction sinking'
 H51772496A3DD: '指令下沈（instruction sinking）不可删除用户的最大数量'
 # 'Maximum number phis to handle in intptr/ptrint folding'
@@ -10941,7 +10941,7 @@ HE99B191AFFD1: '可执行的优化级别最大值'
 # 'Maximum predecessors (maximum successors at the same time) to consider tail duplicating blocks.'
 HEA56889501D6: '考虑尾部复制块的最大前驱（同时考虑的最大后继）数量'
 # 'Maximum recursion depth when finding forked SCEVs (default = 5)'
-H0BFBD51E5518: '查找分支SCEV时的最大递归深度（默认值为5）'
+H0BFBD51E5518: '查找分支SCEV时的最大递归深度（默认值为 5）'
 # 'Maximum recursion level'
 HE3B9BD0F99EA: '最大递归层级'
 # 'Maximum search distance for definition of CR bit spill on ppc'
@@ -10965,11 +10965,11 @@ H43B65927F125: '考虑尾部复制块时的最大后继（同时的最大前驱�
 # 'Maximum throughput from the decoders (instructions per cycle)'
 H7563F8838724: '解码器的吞吐量（每周期指令数）的最大值'
 # 'Maximum time a channel may stay idle until server closes the connection, in seconds. Defaults to 480.'
-HAA88BB6FEBEE: '通道在服务器关闭连接前保持空闲的最大时间（秒）。默认为480'
+HAA88BB6FEBEE: '通道在服务器关闭连接前保持空闲的最大时间（秒）。默认为 480'
 # 'Maximum users to visit in copy from constant transform'
 H0BCD40F173F6: '常量转换中访问的最大用户数'
 # 'Maximum vector size (in 32b registers) to use when promoting alloca'
-HBBF17E62FD6E: '在提升alloca时使用的向量大小（以32位寄存器为单位）的最大值'
+HBBF17E62FD6E: '在提升alloca时使用的向量大小（以 32 位寄存器为单位）的最大值'
 # 'May have atomic operations on fine-grained memory'
 HADF7ECC58A34: '可能在细粒度内存上执行原子操作'
 # 'May have atomic operations on remote memory'
@@ -11009,7 +11009,7 @@ H647C9F0ED977: '如果采样配置文件加载器决定不内联调用站点，�
 # 'Merge the given AST file into the translation unit being compiled.'
 H044732F67319: '将给定的AST文件合并到正在编译的翻译单元中'
 # "Method to generate ID's for compilation units for single source offloading languages CUDA and HIP: 'hash' (ID's generated by hashing file path and command line options) | 'random' (ID's generated as random numbers) | 'none' (disabled). Default is 'hash'. This option will be overridden by option '-cuid=[ID]' if it is specified."
-HF56CB8DC51CB: "为CUDA和HIP单源offloading语言的编译单元生成ID的方法：'hash'（通过哈希文件路径和命令行选项生成ID） | 'random'（通过随机数生成ID） | 'none'（禁用）。默认是'hash'。如果指定了选项'-cuid=[ID]'，此选项将被覆盖。"
+HF56CB8DC51CB: "为CUDA和HIP单源offloading语言的编译单元生成ID的方法：'hash'（通过哈希文件路径和命令行选项生成ID） | 'random'（通过随机数生成ID） | 'none'（禁用）。默认是 'hash'。如果指定了选项'-cuid=[ID]'，此选项将被覆盖。"
 # 'MicroMips instruction size reduce pass'
 H43AA98943979: 'MicroMips指令大小缩减pass'
 # "Microsoft compiler version number to report in _MSC_VER (0 = don't define it (default))"
@@ -11037,7 +11037,7 @@ H4CF75EEC17A9: '最小化转换方言驱动程序\n'
 # 'Minimal common base load/store instructions triggering DS/DQ form preparation'
 H0EEF17599CF6: '触发DS/DQ形式准备的最小公共基数加载/存储指令数量'
 # 'Minimal common base load/store instructions triggering chain commoning preparation. Must be not smaller than 4'
-H8810625AE483: '触发链式公共化准备的最小公共基数加载/存储指令数量。必须不小于4'
+H8810625AE483: '触发链式公共化准备的最小公共基数加载/存储指令数量。必须不小于 4'
 # 'Minimize AVX to SSE transition penalty'
 H8DBDD3BC94CA: '最小化AVX到SSE转换的惩罚'
 # 'Minimize number of registers used'
@@ -11075,7 +11075,7 @@ H05750FA1DE8F: '输出优化备注所需的最小配置文件计数。使用"aut
 # 'Minimum ratio comparing relative sizes of each outline candidate and original function'
 H4C5E36FE2F68: '比较每个外联候选和原始函数相对大小的最小比率'
 # 'Minimum relative gain per loop threshold (1/X). Defaults to 12.5%'
-H2DECB545864A: '每个循环的最小相对收益阈值（1/X）。默认为12.5%'
+H2DECB545864A: '每个循环的最小相对收益阈值（1/X）。默认为 12.5%'
 # 'Minimum time granularity (in microseconds) traced by time profiler'
 H82ABB54FDFA0: '时间分析器跟踪的最小时间粒度（以微秒为单位）'
 # 'Minimum type size in bits for breaking large PHI nodes'
@@ -11137,7 +11137,7 @@ HEC0DF6B1AD3C: '必须至少指定 '
 # 'My Pass Name'
 H68A400666676: 'My Pass Name'
 # 'N must be a power of two. Align loops to the boundary'
-H2A7AB317ED00: 'N必须是2的幂次方。将循环对齐到边界'
+H2A7AB317ED00: 'N必须是 2 的幂次方。将循环对齐到边界'
 # 'NVPTX Address space based Alias Analysis'
 H9D1213E22820: 'NVPTX基于地址空间的别名分析'
 # 'NVPTX Address space based Alias Analysis Wrapper'
@@ -11157,7 +11157,7 @@ HDAF968D22832: 'NVPTX 特定：禁用生成f16 math ops。'
 # "NVPTX Specific: FMA contraction (0: don't do it 1: do it  2: do it aggressively"
 HD36FDD8676CA: 'NVPTX 专用：FMA 收缩（0：不执行 1：执行 2：激进执行'
 # 'NVPTX Specific: force 4-byte minimal alignment for byval params of device functions.'
-H40664A3C3B0F: 'NVPTX 特定：强制设备函数的byval参数使用4字节最小对齐。'
+H40664A3C3B0F: 'NVPTX 特定：强制设备函数的byval参数使用 4 字节最小对齐。'
 # 'NVPTX Specific: schedule for register pressue'
 H0940771EECAF: 'NVPTX 特定：根据寄存器压力进行调度'
 # 'NVPTX Specific: whether to use lg2.approx for log2'
@@ -11201,7 +11201,7 @@ HAC5287C54D8E: 'N元重新关联'
 # 'Natural Loop Information'
 HB731CE00868C: '自然循环信息'
 # 'Neon vector size must be 64 or 128 bits'
-H97DBFE49CD6B: 'NEON向量大小必须为64或128位'
+H97DBFE49CD6B: 'NEON向量大小必须为 64 或 128位'
 # 'Nested profile, the input should be CS flat profile'
 HA55917D514EC: '嵌套配置文件，输入应为CS平面配置文件'
 # 'Never'
@@ -11243,7 +11243,7 @@ H24AE7DC3B6A4: '无析构函数'
 # 'No effect'
 H7ED12CB7B709: '无效果'
 # 'No extract instruction with offset 0'
-HEB2933468549: '没有偏移量为0的提取指令'
+HEB2933468549: '没有偏移量为 0 的提取指令'
 # 'No implicit externals allowed'
 H6CDA41F7B635: '不允许隐式外部符号'
 # 'No implicit typing allowed unless overridden by IMPLICIT statements'
@@ -11267,7 +11267,7 @@ H9A9707BE07DA: '无。'
 # 'Normalize integers in CFI indirect call type signature checks'
 H47F05B50721C: '在CFI间接调用类型签名检查中标准化整数'
 # "Not emit the visibility attribute for asm in AIX OS or give all symbols 'unspecified' visibility in XCOFF object file"
-H98251062C447: "不在AIX操作系统中的asm中生成可见性属性，或在XCOFF对象文件中为所有符号赋予'unspecified'可见性"
+H98251062C447: "不在AIX操作系统中的asm中生成可见性属性，或在XCOFF对象文件中为所有符号赋予 'unspecified' 可见性"
 # 'Number limit for gluing ld/st of memcpy.'
 HD8077326B9B0: 'memcpy合并ld/st的数量限制'
 # 'Number of addresses from which to enable MIMG NSA.'
@@ -11275,11 +11275,11 @@ HCE8A8E1997D3: '启用MIMG NSA的地址数量'
 # 'Number of backend threads'
 HE56514D09150: '后端线程数量'
 # "Number of blocks in the 'x' dimension"
-H76CD51A21746: "'x'维度中的块数量"
+H76CD51A21746: "'x' 维度中的块数量"
 # "Number of blocks in the 'y' dimension"
-H6D16D2BE9F69: "'y'维度中的块数量"
+H6D16D2BE9F69: "'y' 维度中的块数量"
 # "Number of blocks in the 'z' dimension"
-H2E857E7750A0: "'z'维度中的块数量"
+H2E857E7750A0: "'z' 维度中的块数量"
 # 'Number of compile threads'
 H083DE0C34AB1: '编译线程数'
 # 'Number of cycles to assume for a call instruction'
@@ -11309,13 +11309,13 @@ HEC293753B227: '用于并行全LTO代码生成的分区数，仅适用于ld.lld�
 # 'Number of registers to limit to when printing regmask operands in IR dumps. unlimited = -1'
 H0373C047E939: '限制为的寄存器数量（在IR转储中打印寄存器掩码操作数时使用）。-1 表示无限制'
 # 'Number of seconds program is allowed to run before it is killed (default is 300s), 0 disables timeout'
-HE6EB2161F536: '程序允许运行的时间（默认300秒），0表示禁用超时'
+HE6EB2161F536: '程序允许运行的时间（默认 300 秒），0表示禁用超时'
 # "Number of threads in the 'x' dimension"
-H07DD57A90CC5: "'x'维度中的线程数"
+H07DD57A90CC5: "'x' 维度中的线程数"
 # "Number of threads in the 'y' dimension"
-H986B3D9F34E9: "'y'维度中的线程数"
+H986B3D9F34E9: "'y' 维度中的线程数"
 # "Number of threads in the 'z' dimension"
-HFC9646CFE097: "'z'维度中的线程数"
+HFC9646CFE097: "'z' 维度中的线程数"
 # 'Number of threads to use (0 = auto)'
 H9A06154F2AD2: '使用的线程数（0 = 自动检测）'
 # 'Number of times to divide chunks prior to first test'
@@ -11327,13 +11327,13 @@ HEBDA566F30F3: '打乱和验证使用列表的次数'
 # 'Number of tracked SGPRs before initiating hazard cull on memory wait'
 H34DB613CB239: '在内存等待启动危险消除前跟踪的SGPR数量'
 # "Number of triangle-shaped-CFG's that need to be in a row for the triangle tail duplication heuristic to kick in. 0 to disable."
-HAF152F5B6E3F: '需要连续出现的三角形控制流图（CFG）的数量，以便触发三角尾部复制启发式算法。输入0以禁用。'
+HAF152F5B6E3F: '需要连续出现的三角形控制流图（CFG）的数量，以便触发三角尾部复制启发式算法。输入 0 以禁用。'
 # 'Number of unswitch candidates that are ignored when calculating cost multiplier.'
 H4873CA41A98E: '计算成本乘数时忽略的unswitch候选数量'
 # 'Number of uses of a base pointer to check before it is no longer considered for post-indexing.'
 H02421600E168: '检查基址指针的使用次数阈值，超过后不再考虑后索引优化'
 # 'OBJECT_MODE setting %0 is not recognized and is not a valid setting'
-HEC8A063EC23B: 'OBJECT_MODE设置%0无法识别，且不是有效设置'
+HEC8A063EC23B: 'OBJECT_MODE设置 %0 无法识别，且不是有效设置'
 # 'ODS output filename'
 H1E3A5BE01485: 'ODS输出文件名'
 # 'OPTIONS:\n'
@@ -11351,21 +11351,21 @@ HBE7743C7A3D5: 'Objective-C声明只能出现在全局作用域中'
 # 'Objective-C dispatch method to use'
 H71CD5643C8D8: '要使用的Objective-C调度方法'
 # 'Objective-C index expression has incomplete class type %0'
-H3BF9CC2B38D9: 'Objective-C索引表达式具有不完整类类型%0'
+H3BF9CC2B38D9: 'Objective-C索引表达式具有不完整类类型 %0'
 # 'Objective-C message has incomplete result type %0'
-HA58AB6CD0922: 'Objective-C消息具有不完整的结果类型%0'
+HA58AB6CD0922: 'Objective-C消息具有不完整的结果类型 %0'
 # 'Objective-C methods as coroutines are not yet supported'
 H197AF4BB9670: 'Objective-C方法作为协程尚未得到支持'
 # 'Objective-C object of type %0 is bridged to %1, which is not valid CF object'
-HC21532E95928: '类型%0的Objective-C对象被桥接到无效的CF对象%1'
+HC21532E95928: '类型 %0 的Objective-C对象被桥接到无效的CF对象 %1'
 # 'Objective-C++ Automatic Reference Counting standard library kind'
 HBD2739B5128E: 'Objective-C++自动引用计数标准库类型'
 # 'Offloading entry for declare target variable %0 is incorrect: the address is invalid.'
-H44B1C3BF0A67: '声明目标变量%0的卸载条目不正确：地址无效。'
+H44B1C3BF0A67: '声明目标变量 %0 的卸载条目不正确：地址无效。'
 # 'Offloading entry for declare target variable is incorrect: the address is invalid.'
 H3668F9F00CF1: '声明目标变量的卸载条目不正确：地址无效。'
 # 'Offloading entry for target region in %0 is incorrect: either the address or the ID is invalid.'
-HB922AD26B2CB: '在%0中的目标区域卸载条目不正确：地址或ID无效。'
+HB922AD26B2CB: '在 %0 中的目标区域卸载条目不正确：地址或ID无效。'
 # 'Offset element to print.'
 HCA7A2283660F: '要打印的偏移元素'
 # 'Offsets are in UTF-16 code units'
@@ -11473,7 +11473,7 @@ H8C18E65FDB94: '仅包含与指定正则表达式匹配的passes到生成的优�
 # 'Only inline functions explicitly or implicitly marked inline'
 H4FB05EC4AB48: '仅内联显式或隐式标记为inline的函数'
 # 'Only instrument 1 of N groups'
-HE6DD6434319A: '仅插桩1组中的N组'
+HE6DD6434319A: '仅插桩 1 组中的N组'
 # 'Only keep the intrinsics with the specified substring in their record name'
 HCC2CC4639600: '仅保留记录名称中包含指定子字符串的固有函数'
 # 'Only lfence before groups of terminators where at least one branch instruction has an input to the addressing mode that is a register other than %rip.'
@@ -11535,7 +11535,7 @@ H159246FC6C6B: '仅拆分大小小于或等于JumpTableSizeThreshold的jump tabl
 # 'Only supported on AArch64, PowerPC, RISC-V, SPARC, SystemZ, and X86'
 H6BC9222A7886: '仅支持AArch64、PowerPC、RISC-V、SPARC、SystemZ和X86'
 # 'Only try to inject loop invariant conditions and unswitch on them to eliminate branches that are not-taken 1/<this option> times or less.'
-H93BBEDA4C81E: '仅尝试注入循环不变条件并在其上进行反变换以消除那些未被采取的次数少于或等于1/此选项值的分支。'
+H93BBEDA4C81E: '仅尝试注入循环不变条件并在其上进行反变换以消除那些未被采取的次数少于或等于 1/此选项值的分支。'
 # 'Only use DAG-combiner alias analysis in this function'
 H9A1CF1A6CF3A: '在此函数中仅使用DAG-combiner别名分析'
 # 'Only use warnings from specified component'
@@ -11555,23 +11555,23 @@ H89C2A6721B4D: '仅当输出有变化时才写入输出'
 # 'Only write to the output file if it changed'
 H82DD0380BC4C: '仅在内容有变化时写入输出文件'
 # "OpenACC %select{clause '%1'|directive '%2'|sub-array bound}0 requires expression of integer type (%3 invalid)"
-H24F0AB7B1FF3: "OpenACC %select{子句'%1'|指令'%2'|子数组边界}0需要整型表达式（%3无效）"
+H24F0AB7B1FF3: "OpenACC %select{子句 '%1'|指令 '%2'|子数组边界}0需要整型表达式（%3 无效）"
 # "OpenACC '%0' clause cannot appear on the same '%2' construct as a '%1' clause %select{inside a compute construct with a|and a}3 'num_gangs' clause with more than one argument"
-H86F6667DC7E5: "OpenACC '%0'子句不能与同一'%2'结构中的'%1'子句%select{在带有|和}3 'num_gangs'子句（参数超过一个时）共存"
+H86F6667DC7E5: "OpenACC '%0' 子句不能与同一 '%2' 结构中的 '%1' 子句%select{在带有|和}3 'num_gangs' 子句（参数超过一个时）共存"
 # "OpenACC '%0' clause on a 'declare' directive is not allowed at global or namespace scope"
-H0D95AB23A6A9: "在全局或命名空间作用域中不允许在'declare'指令的'%0'子句上使用"
+H0D95AB23A6A9: "在全局或命名空间作用域中不允许在 'declare' 指令的 '%0' 子句上使用"
 # "OpenACC '%0' construct can only be applied to a 'for' loop"
-H7F39DD2F9D48: "OpenACC '%0'结构必须应用于一个'for'循环"
+H7F39DD2F9D48: "OpenACC '%0' 结构必须应用于一个 'for' 循环"
 # "OpenACC '%0' construct must have a terminating condition"
-HA5F584B3696E: "OpenACC '%0'结构必须有一个终止条件"
+HA5F584B3696E: "OpenACC '%0' 结构必须有一个终止条件"
 # "OpenACC '%0' construct must have at least one %1 clause"
-H5108FA0063F8: "OpenACC '%0'结构必须至少包含一个%1子句"
+H5108FA0063F8: "OpenACC '%0' 结构必须至少包含一个 %1 子句"
 # "OpenACC '%0' construct must have initialization clause in canonical form ('var = init' or 'T var = init')"
-HB6396996D535: "OpenACC '%0'结构必须以规范形式包含初始化子句（'var = init'或'T var = init'）"
+HB6396996D535: "OpenACC '%0' 结构必须以规范形式包含初始化子句（'var = init'或'T var = init'）"
 # "OpenACC '%0' variable must monotonically increase or decrease ('++', '--', or compound assignment)"
-H4842B31AA1BD: "OpenACC '%0'变量必须单调递增或递减（使用'++'、'--'或复合赋值）"
+H4842B31AA1BD: "OpenACC '%0' 变量必须单调递增或递减（使用'++'、'--'或复合赋值）"
 # "OpenACC '%1' clause %select{|with more than 1 argument }0may not appear on a '%2' construct with a '%3' clause%select{ with more than 1 argument|}0"
-HE77D7FA4A4F6: "OpenACC '%1' 子句 %select{|带有超过1个参数的 }0不能出现在带有 '%3' 子句%select{ 带有超过1个参数的|}0的 '%2' 构造中"
+HE77D7FA4A4F6: "OpenACC '%1' 子句 %select{|带有超过 1 个参数的 }0不能出现在带有 '%3' 子句%select{ 带有超过 1 个参数的|}0的 '%2' 构造中"
 # "OpenACC '%1' clause cannot appear more than once on a '%0' directive"
 H22BA6A918DDE: "OpenACC '%1' 子句在 '%0' 指令上不能出现多次"
 # "OpenACC '%1' clause is not valid on '%0' directive"
@@ -11581,11 +11581,11 @@ H9E597FA760BB: '声明上的OpenACC "bind"子句必须绑定到与之前bind子�
 # "OpenACC 'collapse' clause loop count must be a %select{constant expression|positive integer value, evaluated to %1}0"
 HF187F732137C: "OpenACC 'collapse' 子句循环计数必须是 %select{常量表达式|正整数值，计算为 %1}0"
 # "OpenACC 'gang' clause may have at most one %select{unnamed or 'num'|'dim'|'static'}0 argument"
-HC064C4557CFE: "OpenACC 'gang' 子句最多可以有一个 %select{未命名或'num'|'dim'|'static'}0 参数"
+HC064C4557CFE: "OpenACC 'gang' 子句最多可以有一个 %select{未命名或 'num'|'dim'|'static'}0 参数"
 # "OpenACC 'reduction' composite variable must not have non-scalar field"
 H9A717A5BB65E: "OpenACC 'reduction' 组合变量不能包含非标量字段"
 # "OpenACC 'reduction' variable must be a composite of scalar types; %1 %select{is not a class or struct|is incomplete|is not an aggregate}0"
-HD35F9CAD567D: "OpenACC 'reduction'变量必须是标量类型的聚合；%1%select{不是类或结构体|类型不完整|不是聚合类型}0"
+HD35F9CAD567D: "OpenACC 'reduction' 变量必须是标量类型的聚合；%1%select{不是类或结构体|类型不完整|不是聚合类型}0"
 # "OpenACC 'reduction' variable must be of scalar type, sub-array, or a composite of scalar types;%select{| sub-array base}1 type is %0"
 HEC7D1B479B8F: "OpenACC 'reduction' 变量必须是标量类型、子数组或标量类型的组合;%select{|子数组基}1类型是 %0"
 # "OpenACC 'reduction' variable must have the same operator in all nested constructs (%0 vs %1)"
@@ -11615,33 +11615,33 @@ H5F66C1830606: 'OpenACC 整数表达式具有不完整类类型 %0'
 # 'OpenACC integer expression requires explicit conversion from %0 to %1'
 H20507033806F: 'OpenACC 整数表达式需要将 %0 显式转换为 %1'
 # "OpenACC routine name '%0' does not name a function"
-H5802CAE72248: "OpenACC例行程序名称'%0'未命名一个函数"
+H5802CAE72248: "OpenACC例行程序名称 '%0' 未命名一个函数"
 # "OpenACC routine name '%0' names a set of overloads"
-HEC7D774C632B: "OpenACC例行程序名称'%0'指向一组重载函数"
+HEC7D774C632B: "OpenACC例行程序名称 '%0' 指向一组重载函数"
 # 'OpenACC sub-array %select{lower bound|length}0 evaluated to a value (%1) that would be out of the range of the subscripted array size of %2'
-HD993EBC2FF56: 'OpenACC子数组%select{下界|长度}0计算得到的值(%1)超出了所下标数组%2的大小范围'
+HD993EBC2FF56: 'OpenACC子数组%select{下界|长度}0计算得到的值(%1)超出了所下标数组 %2 的大小范围'
 # 'OpenACC sub-array %select{lower bound|length}0 evaluated to negative value %1'
-H9C42001B0E35: 'OpenACC子数组%select{下界|长度}0计算得到负值%1'
+H9C42001B0E35: 'OpenACC子数组%select{下界|长度}0计算得到负值 %1'
 # 'OpenACC sub-array base is of incomplete type %0'
-H568C42694CA4: 'OpenACC子数组基类型为不完全类型%0'
+H568C42694CA4: 'OpenACC子数组基类型为不完全类型 %0'
 # 'OpenACC sub-array cannot be of function type %0'
-H1F4C209C1D7A: 'OpenACC子数组不能是函数类型%0'
+H1F4C209C1D7A: 'OpenACC子数组不能是函数类型 %0'
 # 'OpenACC sub-array length is unspecified and cannot be inferred because the subscripted value is %select{not an array|an array of unknown bound}0'
 H3D8516DAE66C: 'OpenACC子数组长度未指定且无法推断，因为所下标值为%select{非数组|未知边界的数组}0'
 # 'OpenACC sub-array specified range [%0:%1] would be out of the range of the subscripted array size of %2'
-H7C8F28679BDB: 'OpenACC子数组指定范围[%0:%1]超出了所下标数组%2的大小范围'
+H7C8F28679BDB: 'OpenACC子数组指定范围[%0:%1]超出了所下标数组 %2 的大小范围'
 # 'OpenACC sub-array subscripted value is not an array or pointer'
 H64A7517C6764: 'OpenACC子数组所下标值不是数组或指针'
 # "OpenACC variable %select{in 'use_device' clause|on 'declare' construct}0 is not a valid variable name or array name"
-H5FFA8811F2EF: "OpenACC变量%select{'use_device'子句中的|'declare'结构中的}0不是一个有效的变量名或数组名"
+H5FFA8811F2EF: "OpenACC变量%select{'use_device' 子句中的|'declare' 结构中的}0不是一个有效的变量名或数组名"
 # 'OpenACC variable in cache directive is not a valid sub-array or array element'
 H0DEC3018E66D: 'OpenACC在cache指令中的变量不是一个有效的子数组或数组元素'
 # 'OpenACC variable is not a valid variable name, sub-array, array element,%select{| member of a composite variable,}0 or composite variable member'
 HA8B26141C7C6: 'OpenACC变量不是一个有效的变量名、子数组、数组元素%select{|或复合变量的成员,}0或复合变量成员'
 # 'OpenCL extension %0 is core feature or supported optional core feature - ignoring'
-H1E2DAA7C8DD9: 'OpenCL扩展%0是核心特性或支持的可选核心特性 - 忽略'
+H1E2DAA7C8DD9: 'OpenCL扩展 %0 是核心特性或支持的可选核心特性 - 忽略'
 # 'OpenCL extension %0 unknown or does not require pragma - ignoring'
-HB7D9C7E097C0: 'OpenCL扩展%0未知或不需要#pragma - 忽略'
+HB7D9C7E097C0: 'OpenCL扩展 %0 未知或不需要#pragma - 忽略'
 # 'OpenCL language standard to compile for.'
 H165955277EF6: '要编译的OpenCL语言标准'
 # 'OpenCL only. Allow denormals to be flushed to zero.'
@@ -11677,19 +11677,19 @@ H6B78DAFB84E5: 'OpenMP数组成形操作在此处不允许'
 # 'OpenMP captured regions are not yet supported in %select{streaming functions|functions with ZA state|functions with ZT0 state}0'
 HBFAEB31DF5F3: 'OpenMP捕获区域在%select{流函数|具有ZA状态的函数|具有ZT0状态的函数}0中尚未支持'
 # "OpenMP clause '%0' is only available as extension, use '-fopenmp-extensions'"
-H7D732B734761: "OpenMP子句'%0'仅作为扩展可用，请使用'-fopenmp-extensions'"
+H7D732B734761: "OpenMP子句 '%0' 仅作为扩展可用，请使用'-fopenmp-extensions'"
 # 'OpenMP constructs may not be nested inside a simd region%select{| except for ordered simd, simd, scan, or atomic directive}0'
 HC65424272817: 'OpenMP结构不能嵌套在simd区域内%select{|，除非是ordered simd、simd、scan或atomic指令}0'
 # 'OpenMP constructs may not be nested inside an atomic region'
 HE2C47884F9E6: 'OpenMP结构不能嵌套在原子区域内'
 # "OpenMP extension clause '%0' only allowed with '#pragma omp %1'"
-HB7695EC8B674: "OpenMP扩展子句'%0'仅允许与'#pragma omp %1'一起使用"
+HB7695EC8B674: "OpenMP扩展子句 '%0' 仅允许与'#pragma omp %1'一起使用"
 # 'OpenMP iterator is not allowed here'
 HB9668BC52F3C: 'OpenMP迭代器不允许在这里使用'
 # 'OpenMP loop iteration variable cannot have more than 64 bits size and will be narrowed'
-H85A842BD8107: 'OpenMP循环迭代变量的大小不能超过64位，将被截断'
+H85A842BD8107: 'OpenMP循环迭代变量的大小不能超过 64 位，将被截断'
 # "OpenMP offloading target '%0' is similar to target '%1' already specified; will be ignored"
-H66F93F9F54F1: "OpenMP卸载目标'%0'与已指定的'%1'目标相似；将被忽略"
+H66F93F9F54F1: "OpenMP卸载目标 '%0' 与已指定的 '%1' 目标相似；将被忽略"
 # 'OpenMP only allows an ordered construct with the simd clause nested in a simd construct'
 H52C83AA3C087: 'OpenMP仅允许将带有simd子句的ordered结构嵌套在simd结构中'
 # 'OpenMP standard version'
@@ -11697,7 +11697,7 @@ HA403864CFA0F: 'OpenMP 标准版本'
 # 'OpenMP support in flang is still experimental'
 HA42DEF114A36: 'flang中的OpenMP支持仍处于实验阶段'
 # "OpenMP target architecture '%0' pointer size is incompatible with host '%1'"
-HF18160FDA94C: "OpenMP目标架构'%0'的指针大小与主机'%1'不兼容"
+HF18160FDA94C: "OpenMP目标架构 '%0' 的指针大小与主机 '%1' 不兼容"
 # "OpenMP target is invalid: '%0'"
 H6461D2D7A8F6: "无效的OpenMP目标：'%0'"
 # 'Optimise without changing ABI'
@@ -12011,61 +12011,61 @@ HBDB4D3B42575: '使用分析信息划分数据段。'
 # 'Partition functions into N groups and select only functions in group i to be instrumented using -fprofile-selected-function-group'
 H245EBE517AA5: '将函数分为N组，并仅选择第i组中的函数进行instrumentation（使用-fprofile-selected-function-group选项）'
 # 'Partition functions into N groups using -fprofile-function-groups and select only functions in group i to be instrumented. The valid range is 0 to N-1 inclusive'
-HE1BA0DFA9946: '使用-fprofile-function-groups将函数分为N组，并仅选择第i组中的函数进行instrumentation。有效范围为0到N-1（包含端点）'
+HE1BA0DFA9946: '使用-fprofile-function-groups将函数分为N组，并仅选择第i组中的函数进行instrumentation。有效范围为 0 到N-1（包含端点）'
 # 'Pascal string is too long'
 HDF5B602956C9: 'Pascal字符串过长'
 # 'Pass -b <arg> to the linker on AIX'
-HC027AB59908D: '在AIX系统上将-b <arg>传递给链接器'
+HC027AB59908D: '在AIX系统上将-b <arg> 传递给链接器'
 # 'Pass -z <arg> to the linker'
-HC96FADA8EF05: '将-z <arg>传递给链接器'
+HC96FADA8EF05: '将-z <arg> 传递给链接器'
 # 'Pass <arg> to clang -cc1'
-H7056B37839B2: '将<arg>传递给clang -cc1'
+H7056B37839B2: '将 <arg> 传递给clang -cc1'
 # 'Pass <arg> to fatbinary invocation'
-HE6E06CC967E5: '将<arg>传递给fatbinary调用'
+HE6E06CC967E5: '将 <arg> 传递给fatbinary调用'
 # 'Pass <arg> to plugin <name>'
-H194FFD6DEF4E: '将<arg>传递给插件<name>'
+H194FFD6DEF4E: '将 <arg> 传递给插件 <name>'
 # 'Pass <arg> to the CUDA/HIP device compilation'
-H6E93CAC5A2A4: '将<arg>传递给CUDA/HIP设备编译'
+H6E93CAC5A2A4: '将 <arg> 传递给CUDA/HIP设备编译'
 # 'Pass <arg> to the CUDA/HIP host compilation'
-HBD5864C8EAAC: '将<arg>传递给CUDA/HIP主机编译'
+HBD5864C8EAAC: '将 <arg> 传递给CUDA/HIP主机编译'
 # 'Pass <arg> to the assembler'
-H260454350861: '将<arg>传递给汇编器'
+H260454350861: '将 <arg> 传递给汇编器'
 # 'Pass <arg> to the clang driver'
-H0BA43F60ADF1: '将<arg>传递给clang驱动程序'
+H0BA43F60ADF1: '将 <arg> 传递给clang驱动程序'
 # 'Pass <arg> to the compilation if the target matches <arch>'
-H28A6957698C7: '如果目标匹配<arch>，则将<arg>传递给编译过程'
+H28A6957698C7: '如果目标匹配 <arch>，则将 <arg> 传递给编译过程'
 # 'Pass <arg> to the flang compiler'
-HA8F1AD31AB5E: '将<arg>传递给flang编译器'
+HA8F1AD31AB5E: '将 <arg> 传递给flang编译器'
 # 'Pass <arg> to the linker'
-H47C4E471D4CC: '将<arg>传递给链接器'
+H47C4E471D4CC: '将 <arg> 传递给链接器'
 # 'Pass <arg> to the offload linkers or the ones identified by -<triple>'
-HF43CE14F52D9: '将<arg>传递给卸载链接器或由-<triple>标识的链接器'
+HF43CE14F52D9: '将 <arg> 传递给卸载链接器或由-<triple> 标识的链接器'
 # 'Pass <arg> to the preprocessor'
-HECFF1F09AA70: '将<arg>传递给ptxas汇编器'
+HECFF1F09AA70: '将 <arg> 传递给ptxas汇编器'
 # 'Pass <arg> to the ptxas assembler'
-HDA10BB61A91B: '将<arg>传递给静态分析器'
+HDA10BB61A91B: '将 <arg> 传递给静态分析器'
 # 'Pass <arg> to the static analyzer'
-H665CD83A1EA3: '将<arg>传递给由<triple>标识的目标卸载工具链'
+H665CD83A1EA3: '将 <arg> 传递给由 <triple> 标识的目标卸载工具链'
 # 'Pass <arg> to the target offloading toolchain identified by <triple>.'
-HD393E82FA340: '将<arg>传递给目标卸载工具链'
+HD393E82FA340: '将 <arg> 传递给目标卸载工具链'
 # 'Pass <arg> to the target offloading toolchain.'
-H786E5FF9D985: '将<arg>传递给目标卸载工具链。'
+H786E5FF9D985: '将 <arg> 传递给目标卸载工具链。'
 # 'Pass a workload definition. This is a file containing a JSON dictionary. The keys are root functions, the values are lists of functions to import in the module defining the root. It is assumed -funique-internal-linkage-names was used, to ensure local linkage functions have unique names. For example: \n{\n  "rootFunction_1": ["function_to_import_1", "function_to_import_2"], \n  "rootFunction_2": ["function_to_import_3", "function_to_import_4"] \n}'
 H8F2A17B54334: '传递一个工作负载定义。这是一个包含JSON字典的文件。键是根函数，值是模块中要导入的函数列表，该模块定义了该根函数。假设使用了-funique-internal-linkage-names选项，以确保内部链接函数具有唯一名称。例如：\n{\n  "rootFunction_1": ["function_to_import_1", "function_to_import_2"], \n  "rootFunction_2": ["function_to_import_3", "function_to_import_4"] \n}'
 # 'Pass all reduction arguments by reference'
 H1F6E6E7DA880: '通过引用传递所有规约参数'
 # 'Pass the comma separated arguments in <arg> to the assembler'
-H0BB4ECAE0BD9: '将<arg>中用逗号分隔的参数传递给汇编器'
+H0BB4ECAE0BD9: '将 <arg> 中用逗号分隔的参数传递给汇编器'
 # 'Pass the comma separated arguments in <arg> to the linker'
-H01CAEC128AC9: '将<arg>中用逗号分隔的参数传递给链接器'
+H01CAEC128AC9: '将 <arg> 中用逗号分隔的参数传递给链接器'
 # 'Pass the comma separated arguments in <arg> to the preprocessor'
-H596C87A5B391: '将<arg>中用逗号分隔的参数传递给预处理器'
+H596C87A5B391: '将 <arg> 中用逗号分隔的参数传递给预处理器'
 # 'Passes available:'
 H13989372E812: '可用的Pass：'
 # 'Path and name to DWP file.'
 H6E3C7CBCF218: 'DWP文件的路径和名称。'
 # 'Path of .dwp file. When not specified, it will be <binary>.dwp in the same directory as the main binary.'
-H743B0B321E91: '路径为.dwp文件。当未指定时，它将在主二进制文件的同一目录下使用<binary>.dwp。'
+H743B0B321E91: '路径为.dwp文件。当未指定时，它将在主二进制文件的同一目录下使用 <binary>.dwp。'
 # 'Path of debug info binary, llvm-profgen will load the DWARF info from it instead of the executable binary.'
 H7CB4490678CE: '包含DWARF信息的调试信息二进制文件路径。llvm-profgen将从此处加载DWARF信息，而不是可执行二进制文件。'
 # 'Path of perf-script trace created by Linux perf tool with `script` command(the raw perf.data should be profiled with -b)'
@@ -12149,7 +12149,7 @@ HF8B0216049CB: '内联需要更改PSTATE.SM调用的惩罚值'
 # 'Percentage of prologue execution count to use as threshold when evaluating whether a block is cold enough to be profitable to move eligible spills there'
 HB814EF09C393: '评估是否将块移动到合适的溢出位置时，用作阈值的函数序言执行次数的百分比'
 # 'Percentage threshold for splitting single-instruction critical edge. If the branch threshold is higher than this threshold, we allow speculative execution of up to 1 instruction to avoid branching to splitted critical edge'
-HF3E418A57D78: '允许对单指令关键边进行推测执行时的分支阈值百分比。若分支阈值高于该值，允许最多推测执行1条指令以避免转向分裂后的关键边'
+HF3E418A57D78: '允许对单指令关键边进行推测执行时的分支阈值百分比。若分支阈值高于该值，允许最多推测执行 1 条指令以避免转向分裂后的关键边'
 # 'Percentage threshold of matched basic blocks at which stale profile inference is executed.'
 H38AE58F6A0A2: '执行陈旧分析推断的基本块匹配百分比阈值。'
 # 'Percentile of profile quality distributions over hottest functions to report.'
@@ -12219,7 +12219,7 @@ HC378DD7FF55D: '将所有主程序变量置于静态内存（否则标量可能�
 # 'Place constant objects with relocatable address values in the RO data section and add -bforceimprw to the linker flags (AIX only)'
 HD2C46719D2EF: '将地址值可重定位的常量对象置于RO数据段，并向链接器标志添加-bforceimprw（仅AIX）'
 # 'Place constants in the .rodata section instead of the .sdata section even if they meet the -G <size> threshold (MIPS)'
-H509FF0828C91: '即使满足-G <size>阈值，仍将常量置于.rodata节而非.sdata节（仅MIPS）'
+H509FF0828C91: '即使满足-G <size> 阈值，仍将常量置于.rodata节而非.sdata节（仅MIPS）'
 # 'Place debug types in their own section (ELF Only)'
 H73B21ADBA4FE: '将调试类型置于独立节（仅ELF）'
 # 'Place each data in its own section'
@@ -12927,9 +12927,9 @@ HE92D60C3DD89: '处理三字符序列'
 # 'Processor register names.'
 H69E6140DD062: '处理器寄存器名称。'
 # 'Produce a faster access sequence for local-dynamic TLS variables where the offset from the TLS base is encoded as an immediate operand (AIX 64-bit only). This access sequence is not used for variables larger than 32KB.'
-H96608A9C1D3A: '为局部动态TLS变量生成更快的访问序列，其中TLS基址的偏移量被编码为立即操作数（仅AIX 64位）。该访问序列不用于大于32KB的变量。'
+H96608A9C1D3A: '为局部动态TLS变量生成更快的访问序列，其中TLS基址的偏移量被编码为立即操作数（仅AIX 64位）。该访问序列不用于大于 32KB的变量。'
 # 'Produce a faster access sequence for local-exec TLS variables where the offset from the TLS base is encoded as an immediate operand (AIX 64-bit only). This access sequence is not used for variables larger than 32KB.'
-HDB020B6BCE8A: '为局部执行TLS变量生成更快的访问序列，其中TLS基址的偏移量被编码为立即操作数（仅AIX 64位）。该访问序列不用于大于32KB的变量。'
+HDB020B6BCE8A: '为局部执行TLS变量生成更快的访问序列，其中TLS基址的偏移量被编码为立即操作数（仅AIX 64位）。该访问序列不用于大于 32KB的变量。'
 # 'Produce gcov notes files (*.gcno)'
 HA873BCAA45B3: '生成gcov注释文件（*.gcno）'
 # 'Produce progress indicator when performing measurements'
@@ -12937,9 +12937,9 @@ H2B5CD09D6FEE: '执行测量时生成进度指示'
 # 'Produce relaxation hints for linkers to try optimizing PIC call sequences into direct calls (MIPS only)'
 HA18E999EA6E6: '为链接器生成松弛提示，尝试将PIC调用序列优化为直接调用（仅MIPS）'
 # "Produced object files can use all ELF features supported by this binutils version and newer. If -fno-integrated-as is specified, the generated assembly will consider GNU as support. 'none' means that all ELF features can be used, regardless of binutils support. Defaults to 2.26."
-H0EBB90A612ED: "生成的对象文件可以使用此binutils版本及更新版本支持的所有ELF特性。如果指定了-fno-integrated-as选项，生成的汇编将考虑GNU汇编器的支持。'none'表示无论binutils是否支持，均可使用所有ELF特性。默认值为2.26。"
+H0EBB90A612ED: "生成的对象文件可以使用此binutils版本及更新版本支持的所有ELF特性。如果指定了-fno-integrated-as选项，生成的汇编将考虑GNU汇编器的支持。'none' 表示无论binutils是否支持，均可使用所有ELF特性。默认值为 2.26。"
 # "Produced object files can use all ELF features supported by this binutils version and newer.If -no-integrated-as is specified, the generated assembly will consider GNU as support.'none' means that all ELF features can be used, regardless of binutils support"
-H1E14DD582B2D: "生成的对象文件可以使用本binutils版本及后续版本支持的所有ELF特性。若指定了-no-integrated-as选项，生成的汇编将考虑GNU汇编器支持。'none'表示可以使用所有ELF特性，无论binutils是否支持"
+H1E14DD582B2D: "生成的对象文件可以使用本binutils版本及后续版本支持的所有ELF特性。若指定了-no-integrated-as选项，生成的汇编将考虑GNU汇编器支持。'none' 表示可以使用所有ELF特性，无论binutils是否支持"
 # 'Produces individual indexes for distributed backends.'
 H3927BD641AFE: '为分布式后端生成独立索引。'
 # 'ProfGen Options'
@@ -12989,9 +12989,9 @@ HF00163550893: '修剪无关Phi节点之间的依赖关系。'
 # 'Prune loop carried order dependences.'
 H49F00DC5D681: '修剪循环携带的顺序依赖关系。'
 # 'Put MODULE files in <dir>'
-HEED5CC89CC67: '将MODULE文件放入<dir>目录'
+HEED5CC89CC67: '将MODULE文件放入 <dir> 目录'
 # 'Put crash-report files in <dir>'
-H837FCDFF092D: '将崩溃报告文件放入<dir>目录'
+H837FCDFF092D: '将崩溃报告文件放入 <dir> 目录'
 # 'Put each data item in its own section'
 HF905C168CBCB: '将每个数据项放入独立的节区'
 # 'Put each function in its own section'
@@ -12999,7 +12999,7 @@ H169F18C51BFF: '将每个函数放入独立的节区'
 # 'Put global and static data smaller than the limit into a special section'
 H7B737FFA3469: '将小于限制的全局和静态数据放入特殊节区'
 # 'Put objects of at most <size> bytes into small data section (MIPS / Hexagon)'
-HB5EE66FF14A5: '将最多<size>字节的对象放入小数据段（MIPS/Hexagon）'
+HB5EE66FF14A5: '将最多 <size> 字节的对象放入小数据段（MIPS/Hexagon）'
 # 'Putting Jump Table in function section'
 H0F2B2856EA39: '将跳转表放入函数节中'
 # 'Qualified name of the symbol being queried.'
@@ -13073,13 +13073,13 @@ H3692DAF330DE: 'RISC-V原子伪指令扩展Pass'
 # 'RISC-V gather/scatter lowering pass'
 H05AC68772FF6: 'RISC-V gather/scatter降级pass'
 # "RISC-V interrupt attribute '%0' requires extension '%1'"
-H6CFF2777C071: "RISC-V中断属性'%0'需要扩展'%1'"
+H6CFF2777C071: "RISC-V中断属性 '%0' 需要扩展 '%1'"
 # 'RISC-V post-regalloc pseudo instruction expansion pass'
 H7D576AB43EFF: 'RISC-V寄存器分配后伪指令扩展pass'
 # 'RISC-V pseudo instruction expansion pass'
 H0A43861EEE99: 'RISC-V伪指令扩展pass'
 # "RISC-V type %0 requires the '%1' extension"
-HD2DE400562E4: "RISC-V类型%0需要'%1'扩展"
+HD2DE400562E4: "RISC-V类型 %0 需要 '%1' 扩展"
 # 'ROCm device library path. Alternative to rocm-path.'
 H671F96D79AC7: 'ROCm设备库路径。rocm-path的替代选项'
 # 'ROCm installation path, used for finding and automatically linking required bitcode libraries.'
@@ -13115,7 +13115,7 @@ HDB933E15EC9A: '可重定位的读写数据，相对于静态基址访问'
 # 'Reads and parses a basic block sections profile.'
 HB98EF81EB7F2: '读取并解析基本块段配置文件。'
 # 'Realign stack to the value of this flag (power of two)'
-H85DCE488EFC2: '将栈重新对齐为此标志的值（必须是2的幂）'
+H85DCE488EFC2: '将栈重新对齐为此标志的值（必须是 2 的幂）'
 # 'Reassociate expressions'
 H525BB5A9D397: '重新关联表达式'
 # 'Rebalance address calculation trees to improve instruction selection'
@@ -13231,7 +13231,7 @@ H9FB0D35F3462: '远程执行客户端（rsh/ssh）'
 # 'Remove .symtab section'
 HDFF82FC1A75B: '移除.symtab节'
 # "Remove CUDA/HIP offloading device architecture (e.g. sm_35, gfx906) from the list of devices to compile for. 'all' resets the list to its default value."
-HC1BC07C832AB: "从要编译的设备列表中移除CUDA/HIP卸载设备架构（例如sm_35、gfx906）。'all'将列表重置为默认值"
+HC1BC07C832AB: "从要编译的设备列表中移除CUDA/HIP卸载设备架构（例如sm_35、gfx906）。'all' 将列表重置为默认值"
 # 'Remove Loads Into Fake Uses'
 H633E035AD42E: '移除伪用途中的加载操作'
 # 'Remove Redundant DEBUG_VALUE analysis'
@@ -13295,7 +13295,7 @@ H4BF82E4A463A: '用向量库调用替换intrinsics'
 # 'Replace narrow shifts with wider shifts.'
 HF4525F5A5F2E: '用更宽的移位操作替换窄移位操作'
 # 'Replace occurrences of __nvvm_reflect() calls with 0/1'
-H9A0C0F0562E0: '将__nvvm_reflect()调用替换为0或1'
+H9A0C0F0562E0: '将__nvvm_reflect()调用替换为 0 或 1'
 # 'Replace physical registers with virtual registers'
 H2480E837105C: '用虚寄存器替换物理寄存器'
 # 'Replace pointer out arguments with struct returns for non-private address space'
@@ -13307,7 +13307,7 @@ H722DD7E4F6B2: '重命名时使用的替换字符串'
 # 'Replace target triples in input files with this triple'
 H1FCD419A56EC: '用此目标三元组替换输入文件中的目标三元组'
 # 'Replace the contents of the <from> file with the contents of the <to> file'
-H96ECB37ACA86: '将<from>文件的内容替换为<to>文件的内容'
+H96ECB37ACA86: '将 <from> 文件的内容替换为 <to> 文件的内容'
 # 'Replace unspecified target triples in input files with this triple'
 H1555B263A14F: '用此三元组替换输入文件中未指定的目标三元组'
 # 'Replacement Options'
@@ -13717,11 +13717,11 @@ H1006B6835AD7: 'Rvalue 引用。'
 # 'SCE targets (e.g. PS4)'
 H24C3BD16186C: 'SCE 目标平台（例如 PS4）'
 # "SDK does not contain 'libarclite' at the path '%0'; try increasing the minimum deployment target"
-HBB626BB3124D: "SDK在路径'%0'中不包含'libarclite'；尝试提高最低部署目标"
+HBB626BB3124D: "SDK在路径 '%0' 中不包含 'libarclite'；尝试提高最低部署目标"
 # "SDK settings were ignored as 'SDKSettings.json' could not be parsed"
 HF609237E0BEB: "由于无法解析'SDKSettings.json'，SDK设置被忽略"
 # "SEH '__try' is not supported on this target"
-H06D89FCA39AA: "SEH的'__try'在该目标平台上不受支持"
+H06D89FCA39AA: "SEH的 '__try' 在该目标平台上不受支持"
 # 'SI Fix SGPR copies'
 HDB9A9026CAAF: 'SI 修复SGPR复制'
 # 'SI Fix VGPR copies'
@@ -13809,9 +13809,9 @@ H49B0CF838F29: "子命令 '"
 # 'SUBCOMMANDS:\n\n'
 H5B04A2FD12F5: '子命令列表：\n\n'
 # 'SVE vector type %0 cannot be used in a non-streaming function'
-H9A5DD8A133CA: 'SVE向量类型%0不能在非流式函数中使用'
+H9A5DD8A133CA: 'SVE向量类型 %0 不能在非流式函数中使用'
 # 'SVE vector type %0 cannot be used in a target without sve'
-H9A595E01748A: 'SVE向量类型%0不能在没有sve的目标中使用'
+H9A595E01748A: 'SVE向量类型 %0 不能在没有sve的目标中使用'
 # 'SYCL host compilation'
 H61E19C960525: 'SYCL主机编译'
 # 'SYCL language standard to compile for.'
@@ -13975,7 +13975,7 @@ HA1F9E472551C: '选择教程版本'
 # 'Select underlying type for wchar_t'
 H871CFB3D3DBF: '选择wchar_t的基础类型'
 # "Select which XRay instrumentation points to emit. Options: all, none, function-entry, function-exit, function, custom. Default is 'all'.  'function' includes both 'function-entry' and 'function-exit'."
-HF1CF9325D610: "选择要生成的XRay插桩点。选项：all, none, function-entry, function-exit, function, custom. 默认值为'all'。  'function'包括'function-entry'和'function-exit'"
+HF1CF9325D610: "选择要生成的XRay插桩点。选项：all, none, function-entry, function-exit, function, custom. 默认值为 'all'。  'function' 包括'function-entry'和'function-exit'"
 # 'Select which denormal numbers the code is permitted to require'
 H2AC882EF26F4: '指定代码允许要求的非规格化数类型'
 # 'Select which denormal numbers the code is permitted to require for float'
@@ -14007,9 +14007,9 @@ HC407FF843F6C: '设置LTO模式'
 # 'Set LTO mode for offload compilation'
 HAFC85CCA6F44: '设置卸载编译的LTO模式'
 # 'Set OpenMP version (e.g. 45 for OpenMP 4.5, 51 for OpenMP 5.1). Default value is 11 for Flang'
-HB4B241AD39C3: '设置OpenMP版本（例如45对应OpenMP 4.5，51对应OpenMP 5.1）。默认值为Flang的11'
+HB4B241AD39C3: '设置OpenMP版本（例如 45 对应OpenMP 4.5，51对应OpenMP 5.1）。默认值为Flang的 11'
 # 'Set OpenMP version (e.g. 45 for OpenMP 4.5, 51 for OpenMP 5.1). Default value is 51 for Clang'
-H81EB65FB7662: '设置OpenMP版本（例如45对应OpenMP 4.5，51对应OpenMP 5.1）。默认值为Clang的51'
+H81EB65FB7662: '设置OpenMP版本（例如 45 对应OpenMP 4.5，51对应OpenMP 5.1）。默认值为Clang的 51'
 # 'Set ThinLTO cache entry expiration time.'
 HAC92585FAE36: '设置ThinLTO缓存条目过期时间。'
 # 'Set ThinLTO cache pruning directory maximum number of files.'
@@ -14039,13 +14039,13 @@ H05FB1FB7BA76: '设置构建目标为arm64ec'
 # 'Set default AMDHSA Code Object Version (module flag or asm directive still take priority if present)'
 H146533C17448: '设置默认的AMDHSA代码对象版本（若存在模块标志或asm指令则优先使用）'
 # "Set default MTE mode to 'sync' (default) or 'async'"
-H20B84E4CC1C3: "设置默认的MTE模式为'sync'（默认）或'async'"
+H20B84E4CC1C3: "设置默认的MTE模式为 'sync'（默认）或 'async'"
 # 'Set default calling convention'
 HDE29EF09B114: '设置默认调用约定'
 # 'Set default maximum struct packing alignment'
 HB9DF8419AE20: '设置默认最大结构体填充对齐值'
 # 'Set default maximum struct packing alignment to 1'
-H4F682E117F17: '将默认最大结构体填充对齐值设为1'
+H4F682E117F17: '将默认最大结构体填充对齐值设为 1'
 # 'Set directory to SYSTEM include search path with prefix'
 H68EB156B894F: '将带有前缀的目录添加到SYSTEM包含搜索路径'
 # 'Set directory to include search path with prefix'
@@ -14131,9 +14131,9 @@ H652EEA8353CA: '将源代码和运行时编码设置为UTF-8（默认）'
 # 'Set source encoding, supports only UTF-8'
 H3F8729E6E52F: '设置源代码编码，仅支持UTF-8'
 # 'Set stack probe size (default 4096)'
-HD0B9F95D20C7: '设置栈探测大小（默认4096）'
+HD0B9F95D20C7: '设置栈探测大小（默认 4096）'
 # 'Set tab expansion size for html coverage reports (default = 2)'
-H020BCDC65A3D: '设置HTML覆盖率报告中的制表符扩展大小（默认值为2）'
+H020BCDC65A3D: '设置HTML覆盖率报告中的制表符扩展大小（默认值为 2）'
 # 'Set target profile'
 H5E78CA7AD76D: '设置目标配置文件'
 # 'Set the -iwithprefix/-iwithprefixbefore prefix'
@@ -14141,13 +14141,13 @@ HE253558596E6: '设置 -iwithprefix/-iwithprefixbefore 前缀'
 # 'Set the Data Stream Control Register.'
 H13FF9AB8D2D0: '设置数据流控制寄存器。'
 # 'Set the case probability threshold for peeling the case from a switch statement. A value greater than 100 will void this optimization'
-H4CFCB81E6294: '设置从switch语句剥离case的概率阈值。大于100的值将使此优化失效'
+H4CFCB81E6294: '设置从switch语句剥离case的概率阈值。大于 100 的值将使此优化失效'
 # 'Set the count value cutoff. Functions with the maximum count less than this value will not be printed out. (Default is 0)'
-H314CB3F4FF30: '设置计数值截止值。最大计数小于该值的函数将不会被打印。（默认值为0）'
+H314CB3F4FF30: '设置计数值截止值。最大计数小于该值的函数将不会被打印。（默认值为 0）'
 # 'Set the default double precision kind to an 8 byte wide type'
-H826E52CBA80A: '设置默认双精度类型为8字节宽类型'
+H826E52CBA80A: '设置默认双精度类型为 8 字节宽类型'
 # 'Set the default integer and logical kind to an 8 byte wide type'
-HBB03F45115A1: '设置默认整数和逻辑类型为8字节宽类型'
+HBB03F45115A1: '设置默认整数和逻辑类型为 8 字节宽类型'
 # 'Set the default most-general representation to multiple inheritance'
 H4BB3649A0500: '设置默认最通用的表示为多重继承'
 # 'Set the default most-general representation to single inheritance'
@@ -14155,7 +14155,7 @@ HD5A0F69F41ED: '设置默认最通用的表示为单继承'
 # 'Set the default most-general representation to virtual inheritance'
 H106974060665: '设置默认最通用的表示为虚继承'
 # 'Set the default real kind to an 8 byte wide type'
-H7B0DABF8B0EB: '设置默认实数类型为8字节宽类型'
+H7B0DABF8B0EB: '设置默认实数类型为 8 字节宽类型'
 # 'Set the default structure layout to be compatible with the Microsoft compiler standard'
 H10F147D00248: '设置默认结构体布局与Microsoft编译器标准兼容'
 # 'Set the default symbol visibility for all global definitions'
@@ -14165,7 +14165,7 @@ H814D918A5F74: '设置部署目标为指定的操作系统及其版本'
 # 'Set the device id.'
 H4C967743D4CC: '设置设备ID。'
 # "Set the driver mode to either 'gcc', 'g++', 'cpp', 'cl' or 'flang'"
-HD0838A0BABB3: "设置驱动程序模式为'gcc'、'g++'、'cpp'、'cl'或'flang'"
+HD0838A0BABB3: "设置驱动程序模式为 'gcc'、'g++'、'cpp'、'cl' 或 'flang'"
 # 'Set the kind of module destructors emitted by AddressSanitizer instrumentation. These destructors are emitted to unregister instrumented global variables when code is unloaded (e.g. via `dlclose()`).'
 H83083E1D2A16: '设置AddressSanitizer插桩所生成的模块析构函数类型。这些析构函数用于在代码卸载时（例如通过`dlclose()`）注销被插桩的全局变量。'
 # 'Set the loop counter bitwidth'
@@ -14223,9 +14223,9 @@ H7736F9C56939: '设置WebAssembly加载和存储的p2align操作数'
 # 'Set the parallelization strategy'
 HF0A794612D46: '设置并行化策略'
 # "Set the profile instrumentation burst duration, which can range from 1 to the value of 'sampled-instr-period' (0 is invalid). This number of samples will be recorded for each 'sampled-instr-period' count update. Setting to 1 enables simple sampling, in which case it is recommended to set 'sampled-instr-period' to a prime number."
-H5CA10C80C24A: "设置配置文件采样突发时长，取值范围为1到'sampled-instr-period'的值（0无效）。每个采样周期将记录该数量的样本。设置为1时启用简单采样，此时建议将'sampled-instr-period'设为质数。"
+H5CA10C80C24A: "设置配置文件采样突发时长，取值范围为 1 到'sampled-instr-period'的值（0无效）。每个采样周期将记录该数量的样本。设置为 1 时启用简单采样，此时建议将'sampled-instr-period'设为质数。"
 # "Set the profile instrumentation sample period. A sample period of 0 is invalid. For each sample period, a fixed number of consecutive samples will be recorded. The number is controlled by 'sampled-instr-burst-duration' flag. The default sample period of 65536 is optimized for generating efficient code that leverages unsigned short integer wrapping in overflow, but this is disabled under simple sampling (burst duration = 1)."
-HC029DE20A3E1: "设置配置文件采样周期。0无效。每个采样周期将记录固定数量的连续样本。具体数量由'sampled-instr-burst-duration'参数控制。默认采样周期65536经过优化，可生成利用无符号短整型溢出的高效代码，但在简单采样（突发时长=1）时该优化会被禁用。"
+HC029DE20A3E1: "设置配置文件采样周期。0无效。每个采样周期将记录固定数量的连续样本。具体数量由'sampled-instr-burst-duration'参数控制。默认采样周期 65536 经过优化，可生成利用无符号短整型溢出的高效代码，但在简单采样（突发时长=1）时该优化会被禁用。"
 # "Set the rsp quoting to either 'posix', or 'windows'"
 HFF7A11383873: '设置RSP文件的引号方式为"posix"或"windows"'
 # 'Set the stack alignment'
@@ -14267,7 +14267,7 @@ H40BE9F55402A: '在默认浮点模式寄存器中设置IEEE位。支持IEEE 754-
 # 'Sets the SIMD width. Zero is autoselect.'
 HA8F45CFC1E01: '设置SIMD宽度。零表示自动选择。'
 # 'Sets the bias which adds weight to occupancy vs latency. Set it to 100 to chase the occupancy only.'
-HDE531962A442: '设置偏向权重（occupancy vs latency）。设置为100时仅优化occupancy。'
+HDE531962A442: '设置偏向权重（occupancy vs latency）。设置为 100 时仅优化occupancy。'
 # 'Sets the cost threshold for when multiple conditionals will be merged into one branch versus be split in multiple branches. Merging conditionals saves branches at the cost of additional instructions. This value sets the instruction cost limit, below which conditionals will be merged, and above which conditionals will be split. Set to -1 to never merge branches.'
 H908B80F5C5DD: '设置合并多个条件为一个分支或拆分为多个分支的成本阈值。合并条件可以减少分支数量但会增加指令数量。该值设置指令成本限制：低于该值时合并条件，高于该值时拆分条件。设置为-1可禁用合并。'
 # 'Sets the default matrix layout'
@@ -14283,7 +14283,7 @@ H0A768F10FB45: '设置实验性内层循环的首选循环对齐方式（以log2
 # 'Sets the vectorization interleave count. Zero is autoselect.'
 H0275ABE673BB: '设置向量化交织次数。零表示自动选择。'
 # 'Sets various macros to claim compatibility with the given GCC version (default is 4.2.1)'
-HF256B239FB01: '设置各种宏以声明与给定GCC版本的兼容性（默认为4.2.1）'
+HF256B239FB01: '设置各种宏以声明与给定GCC版本的兼容性（默认为 4.2.1）'
 # 'Shadow Stack GC Lowering'
 H04B76D4FEDB5: 'Shadow Stack GC 降级'
 # 'Should __STATIC__ be defined'
@@ -14491,7 +14491,7 @@ H4D487410E126: '根据大小专门化memcmp和bcmp调用'
 # 'SjLj exception handling'
 HA2DEA63BE575: 'SjLj 异常处理'
 # 'Skip 64-bit divide for dynamic 32-bit values'
-HBC981EB66354: '跳过对动态32位值的64位除法'
+HBC981EB66354: '跳过对动态 32 位值的 64 位除法'
 # 'Skip Callsite up to this number for this compilation'
 HD2D3E00B6C18: '在此编译中跳过最多数量的调用点'
 # 'Skip Cost Analysis'
@@ -14581,9 +14581,9 @@ HD8341B8B44B5: '源代码分析 - 符号约束引擎'
 # 'Source prefix to elide'
 HF556E14613B2: '要省略的源前缀'
 # "Source-level compatibility for Altivec vectors (for PowerPC targets). This includes results of vector comparison (scalar for 'xl', vector for 'gcc') as well as behavior when initializing with a scalar (splatting for 'xl', element zero only for 'gcc'). For 'mixed', the compatibility is as 'gcc' for 'vector bool/vector pixel' and as 'xl' for other types. Current default is 'mixed'."
-HCF923B012626: "源级兼容性设置（针对PowerPC目标平台的AltiVec向量）。包括向量比较结果（'xl'为标量，'gcc'为向量）以及使用标量初始化时的行为（'xl'为扩展，'gcc'仅保留第一个元素）。对于'mixed'模式，'vector bool/vector pixel'类型与'gcc'兼容，其他类型与'xl'兼容。当前默认为'mixed'。"
+HCF923B012626: "源级兼容性设置（针对PowerPC目标平台的AltiVec向量）。包括向量比较结果（'xl' 为标量，'gcc' 为向量）以及使用标量初始化时的行为（'xl' 为扩展，'gcc' 仅保留第一个元素）。对于 'mixed' 模式，'vector bool/vector pixel'类型与 'gcc' 兼容，其他类型与 'xl' 兼容。当前默认为 'mixed'。"
 # 'SourceLocation in file %0 at offset %1 is invalid'
-H2A6519004798: '文件%0中偏移量%1处的SourceLocation无效'
+H2A6519004798: '文件 %0 中偏移量 %1 处的SourceLocation无效'
 # 'Spawn a separate process for each cc1'
 H4079AEA987DF: '为每个cc1进程创建独立的子进程'
 # 'Spawns a subprocess for each snippet execution, allows for the use of memory annotations'
@@ -14597,7 +14597,7 @@ HAF01AE884575: '指定要免于TOC数据转换的变量列表。'
 # 'Specifies a list of variables to which the TOC data transformation will be applied.'
 H33958769FAEF: '指定要应用TOC数据转换的变量列表。'
 # "Specifies preferred vector width for auto-vectorization. Defaults to 'none' which allows target specific decisions."
-H30D4DB622AB0: "指定自动向量化使用的首选向量宽度。默认为'none'，允许目标特定的决策。"
+H30D4DB622AB0: "指定自动向量化使用的首选向量宽度。默认为 'none'，允许目标特定的决策。"
 # 'Specifies that the sample profile is accurate'
 H3A3F53CE7955: '指定样本配置文件是准确的'
 # 'Specifies the JITDylib to be used for any subsequent -extra-module arguments.'
@@ -14615,13 +14615,13 @@ H7C74E7BEFD7B: "指定'::operator new(size_t)'保证的最大对齐方式"
 # 'Specifies the name we should consider the input file'
 H048BF6366B06: '指定输入文件的名称'
 # 'Specifies the size of batches for processing CUs. Higher number has better performance, but more memory usage. Default value is 1.'
-HE1BE8B43F7F0: '指定处理CUs的批处理大小。数值越大性能越好，但内存使用越高。默认值为1。'
+HE1BE8B43F7F0: '指定处理CUs的批处理大小。数值越大性能越好，但内存使用越高。默认值为 1。'
 # 'Specify "safe" i.e. known-good backend:'
 H8A9DA72ACD37: '指定“安全”即已知良好的后端:'
 # 'Specify <function, basic block1[;basic block2...]> pairs to extract.\nEach pair will create a function.\nIf multiple basic blocks are specified in one pair,\nthe first block in the sequence should dominate the rest.\neg:\n  --bb=f:bb1;bb2 will extract one function with both bb1 and bb2;\n  --bb=f:bb1 --bb=f:bb2 will extract two functions, one with bb1, one with bb2.'
 H849E2CD57584: '指定要提取的<函数, basic block1[;basic block2...]>对。\n每一对将创建一个函数。\n如果一对中包含多个basic block，\n第一个块应在序列中支配其余块。\n示例：\n  --bb=f:bb1;bb2 将提取一个包含bb1和bb2的函数；\n  --bb=f:bb1 --bb=f:bb2 将提取两个函数，一个包含bb1，一个包含bb2。'
 # 'Specify <script> as linker script'
-HE790F52CC3F0: '指定链接器脚本<script>'
+HE790F52CC3F0: '指定链接器脚本 <script>'
 # 'Specify CU wavefront execution mode (AMDGPU only)'
 H0AC391ACF1B8: '指定CU波前执行模式（仅AMDGPU）'
 # 'Specify O2(not Os) spill func threshold'
@@ -14637,7 +14637,7 @@ H6CD3C27C7374: '指定上下文敏感型PGO剖面文件'
 # "Specify a default target triple when it's not available in the module"
 H8905580ACB2D: '当模块中未提供时，指定默认目标三元组'
 # "Specify a directory where Clang can find 'include' and 'lib{,32,64}/gcc{,-cross}/$triple/$version'. Clang will use the GCC installation with the largest version"
-H5F9EC5F91118: "指定Clang可以找到'include'和'lib{,32,64}/gcc{,-cross}/$triple/$version'的目录。Clang将使用版本最大的GCC安装"
+H5F9EC5F91118: "指定Clang可以找到 'include' 和'lib{,32,64}/gcc{,-cross}/$triple/$version'的目录。Clang将使用版本最大的GCC安装"
 # "Specify a directory where Flang can find 'lib{,32,64}/gcc{,-cross}/$triple/$version'. Flang will use the GCC installation with the largest version"
 H59AA0290DBA6: "指定Flang可以找到'lib{,32,64}/gcc{,-cross}/$triple/$version'的目录。Flang将使用版本最大的GCC安装"
 # 'Specify a plugin to optimize LFENCE insertion'
@@ -14651,13 +14651,13 @@ H4D5920CD11AC: '指定要提取的别名'
 # 'Specify alias(es) to extract using a regular expression'
 H5A885E78EEAE: '使用正则表达式指定要提取的别名'
 # "Specify an offloading device architecture for CUDA, HIP, or OpenMP. (e.g. sm_35). If 'native' is used the compiler will detect locally installed architectures. For HIP offloading, the device architecture can be followed by target ID features delimited by a colon (e.g. gfx908:xnack+:sramecc-). May be specified more than once."
-H03D163E89A58: "指定CUDA、HIP或OpenMP的卸载设备架构。例如sm_35。如果使用'native'，编译器将检测本地安装的架构。对于HIP卸载，设备架构后可跟随用冒号分隔的目标ID特性（例如gfx908:xnack+:sramecc-）。可以多次指定该选项。"
+H03D163E89A58: "指定CUDA、HIP或OpenMP的卸载设备架构。例如sm_35。如果使用 'native'，编译器将检测本地安装的架构。对于HIP卸载，设备架构后可跟随用冒号分隔的目标ID特性（例如gfx908:xnack+:sramecc-）。可以多次指定该选项。"
 # 'Specify an output filename for an HTML report. This describes both recommendations and reasons for changes.'
 H8B1F64A00015: '指定HTML报告的输出文件名。该报告将描述建议和变更原因。'
 # 'Specify bit size of immediate TLS offsets (AArch64 ELF only): 12 (for 4KB) | 24 (for 16MB, default) | 32 (for 4GB) | 48 (for 256TB, needs -mcmodel=large)'
 H26411589DDDC: '指定即时TLS偏移的位大小（仅AArch64 ELF）：12（4KB）| 24（16MB，默认）| 32（4GB）| 48（256TB，需要-mcmodel=large）'
 # 'Specify code object ABI version. Defaults to 6. (AMDGPU only)'
-HA8698B7A4F07: '指定代码对象ABI版本。默认为6。（仅AMDGPU）'
+HA8698B7A4F07: '指定代码对象ABI版本。默认为 6。（仅AMDGPU）'
 # 'Specify comma-separated list of offloading target triples (CUDA and HIP only)'
 H4646687E209A: '指定以逗号分隔的卸载目标三元组列表（CUDA和HIP仅）'
 # 'Specify comma-separated list of triples OpenMP offloading targets to be supported'
@@ -14667,7 +14667,7 @@ H1E332E02D801: '指定要运行的命令'
 # 'Specify configuration file'
 HF189739D324B: '指定配置文件'
 # "Specify default stream. The default value is 'legacy'. (CUDA/HIP only)"
-H9CAF3E629210: "指定默认流。默认值为'legacy'。（CUDA/HIP仅）"
+H9CAF3E629210: "指定默认流。默认值为 'legacy'。（CUDA/HIP仅）"
 # 'Specify file to retrieve coverage information from'
 HF677E8D618FB: '指定用于检索覆盖信息的文件'
 # 'Specify file to retrieve the list of functions to apply CHR to'
@@ -14831,9 +14831,9 @@ H8693C7688390: '指定要对齐的分支类型'
 # 'Specify types of branches to align (plus separated list of types):\njcc      indicates conditional jumps\nfused    indicates fused conditional jumps\njmp      indicates direct unconditional jumps\ncall     indicates direct and indirect calls\nret      indicates rets\nindirect indicates indirect unconditional jumps'
 H3D330EC77559: '指定要对齐的分支类型（用加号分隔的类型列表）：\njcc      表示条件跳转\nfused    表示融合条件跳转\njmp      表示直接无条件跳转\ncall     表示直接和间接调用\nret      表示返回\nindirect 表示间接无条件跳转'
 # 'Specify wavefront size 32 mode (AMDGPU only)'
-HA9AC5ACEB8A1: '指定wavefront大小32模式（仅AMDGPU）'
+HA9AC5ACEB8A1: '指定wavefront大小 32 模式（仅AMDGPU）'
 # 'Specify wavefront size 64 mode (AMDGPU only)'
-H33E655B3FFCB: '指定wavefront大小为64模式（仅AMDGPU）'
+H33E655B3FFCB: '指定wavefront大小为 64 模式（仅AMDGPU）'
 # 'Specify where to find the compiled intrinsic modules'
 H60F443A1A2B8: '指定查找编译后的intrinsic模块的位置'
 # 'Specify which frame pointers to retain.'
@@ -15165,7 +15165,7 @@ H065EFBB6A92E: '用于getRegisterBitWidth查询的LMUL。会影响自动向量�
 # 'The OOO window for processor resources during scheduling.'
 H7F8CE8011253: '调度期间处理器资源的OOO窗口。'
 # 'The alignment to use when accessing the buffers\nDefault is unaligned\nUse 0 to disable address randomization'
-H9D92202DC06A: '访问缓冲区时使用的对齐方式\n默认为未对齐\n使用0禁用地址随机化'
+H9D92202DC06A: '访问缓冲区时使用的对齐方式\n默认为未对齐\n使用 0 禁用地址随机化'
 # 'The amount of branches that we are willing to explore withthe exact algorithm before giving up.'
 H46BDE8E006FD: '在放弃之前，使用精确算法愿意探索的分支数量。'
 # 'The associativity of the first cache level.'
@@ -15181,7 +15181,7 @@ HA507EEDE87C4: '我们计划生成的方言中操作的基类'
 # 'The bonus weight of users of allocas within loop when sorting profitable allocas'
 HBDF3A84E4987: '在排序有利的alloca时，循环内使用alloca的用户的额外权重'
 # 'The clause simdlen must fit the %0-bit lanes in the architectural constraints for SVE (min is 128-bit, max is 2048-bit, by steps of 128-bit)'
-H637FD9B0F74C: 'simdlen子句必须符合SVE架构约束中的%0位通道（最小为128位，最大为2048位，步长为128位）'
+H637FD9B0F74C: 'simdlen子句必须符合SVE架构约束中的 %0 位通道（最小为 128 位，最大为 2048 位，步长为 128 位）'
 # 'The clause simdlen(1) has no effect when targeting aarch64.'
 H28E8D9873AFA: '当目标为aarch64时，simdlen(1)子句无效'
 # 'The code working set size is considered huge if the number of blocks required to reach the -profile-summary-cutoff-hot percentile exceeds this count.'
@@ -15243,7 +15243,7 @@ HEDD158AF26CA: '循环分解的成本阈值'
 # 'The current shard index'
 H876C17A38CA1: '当前分片索引'
 # 'The default 2nd-level tile size (if not enough were provided by --polly-2nd-level-tile-sizes)'
-H1853EDCB107B: '默认的第2级分块大小（如果未通过--polly-2nd-level-tile-sizes提供足够的值）'
+H1853EDCB107B: '默认的第 2 级分块大小（如果未通过--polly-2nd-level-tile-sizes提供足够的值）'
 # 'The default address space is assumed as the flat address space. This is mainly for test purpose.'
 HE348DDF306A6: '默认的地址空间被假设为平坦地址空间。这主要用于测试目的。'
 # 'The default associativity of the first cache level (if not enough were provided by the TargetTransformInfo).'
@@ -15357,7 +15357,7 @@ H7CD48ED835E9: 'ExtTSP值的后向跳转最大距离（以字节为单位）'
 # 'The maximum interleave count to use when interleaving a scalar reduction in a nested loop.'
 H672121274D43: '在嵌套循环中交错标量约简时允许的最大交错次数'
 # 'The maximum length of a constant string for a builtin string cmp call eligible for inlining. The default value is 3.'
-H6551F5EAB050: '允许内联的内建字符串比较调用的常量字符串最大长度。默认值为3'
+H6551F5EAB050: '允许内联的内建字符串比较调用的常量字符串最大长度。默认值为 3'
 # 'The maximum length of a constant string to inline a memchr call.'
 HAAA048CEEC02: '允许内联memchr调用的常量字符串最大长度'
 # 'The maximum length of a single temporal profile trace (default: 10000)'
@@ -15391,7 +15391,7 @@ H9DEE4E0B8275: '单个函数特化允许的最大克隆数量'
 # 'The maximum number of functions to track per lattice value'
 HCD37A486700C: '每个晶格值要跟踪的最大函数数量'
 # 'The maximum number of heap allocations to consider in one function before skipping (to save compilation time). Set to 0 for no limit.'
-H9E920C5F07AD: '在跳过之前考虑一个函数中的堆分配的最大数量（以节省编译时间）。设置为0表示无限制。'
+H9E920C5F07AD: '在跳过之前考虑一个函数中的堆分配的最大数量（以节省编译时间）。设置为 0 表示无限制。'
 # 'The maximum number of incoming values a PHI node can have to be considered during the specialization bonus estimation'
 H03E2B05D3E4E: '在专用化奖励估算期间，PHI节点可以拥有的传入值的最大数量'
 # 'The maximum number of instructions considered for cycle sinking.'
@@ -15407,11 +15407,11 @@ HFD5552B5CF15: '在死代码估算期间，基本块可以拥有的前驱块的�
 # 'The maximum number of scheduling group conflicts which we attempt to solve with the exponential time exact solver. Problem sizes greater than this willbe solved by the less accurate greedy algorithm. Selecting solver by size is superseded by manually selecting the solver (e.g. by amdgpu-igrouplp-exact-solver'
 H071D666725DB: '使用指数时间精确求解器尝试解决的调度组冲突最大数量。大于该大小的问题将由精度较低的贪心算法解决。通过大小选择求解器将被手动选择的求解器（例如通过amdgpu-igrouplp-exact-solver参数）覆盖'
 # 'The maximum number of steps while walking upwards to find MemoryDefs that may be killed (default = 90)'
-HA207F5C7ADD1: '向上遍历时寻找可能被杀死的MemoryDefs步骤的最大数量（默认值为90）'
+HA207F5C7ADD1: '向上遍历时寻找可能被杀死的MemoryDefs步骤的最大数量（默认值为 90）'
 # 'The maximum number of stored temporal profile traces (default: 100)'
 H6A4CCB113506: '存储的时序剖面轨迹最大数量（默认：100）'
 # 'The maximum number of stores/phis MemorySSAwill consider trying to walk past (default = 100)'
-H0C4FBDD67710: 'MemorySSA将尝试遍历的最大存储/PHI节点数量（默认值为100）'
+H0C4FBDD67710: 'MemorySSA将尝试遍历的最大存储/PHI节点数量（默认值为 100）'
 # 'The maximum number of times a live range can be evicted before preventing it from being evicted'
 HEF28AF0C80C6: '在阻止其被替换之前，活动范围可以被替换的最大次数'
 # 'The maximum number of times the analyzer will go through a loop'
@@ -15487,7 +15487,7 @@ HF09A01C5BE8E: '要使用的发行版名称'
 # 'The name of the executor to use.'
 H9A67A8D34CB5: '要使用的执行器名称'
 # "The name of the predefined style used as a\nfallback in case clang-format is invoked with\n-style=file, but can not find the .clang-format\nfile to use. Defaults to 'LLVM'.\nUse -fallback-style=none to skip formatting."
-H605E77115F2D: "当以-style=file调用clang-format但无法找到要使用的.clang-format文件时，用作回退的预定义样式名称。默认为'LLVM'。\n使用-fallback-style=none可跳过格式化。"
+H605E77115F2D: "当以-style=file调用clang-format但无法找到要使用的.clang-format文件时，用作回退的预定义样式名称。默认为 'LLVM'。\n使用-fallback-style=none可跳过格式化。"
 # 'The name of the struct/class.'
 HA728CE8CB2EB: '结构体/类的名称'
 # 'The name of this group of passes'
@@ -15517,7 +15517,7 @@ H1DDD94D0908A: '窗口算法中每个循环的搜索次数。0表示没有搜索
 # 'The number of shards into which the op classes will be divided'
 H2AD8480DFFBC: '操作类将被划分为的分片数量'
 # 'The number of threads used to process all files in parallel. Set to 0 for hardware concurrency. This flag only applies to all-TUs.'
-H14270C0E6B74: '并行处理所有文件使用的线程数。设置为0以使用硬件线程数。此标志仅适用于所有翻译单元。'
+H14270C0E6B74: '并行处理所有文件使用的线程数。设置为 0 以使用硬件线程数。此标志仅适用于所有翻译单元。'
 # 'The number of times to repeat measurements on the benchmark k before aggregating the results'
 HEB3E720640C3: '在聚合结果前对基准测试k进行测量的重复次数阈值'
 # 'The option is used to turn on/off warnings about hash mismatch for comdat or weak functions.'
@@ -15579,7 +15579,7 @@ H416C25DD1085: '插桩剖面用于配置文件引导型尺寸优化的摘要截�
 # 'The profile guided size optimization profile summary cutoff for sample profile.'
 H7CFAC61196B3: '基于采样配置文件的大小优化配置文件摘要截断值。'
 # 'The ratio of searches per loop in the window algorithm. 100 means search all positions in the loop, while 0 means not performing any search.'
-H69F36D760102: '窗口算法中每个循环的搜索比率。100表示搜索循环中的所有位置，而0表示不进行任何搜索。'
+H69F36D760102: '窗口算法中每个循环的搜索比率。100表示搜索循环中的所有位置，而 0 表示不进行任何搜索。'
 # 'The relative/absolute file path of new cc.'
 HE0F45871CC31: '新cc的相对/绝对文件路径。'
 # 'The relative/absolute file path of new header.'
@@ -15649,7 +15649,7 @@ H4AEDA738C805: '基于优先级的样本配置文件加载器内联的大小增�
 # 'The upper limit of II in the window algorithm.'
 H6259F5DF8819: '窗口算法中II的上限值。'
 # 'The value specified in simdlen must be a power of 2 when targeting Advanced SIMD.'
-HAAC03787F717: 'simdlen指定的值在针对Advanced SIMD目标时必须是2的幂。'
+HAAC03787F717: 'simdlen指定的值在针对Advanced SIMD目标时必须是 2 的幂。'
 # 'The vectorization factor for byte-compare patterns.'
 H892AED0C291C: '字节比较模式的向量化因子。'
 # 'The vectorization style for loop idiom transform.'
@@ -15835,15 +15835,15 @@ H912BF1C6F685: '整数溢出时触发陷阱'
 # 'Trap when incorrect'
 H9EC2646A38E0: '错误时触发陷阱'
 # 'Treat <file> as C source file'
-H5AAFC1A35AEE: '将<file>视为C源文件'
+H5AAFC1A35AEE: '将 <file> 视为C源文件'
 # 'Treat <file> as C++ source file'
-H467B7FCAE3B7: '将<file>视为C++源文件'
+H467B7FCAE3B7: '将 <file> 视为C++源文件'
 # 'Treat INCLUDE lines like #include directives in -E mode'
 H8BB5A80B42A6: '在-E模式下将INCLUDE行视为#include指令'
 # 'Treat all #include paths starting with <prefix> as including a system header.'
-H4CD79E350724: '将所有以<prefix>开头的#include路径视为包含系统头文件。'
+H4CD79E350724: '将所有以 <prefix> 开头的#include路径视为包含系统头文件。'
 # 'Treat all #include paths starting with <prefix> as not including a system header.'
-H7FC347478B10: '将所有以<prefix>开头的#include路径视为不包含系统头文件。'
+H7FC347478B10: '将所有以 <prefix> 开头的#include路径视为不包含系统头文件。'
 # 'Treat all parameters to functions that are pointers as dereferencible. This is useful for invariant load hoisting, since we can generate less runtime checks. This is only valid if all pointers to functions are always initialized, so that Polly can choose to hoist their loads. '
 H01E314D59C27: '将函数的所有指针参数视为可解引用的。这对于不变量加载提升很有用，因为可以生成更少的运行时检查。只有当所有指向函数的指针始终被初始化时，Polly才能选择提升它们的加载操作。'
 # 'Treat all source files as C'
@@ -15851,15 +15851,15 @@ H55FA85BDA2A5: '将所有源文件视为C语言'
 # 'Treat all source files as C++'
 H7EEC5BB50052: '将所有源文件视为C++语言'
 # 'Treat any <pattern> strings as regular expressions when selecting instead of just as an exact string match.'
-HB8CFB19C5C18: '在选择时将任何<pattern>字符串视为正则表达式，而不是精确字符串匹配。'
+HB8CFB19C5C18: '在选择时将任何 <pattern> 字符串视为正则表达式，而不是精确字符串匹配。'
 # 'Treat each comma separated argument in <arg> as a documentation comment block command'
-HCB49DF1FFB5A: '将<arg>中的每个逗号分隔的参数视为文档注释块命令'
+HCB49DF1FFB5A: '将 <arg> 中的每个逗号分隔的参数视为文档注释块命令'
 # 'Treat editor placeholders as valid source code'
 H5F226C718000: '将编辑器占位符视为有效源代码'
 # "Treat fixed form lines with 'd' or 'D' in the first column as blank."
-HADC0D4FE88CA: "将固定格式中首列有'd'或'D'的行视为空白行。"
+HADC0D4FE88CA: "将固定格式中首列有 'd' 或 'D' 的行视为空白行。"
 # "Treat fixed form lines with 'd' or 'D' in the first column as comments."
-H3F2B7A8C2293: "将固定格式中首列有'd'或'D'的行视为注释。"
+H3F2B7A8C2293: "将固定格式中首列有 'd' 或 'D' 的行视为注释。"
 # 'Treat hip and hipv4 offload kinds as compatible with openmp kind, and vice versa.\n'
 HC9954ACD9B9E: '将hip和hipv4 offload类型视为与openmp类型兼容，反之亦然。\n'
 # 'Treat input as a PDB file (default)'
@@ -15887,7 +15887,7 @@ H1D5DFE08E7A8: '将栈生命周期的起始点视为首次使用，而不是STAR
 # 'Treat string literals as const'
 H79E1F4486D77: '将字符串字面量视为const类型'
 # 'Treat subsequent input files as having type <language>'
-HC2DB15026570: '将后续输入文件视为具有类型<language>'
+HC2DB15026570: '将后续输入文件视为具有类型 <language>'
 # 'Treat usage of null pointers as undefined behavior (default)'
 HEF76E5F5F913: '将空指针的使用视为未定义行为（默认）'
 # 'Treat warnings as errors'
@@ -15919,7 +15919,7 @@ H020E4D562B19: '尝试将调用点的nonnull参数属性传播到被调函数'
 # 'Try to simplify all loads.'
 HBDC33CA86746: '尝试简化所有加载操作'
 # 'Try to vectorize with non-power-of-2 number of elements.'
-H0125A5F09D1C: '尝试使用非2的幂次元素数量进行向量化'
+H0125A5F09D1C: '尝试使用非 2 的幂次元素数量进行向量化'
 # 'Try wider VFs if they enable the use of vector variants'
 H26EA4E292B56: '如果可以使用向量变体，则尝试更宽的VFs'
 # 'Tune debug info for a particular debugger'
@@ -15997,7 +15997,7 @@ HFAB714AB2388: '取消定义 __DEPRECATED 宏'
 # 'Underlying type for type definitions.'
 HE810C104AEFC: '类型定义的底层类型'
 # 'Unexpected vftable component type %0 for component number %1'
-H40151C08E668: '组件号%1的vftable组件类型%0意外'
+H40151C08E668: '组件号 %1 的vftable组件类型 %0 意外'
 # 'Uniformity Analysis'
 H18CD82918982: '统一性分析'
 # 'Unify divergent function exit nodes'
@@ -16019,7 +16019,7 @@ HDFEBDFAE4C78: '与依赖模块一起反编译并停止。'
 # 'Unparse with symbols and stop.'
 H0D9F89477381: '带符号反编译并停止。'
 # 'Unroll factor (affecting 4x32-bit operations) to use for memory operations when lowering memcpy as a loop'
-HE43C43B147A4: '将 memcpy 作为循环展开时，用于内存操作的展开因子（影响4x32位操作）'
+HE43C43B147A4: '将 memcpy 作为循环展开时，用于内存操作的展开因子（影响 4x32位操作）'
 # 'Unroll loops'
 H14907BD20FBA: '展开循环'
 # 'Unroll loops with run-time trip counts'
@@ -16063,15 +16063,15 @@ H9DEC86EE53C8: '使用带有显式目录的 .file 指令'
 # 'Use 16-bit hardware multiplier'
 HE39242B4C409: '使用 16 位硬件乘法器'
 # 'Use 32-bit floating point registers (MIPS only)'
-HE9E46E3267C7: '使用32位浮点寄存器（仅MIPS）'
+HE9E46E3267C7: '使用 32 位浮点寄存器（仅MIPS）'
 # 'Use 32-bit hardware multiplier'
 H48A0735D6EC9: '使用 32 位硬件乘法器'
 # 'Use 32-bit pointers for accessing const/local/shared address spaces'
-HEBB1FFB0999C: '使用32位指针访问const/local/shared地址空间'
+HEBB1FFB0999C: '使用 32 位指针访问const/local/shared地址空间'
 # 'Use 32-bit pointers for accessing const/local/shared address spaces.'
-H1C423A27FAD4: '使用32位指针访问 const/local/shared 地址空间。'
+H1C423A27FAD4: '使用 32 位指针访问 const/local/shared 地址空间。'
 # 'Use 64-bit floating point registers (MIPS only)'
-H4492AB59FFA0: '使用64位浮点寄存器（仅MIPS）'
+H4492AB59FFA0: '使用 64 位浮点寄存器（仅MIPS）'
 # 'Use <dumpfpx> as a prefix to form auxiliary and dump file names'
 H3DFDBA26A67C: '使用 <dumpfpx> 作为辅助和转储文件名的前缀'
 # 'Use <suffix> as the suffix for module files (the default value is `.mod`)'
@@ -16195,7 +16195,7 @@ H600ECC7683CF: '使用完整的推测屏障来强化调用和返回边，而非�
 # 'Use a most-general representation for member pointers'
 H0E7635ED3666: '使用成员指针的最通用表示方法'
 # 'Use a rematerializable pseudoinstruction for 2 instruction constant materialization'
-H3A40020AE1F7: '使用可重新生成的伪指令进行2条指令常量生成'
+H3A40020AE1F7: '使用可重新生成的伪指令进行 2 条指令常量生成'
 # 'Use a signed type for wchar_t'
 H48F702933B27: '为wchar_t使用有符号类型'
 # 'Use a single TBAA tree for all functions and do not use the FIR alias tags pass'
@@ -16221,11 +16221,11 @@ HE1A472AB0CD6: '使用原子获取并增加操作处理函数中的首个计数�
 # 'Use base address specifiers in debug_ranges'
 H16F9B262870C: '在debug_ranges中使用基地址指定符'
 # 'Use base and pass 1 discriminators'
-HFD9F1E3E9AB6: '仅使用基判别器和第1阶段判别器'
+HFD9F1E3E9AB6: '仅使用基判别器和第 1 阶段判别器'
 # 'Use base and pass 1-2 discriminators'
-H8235CCC718A7: '使用基判别器和第1-2阶段判别器'
+H8235CCC718A7: '使用基判别器和第 1-2阶段判别器'
 # 'Use base and pass 1-3 discriminators'
-HF4182389B253: '使用基判别器和第1-3阶段判别器'
+HF4182389B253: '使用基判别器和第 1-3阶段判别器'
 # 'Use base discriminators only'
 HF3EBCD1C0036: '仅使用基判别器'
 # 'Use best guess'
@@ -16247,7 +16247,7 @@ HCBB3CB058AC9: '使用不区分大小写的匹配'
 # 'Use codegen data read from default.cgdata to optimize the binary'
 HEFC973859186: '使用从default.cgdata读取的代码生成数据来优化二进制文件'
 # 'Use codegen data read from the specified <path>.'
-HA873FDC06A7F: '使用从指定<path>读取的代码生成数据'
+HA873FDC06A7F: '使用从指定 <path> 读取的代码生成数据'
 # 'Use colors in detailed AST output. If not set, colors\nwill be used if the terminal connected to\nstandard output supports colors.'
 H3428909B1528: '在详细的AST输出中使用颜色。如果没有设置，则在标准输出连接的终端支持颜色时使用颜色。'
 # 'Use colors in output (default=autodetect)'
@@ -16343,7 +16343,7 @@ H2DC2FFE65115: '使用基于指令引用的 LiveDebugValues 并采用常规 DBG_
 # 'Use instrumentation data for profile-guided optimization'
 H9DC257CB2810: '使用插桩数据进行配置文件引导型优化'
 # 'Use instrumentation data for profile-guided optimization. If pathname is a directory, it reads from <pathname>/default.profdata. Otherwise, it reads from file <pathname>.'
-HDBC8B9085819: '使用插桩数据进行配置文件引导型优化。若路径名是目录则读取<pathname>/default.profdata，否则读取文件<pathname>'
+HDBC8B9085819: '使用插桩数据进行配置文件引导型优化。若路径名是目录则读取 <pathname>/default.profdata，否则读取文件 <pathname>'
 # 'Use instrumented (context sensitive) profile to guide PGO.'
 HF618D20FE941: '使用上下文敏感型插桩剖面引导PGO'
 # 'Use instrumented profile to guide PGO.'
@@ -16483,7 +16483,7 @@ H7751642AFC12: '使用基本块部分配置文件确定热函数的文本段前�
 # 'Use the current working directory as the base directory of compiled module files.'
 HC4A3722E1C1D: '使用当前工作目录作为已编译模块文件的基础目录'
 # 'Use the current working directory as the home directory of module maps specified by -fmodule-map-file=<FILE>'
-H8AE9B0359BD7: '使用当前工作目录作为通过-fmodule-map-file=<FILE>指定的模块映射的主目录'
+H8AE9B0359BD7: '使用当前工作目录作为通过-fmodule-map-file=<FILE> 指定的模块映射的主目录'
 # 'Use the dependence analysis interface'
 HDF3A2E881A47: '使用依赖性分析接口'
 # 'Use the experimental C++ class ABI for classes with virtual tables'
@@ -16515,7 +16515,7 @@ H19B5E5B63186: '在展开__FILE__宏时使用主机平台特定的路径分隔�
 # 'Use the implementation defaults'
 H46CDBE8DC11A: '使用实现默认设置'
 # 'Use the last modification time of <file> as the build session timestamp'
-HC4A79FF67275: '使用<file>的最后修改时间作为构建会话时间戳'
+HC4A79FF67275: '使用 <file> 的最后修改时间作为构建会话时间戳'
 # 'Use the llvm.experimental.noalias.scope.decl intrinsic during inlining.'
 H9063D587CE9C: '在内联时使用llvm.experimental.noalias.scope.decl内建函数。'
 # 'Use the named plugin action in addition to the default action'
@@ -16541,7 +16541,7 @@ H2E61A14D081C: '使用旧的（不正确的）指令延迟计算方法'
 # 'Use the preinliner decisions stored in profile context.'
 HD0A0D412FA60: '使用存储在配置文件上下文中的预内联决策。'
 # 'Use the remappings described in <file> to match the profile data against names in the program'
-HD47D317FB40F: '使用<file>中描述的重映射将分析数据与程序中的名称匹配'
+HD47D317FB40F: '使用 <file> 中描述的重映射将分析数据与程序中的名称匹配'
 # 'Use the scalar evolution interface'
 HD228C1FFC83E: '使用标量进化接口'
 # 'Use the specified contextual profile file'
@@ -16999,7 +16999,7 @@ H16C37A921AE2: '在AMDGPULateCodeGenPrepare中扩展子字节常量地址空间�
 # "Widen the loop induction variables, if possible, so overflow checks won't reject flattening"
 HF84F6515DE2A: '尽可能扩展循环归纳变量，以便溢出检查不会拒绝展平'
 # 'Widen uniform 16-bit instructions to 32-bit in AMDGPUCodeGenPrepare'
-H46D2473C38FB: '在AMDGPUCodeGenPrepare中将统一的16位指令扩展为32位'
+H46D2473C38FB: '在AMDGPUCodeGenPrepare中将统一的 16 位指令扩展为 32 位'
 # 'Windows exception model'
 H86EB91F51633: 'Windows 异常模型'
 # 'With -globals, only dump globals whose name matches the given value'
@@ -17009,13 +17009,13 @@ HA68492B41822: '在PGO模式下，将分析统计信息包含在优化备注中'
 # 'Work around Cortex-A57 Erratum 1742098 (ARM only)'
 H2CF5C8E79954: '绕过 Cortex-A57 Erratum 1742098（仅 ARM）'
 # 'Work around Cortex-A72 Erratum 1655431 (ARM only)'
-HB9954D8E1844: '规避Cortex-A72错误1655431（仅ARM）'
+HB9954D8E1844: '规避Cortex-A72错误 1655431（仅ARM）'
 # 'Work around VLLDM erratum CVE-2021-35465 (ARM only)'
 H6484FD8B0341: '规避VLLDM错误CVE-2021-35465（仅ARM）'
 # 'Work with `--skip-symbolization` or `--unsymbolized-profile` to write/read the offset instead of virtual address.'
 H1CA65028F454: '使用 `--skip-symbolization` 或 `--unsymbolized-profile` 以写入/读取偏移量而非虚地址。'
 # 'Workaround Cortex-A53 erratum 835769 (AArch64 only)'
-H479486F0F64D: '规避Cortex-A53错误835769（仅AArch64）'
+H479486F0F64D: '规避Cortex-A53错误 835769（仅AArch64）'
 # "Wouldn't use segmented stack"
 HF45022A557BC: '不会使用分段栈'
 # 'Write Bitcode'
@@ -17033,7 +17033,7 @@ HF98DECE931FC: '将当前时间写入COFF输出（默认）'
 # 'Write debug info in the new non-intrinsic format. Has no effect if --preserve-input-debuginfo-format=true.'
 H438D54E25242: '以新的非内禀格式生成调试信息。若--preserve-input-debuginfo-format=true时无效。'
 # 'Write depfile output from -MMD, -MD, -MM, or -M to <file>'
-H7F1DEF2B183F: '将来自-MMD、-MD、-MM或-M的依赖文件输出写入<file>'
+H7F1DEF2B183F: '将来自-MMD、-MD、-MM或-M的依赖文件输出写入 <file>'
 # 'Write extracted files to a static archive'
 H167164B5BAE5: '将提取的文件写入静态档案库'
 # 'Write lazy-function executions to a CSV file as (JITDylib, function) pairs'
@@ -17043,7 +17043,7 @@ HCE5CCE000DB8: '优化前将链接的LTO模块写入文件'
 # 'Write merged LTO module to file before CodeGen'
 HD65008F3EA67: '代码生成前将合并的LTO模块写入文件'
 # 'Write minimized bitcode to <file> for the ThinLTO thin link only'
-H675031C72335: '为ThinLTO薄链接仅将最小化比特码写入<file>'
+H675031C72335: '为ThinLTO薄链接仅将最小化比特码写入 <file>'
 # 'Write out individual imports files via InProcessThinLTO. Has no effect unless specified with -thinlto-emit-indexes or -thinlto-distributed-indexes'
 H19E7DA782B06: '通过InProcessThinLTO单独输出导入文件。需与-thinlto-emit-indexes或-thinlto-distributed-indexes选项配合使用才生效'
 # 'Write out individual index and import files for the distributed backend case'
@@ -17055,9 +17055,9 @@ HC401168D9C72: '将输出写为LLVM汇编语言'
 # 'Write output as ThinLTO-ready bitcode'
 H81BE69D83D3F: '将输出写为ThinLTO准备的bitcode'
 # 'Write output to <file>'
-HCABB93CE5040: '将输出写入<file>'
+HCABB93CE5040: '将输出写入 <file>'
 # 'Write output to <file>.'
-HA5CAFFC7A76E: '将输出写入<file>。'
+HA5CAFFC7A76E: '将输出写入 <file>。'
 # 'Write relative block frequency to function summary '
 H61EDFA1BBE67: '将相对块频率写入函数摘要'
 # 'Write summary to given YAML file after running pass'
@@ -17157,13 +17157,13 @@ H8C715EEC26A7: '[输入比特码文件]...'
 # '[no]neon is not accepted as modifier, please use [no]simd instead'
 H34DCBA8F9AA1: '[no]neon不能作为修饰符使用，请改用[no]simd'
 # '\\%0 used with no following hex digits'
-H4ACD9688DA19: '\\%0使用时未跟随十六进制数字'
+H4ACD9688DA19: '\\%0 使用时未跟随十六进制数字'
 # "\\%0 used with no following hex digits; treating as '\\' followed by identifier"
-H34C9A007F8A0: "\\%0使用时未跟随十六进制数字；将视为'\\'后跟标识符"
+H34C9A007F8A0: "\\%0 使用时未跟随十六进制数字；将视为'\\'后跟标识符"
 # '^^ is a reserved operator in OpenCL'
 H0C0A23A57F10: '^^在OpenCL中是保留运算符'
 # '_Atomic cannot be applied to %select{incomplete |array |function |reference |atomic |qualified |sizeless ||integer |}0type %1 %select{|||||||which is not trivially copyable||in C23}0'
-H323CC2CB8E5D: '_Atomic不能应用于%select{不完整 |数组 |函数 |引用 |原子 |限定 |无尺寸 ||整数 |}0类型%1 %select{|||||||无法被简单复制||在C23中}0'
+H323CC2CB8E5D: '_Atomic不能应用于%select{不完整 |数组 |函数 |引用 |原子 |限定 |无尺寸 ||整数 |}0类型 %1 %select{|||||||无法被简单复制||在C23中}0'
 # '_GLOBAL_OFFSET_TABLE_'
 HE310DB69A9CE: '_GLOBAL_OFFSET_TABLE_'
 # '_Pragma takes a parenthesized string literal'
@@ -17189,31 +17189,31 @@ H10FB78A8E9A5: '__block属性不允许在具有变长修改类型的声明中使
 # '__block attribute not allowed, only allowed on local variables'
 HE188099287CD: '__block属性不允许使用，仅允许在局部变量上使用'
 # '__block variable %0 cannot be captured in a %select{lambda expression|captured statement}1'
-HD7DB9752FAAD: '__block变量%0不能被捕获到%select{lambda表达式|被捕获的语句}1中'
+HD7DB9752FAAD: '__block变量 %0 不能被捕获到%select{lambda表达式|被捕获的语句}1中'
 # '__builtin_btf_type_id argument %0 not a constant'
-H48F1BECDC866: '__builtin_btf_type_id参数%0不是常量'
+H48F1BECDC866: '__builtin_btf_type_id参数 %0 不是常量'
 # '__builtin_longjmp is not supported for the current target'
 H53A6EFDFCD17: '__builtin_longjmp不支持当前目标平台'
 # "__builtin_mul_overflow does not support 'signed _BitInt' operands of more than %0 bits"
-H24B9AB05270A: "__builtin_mul_overflow不支持超过%0位的'signed _BitInt'操作数"
+H24B9AB05270A: "__builtin_mul_overflow不支持超过 %0 位的'signed _BitInt'操作数"
 # '__builtin_preserve_enum_value argument %0 invalid'
-H341194DCABD7: '__builtin_preserve_enum_value参数%0无效'
+H341194DCABD7: '__builtin_preserve_enum_value参数 %0 无效'
 # '__builtin_preserve_enum_value argument %0 not a constant'
-HCADD1D27CE0B: '__builtin_preserve_enum_value参数%0不是常量'
+HCADD1D27CE0B: '__builtin_preserve_enum_value参数 %0 不是常量'
 # '__builtin_preserve_field_info argument %0 not a constant'
-HA3DE67421A5E: '__builtin_preserve_field_info参数%0不是常量'
+HA3DE67421A5E: '__builtin_preserve_field_info参数 %0 不是常量'
 # '__builtin_preserve_field_info argument %0 not a field access'
-H153927D1D427: '__builtin_preserve_field_info参数%0不是一个字段访问'
+H153927D1D427: '__builtin_preserve_field_info参数 %0 不是一个字段访问'
 # '__builtin_preserve_type_info argument %0 invalid'
-H92B5B29F2F9A: '__builtin_preserve_type_info参数%0无效'
+H92B5B29F2F9A: '__builtin_preserve_type_info参数 %0 无效'
 # '__builtin_preserve_type_info argument %0 not a constant'
-H57FE08B33075: '__builtin_preserve_type_info参数%0不是常量'
+H57FE08B33075: '__builtin_preserve_type_info参数 %0 不是常量'
 # '__builtin_setjmp is not supported for the current target'
 H08E9B75B93D5: '__builtin_setjmp不支持当前目标平台'
 # '__constant__, __device__, and __managed__ are not allowed on non-static local variables'
 H4A2DC7998EB3: '不允许在非静态局部变量上使用__constant__、__device__和__managed__'
 # '__declspec attribute %0 is not supported'
-H4B7BDD3DADC0: '__declspec属性%0不受支持'
+H4B7BDD3DADC0: '__declspec属性 %0 不受支持'
 # '__declspec attributes must be an identifier or string literal'
 HBBCBBEE3784E: '__declspec属性必须是标识符或字符串字面量'
 # '__final is a GNU extension, consider using C++11 final'
@@ -17235,7 +17235,7 @@ HAD92983EAEB2: '__weak 属性不能指定在字段声明上'
 # '__weak attribute cannot be specified on an automatic variable when ARC is not enabled'
 HC15AE9021482: '__weak 属性在未启用 ARC 时不能指定在自动变量上'
 # '`#pragma const_seg` for section %1 will not apply to %0 due to the presence of a %select{mutable field||non-trivial constructor|non-trivial destructor}2'
-H8811D5F6122A: "'#pragma const_seg'为%1节将不适用于%0，因为存在%select{可变字段||非平凡构造函数|非平凡析构函数}2"
+H8811D5F6122A: "'#pragma const_seg'为 %1 节将不适用于 %0，因为存在%select{可变字段||非平凡构造函数|非平凡析构函数}2"
 # 'a %select{function|block}0 declaration without a prototype is deprecated %select{in all versions of C|}0'
 HA427D7F1B8D9: '没有原型的 %select{函数|块}0 声明在所有 C 版本中已弃用 %select{ | 和在 C23 中不受支持}0'
 # "a %select{pack indexing|'decltype'}0 specifier cannot be used in a declarative nested name specifier"
@@ -17265,25 +17265,25 @@ H65FE428CB516: 'lambda 参数不能隐藏显式捕获的实体'
 # 'a lambda with an explicit object parameter cannot be mutable'
 HF1252DDC6E4B: '具有显式对象参数的 lambda 不能是 mutable'
 # 'a lastprivate variable with incomplete type %0'
-H8324467E21DA: '类型不完整的lastprivate变量%0'
+H8324467E21DA: '类型不完整的lastprivate变量 %0'
 # 'a linear variable with incomplete type %0'
-HE61951ED0B99: '类型不完整的线性变量%0'
+HE61951ED0B99: '类型不完整的线性变量 %0'
 # 'a module can only be re-exported as another top-level module'
 H272C723A8726: '模块只能作为另一个顶层模块重新导出'
 # 'a non-type template parameter cannot have type %0'
-H4D4081CB8796: '非类型模板参数不能具有类型%0'
+H4D4081CB8796: '非类型模板参数不能具有类型 %0'
 # 'a non-type template parameter cannot have type %0 before C++20'
-HEEE0AA3066FD: '在C++20之前，非类型模板参数不能具有类型%0'
+HEEE0AA3066FD: '在C++20之前，非类型模板参数不能具有类型 %0'
 # 'a parameter list without types is only allowed in a function definition'
 H52BB0DED62AC: '不带类型的参数列表仅允许在函数定义中使用'
 # 'a parameter pack may not be accessed at an out of bounds index'
 H3E85B76262B3: '参数包不能在越界索引处被访问'
 # 'a private variable with incomplete type %0'
-H0A7C86E8874A: '类型不完整的私有变量%0'
+H0A7C86E8874A: '类型不完整的私有变量 %0'
 # 'a randomized struct can only be initialized with a designated initializer'
 H4615845B3A9F: '随机化结构体只能使用指定初始化器进行初始化'
 # 'a reduction list item with incomplete type %0'
-H06AA7BC953CB: '类型不完整的规约列表项%0'
+H06AA7BC953CB: '类型不完整的规约列表项 %0'
 # 'a requires expression cannot have an explicit object parameter'
 H86B74E3E67C6: 'requires表达式不能包含显式对象参数'
 # 'a requires expression must contain at least one requirement'
@@ -17299,19 +17299,19 @@ HA1124669302F: 'static_assert声明不能是模板'
 # 'a template argument list is expected after a name prefixed by the template keyword'
 HF4A21ADFAB4E: '模板关键字前缀的名称后面需要跟随模板参数列表'
 # 'a type named %0 is hidden by a declaration in a different namespace'
-H26CC1C864C4C: '名称%0的类型被其他命名空间的声明所隐藏'
+H26CC1C864C4C: '名称 %0 的类型被其他命名空间的声明所隐藏'
 # 'a type specifier is required for all declarations'
 HA2239D7DA67E: '所有声明都需要指定类型说明符'
 # 'a typedef cannot be a template'
 H878607247E5C: 'typedef不能是模板'
 # 'absolute value function %0 given an argument of type %1 but has parameter of type %2 which may cause truncation of value'
-H2B4AC1EEC989: '绝对值函数%0 的参数类型为%2，但传入的实参类型为%1，可能导致数值被截断'
+H2B4AC1EEC989: '绝对值函数 %0 的参数类型为 %2，但传入的实参类型为 %1，可能导致数值被截断'
 # "abstract class is marked '%select{final|sealed}0'"
 H9546D737D23E: "抽象类被标记为'%select{final|sealed}0'"
 # 'access declarations are deprecated; use using declarations instead'
 H3431BA5113E5: '访问声明已弃用；请改用using声明'
 # 'access qualifier %0 cannot be used for %1 %select{|prior to OpenCL C version 2.0 or in version 3.0 and without __opencl_c_read_write_images feature}2'
-HC43552CB1BAC: '访问限定符%0不能用于%1 %select{|prior to OpenCL C version 2.0 or in version 3.0 and without __opencl_c_read_write_images feature}2'
+HC43552CB1BAC: '访问限定符 %0 不能用于 %1 %select{|prior to OpenCL C version 2.0 or in version 3.0 and without __opencl_c_read_write_images feature}2'
 # 'access qualifier can only be used for pipe and image type'
 HCF9598AD42BA: '访问限定符只能用于管道和图像类型'
 # 'access specifier can only have annotation attributes'
@@ -17321,29 +17321,29 @@ H23D01BBD184F: '访问说明符是clang的HLSL扩展'
 # 'accessing a member of an atomic structure or union is undefined behavior'
 H1C0790EC0EC6: '访问原子结构或联合的成员属于未定义行为'
 # 'accessing inaccessible direct base %0 of %1 is a Microsoft extension'
-H76AFA5796E64: '访问%1 的不可访问直接基类%0 是Microsoft的扩展'
+H76AFA5796E64: '访问 %1 的不可访问直接基类 %0 是Microsoft的扩展'
 # "acquiring %0 '%1' requires negative capability '%2'"
-HC095E2CF1B84: "获取%0 '%1' 需要负面能力'%2'"
+HC095E2CF1B84: "获取 %0 '%1' 需要负面能力 '%2'"
 # "acquiring %0 '%1' that is already held"
-H4DA573668147: "尝试获取已持有的%0 '%1'"
+H4DA573668147: "尝试获取已持有的 %0 '%1'"
 # 'action %0 not compiled in'
-HA82E8BAC3ED2: '未编译动作%0'
+HA82E8BAC3ED2: '未编译动作 %0'
 # "active '%0' clause defined here"
-H5264E053D9D8: "此处定义了活动'%0'子句"
+H5264E053D9D8: "此处定义了活动 '%0' 子句"
 # 'add \'__arm_preserves("za")\' to the callee if it preserves ZA'
 HD939B5A83F36: '如果被调用函数保留ZA寄存器，请添加\'__arm_preserves("za")\''
 # "add 'constexpr'"
-H48500D7C1CF8: "添加'constexpr'"
+H48500D7C1CF8: "添加 'constexpr'"
 # "add 'export' here if this is intended to be a module interface unit"
-H8499B2C3202C: "如果这是模块接口单元，请在此添加'export'"
+H8499B2C3202C: "如果这是模块接口单元，请在此添加 'export'"
 # "add 'module;' to the start of the file to introduce a global module fragment"
 H1399A9153C66: "在文件开头添加'module;'以引入全局模块片段"
 # "add 'typename' to treat this using declaration as a type"
-H2514B140BEE5: "添加'typename'以将此using声明视为类型"
+H2514B140BEE5: "添加 'typename' 以将此using声明视为类型"
 # "add 'u8' prefix to form a 'char8_t' string literal"
-H8C73CF0B8333: "添加'u8'前缀以形成char8_t字符串字面量"
+H8C73CF0B8333: "添加 'u8' 前缀以形成char8_t字符串字面量"
 # "add 'void' to the parameter list to turn an old-style K&R function declaration into a prototype"
-H460C61046151: "在参数列表中添加'void'将旧式K&R函数声明转换为原型"
+H460C61046151: "在参数列表中添加 'void' 将旧式K&R函数声明转换为原型"
 # "add a '@synthesize' directive"
 H11A117C94448: "添加 '@synthesize' 指令"
 # 'add a deduction guide to suppress this warning'
@@ -17407,37 +17407,37 @@ HED971913A5AB: '原子操作的地址参数必须是指向_Atomic类型的指针
 # 'address argument to atomic operation must be a pointer to a trivially-copyable type (%0 invalid)'
 H0F2B276FBFF5: '原子操作的地址参数必须是指向平凡可复制类型的指针（%0 无效）'
 # 'address argument to atomic operation must be a pointer to non-%select{const|constant}0 _Atomic type (%1 invalid)'
-H77D9C30AD097: '原子操作的地址参数必须是指向非%select{const|constant}0 _Atomic类型的指针（%1 无效）'
+H77D9C30AD097: '原子操作的地址参数必须是指向非 %select{const|constant}0 _Atomic类型的指针（%1 无效）'
 # 'address argument to atomic operation must be a pointer to non-const type (%0 invalid)'
 HA961ACF648B8: '地址参数必须是指向非const类型的指针（%0 无效）'
 # 'address argument to load or store exclusive builtin must be a pointer to 1,2,4 or 8 byte type (%0 invalid)'
-H7473631C7DCE: '加载或存储内建函数的地址参数必须是指向1、2、4或8字节类型的指针（%0 无效）'
+H7473631C7DCE: '加载或存储内建函数的地址参数必须是指向 1、2、4或 8 字节类型的指针（%0 无效）'
 # 'address argument to nontemporal builtin must be a pointer (%0 invalid)'
 H15C0E2A98779: '非临时性内建函数的地址参数必须是指向指针（%0 无效）'
 # 'address argument to nontemporal builtin must be a pointer to integer, float, pointer, or a vector of such types (%0 invalid)'
 H411242986562: '非临时性内建函数的地址参数必须是指向整型、浮点型、指针或此类类型的向量的指针（%0 无效）'
 # "address of %select{'%1'|function '%1'|array '%1'|lambda function pointer conversion operator}0 will always evaluate to 'true'"
-H17F3EBE2635E: "%select{'%1'函数|函数'%1'|数组'%1'|lambda函数指针转换运算符}0的地址始终会评估为'true'"
+H17F3EBE2635E: "%select{'%1' 函数|函数 '%1'|数组 '%1'|lambda函数指针转换运算符}0的地址始终会评估为 'true'"
 # 'address of %select{bit-field|vector element|property expression|register variable|matrix element}0 requested'
 HD8B1334D046A: '请求了%select{位段|向量元素|属性表达式|寄存器变量|矩阵元素}0的地址'
 # "address of non-static constexpr variable %0 may differ on each invocation of the enclosing function; add 'static' to give it a constant address"
-HE51DD27041F6: "非静态constexpr变量%0的地址在每次调用包含函数时可能不同；添加'static'使其具有常量地址"
+HE51DD27041F6: "非静态constexpr变量 %0 的地址在每次调用包含函数时可能不同；添加 'static' 使其具有常量地址"
 # 'address of overloaded function %0 cannot be cast to type %1'
-H358904EBF6FD: '重载函数%0的地址不能被转换为类型%1'
+H358904EBF6FD: '重载函数 %0 的地址不能被转换为类型 %1'
 # 'address of overloaded function %0 cannot be converted to type %1'
-HCCA08BC04209: '重载函数%0的地址无法转换为类型%1'
+HCCA08BC04209: '重载函数 %0 的地址无法转换为类型 %1'
 # 'address of overloaded function %0 cannot be static_cast to type %1'
-HE4591559B0BB: '重载函数%0的地址不能被static_cast转换为类型%1'
+HE4591559B0BB: '重载函数 %0 的地址不能被static_cast转换为类型 %1'
 # 'address of overloaded function %0 does not match required type %1'
-H11264D1F1C79: '重载函数%0的地址与所需类型%1不匹配'
+H11264D1F1C79: '重载函数 %0 的地址与所需类型 %1 不匹配'
 # 'address of overloaded function %0 is ambiguous'
-H33C49268724E: '重载函数%0的地址存在歧义'
+H33C49268724E: '重载函数 %0 的地址存在歧义'
 # 'address space is larger than the maximum supported (%0)'
 HFA6456E815BE: '地址空间大于最大支持值（%0）'
 # 'address space is negative'
 H7DA3DAA44B98: '地址空间为负数'
 # 'address taken in non-type template argument for template parameter of reference type %0'
-HD465BC48688F: '引用类型模板参数%0的非常量模板实参中获取了地址'
+HD465BC48688F: '引用类型模板参数 %0 的非常量模板实参中获取了地址'
 # 'address-of operator cannot be applied to a call to a function with unknown return type'
 HA9D761CAF77E: '无法对返回类型未知的函数调用应用地址取用运算符（address-of operator）'
 # 'adjust block counts based on outgoing branch counts'
@@ -17447,13 +17447,13 @@ H14DEF224A29B: '根据基本块执行计数调整函数计数'
 # 'adjust function profile after inlining'
 HDCFC372259BA: '内联后调整函数概要'
 # "after modifying system headers, please delete the module cache at '%0'"
-H01FFB29D96B3: "修改系统头文件后，请删除位于'%0'的模块缓存"
+H01FFB29D96B3: "修改系统头文件后，请删除位于 '%0' 的模块缓存"
 # 'aggregate basic samples (without LBR info)'
 H9B9419C851BC: '聚合基本样本（无LBR信息）'
 # 'aggregate initialization of type %0 from a parenthesized list of values is a C++20 extension'
-H6B5CF381E65A: '使用带括号的值列表对类型%0进行聚合初始化是C++20扩展'
+H6B5CF381E65A: '使用带括号的值列表对类型 %0 进行聚合初始化是C++20扩展'
 # 'aggregate initialization of type %0 with user-declared constructors is incompatible with C++20'
-HC24621DDDD5F: '具有用户声明构造函数的类型%0的聚合初始化与C++20不兼容'
+HC24621DDDD5F: '具有用户声明构造函数的类型 %0 的聚合初始化与C++20不兼容'
 # 'aggressive strategy'
 H5CB7E66C0F79: '激进策略'
 # 'aggressively inline everything'
@@ -17473,7 +17473,7 @@ HE9649A76CF28: '别名声明是C++11扩展'
 # 'alias declarations are incompatible with C++98'
 H47305448BB21: '别名声明与C++98标准不兼容'
 # 'alias definition of %0 after tentative definition'
-HBC2E292F4F78: '在尝试定义之后对%0进行别名声明'
+HBC2E292F4F78: '在尝试定义之后对 %0 进行别名声明'
 # 'alias for --icp-jump-tables-targets'
 H3295D8EF4BCC: '--icp-jump-tables-targets的别名'
 # 'alias for --indirect-call-promotion-calls-topn'
@@ -17505,19 +17505,19 @@ H546676202A2D: '对齐基本块'
 # 'align functions at a given value (relocation mode)'
 HA06778A68136: '在给定值处对齐函数（重定位模式）'
 # 'align only blocks with frequency larger than containing function execution frequency specified in percent. E.g. 1000 means aligning blocks that are 10 times more frequently executed than the containing function.'
-H9CD01CD0B966: '仅对执行频率高于包含函数指定百分比的基本块进行对齐。例如，1000表示对齐那些执行频率是包含函数10倍的基本块。'
+H9CD01CD0B966: '仅对执行频率高于包含函数指定百分比的基本块进行对齐。例如，1000表示对齐那些执行频率是包含函数 10 倍的基本块。'
 # "aligned %select{allocation|deallocation}0 function of type '%1' is %select{only|not}4 available on %2%select{ %3 or newer|}4"
-H9703DDF7875E: '类型为%1的对齐%select{分配|释放}0函数在%2%select{ %3或更高版本|}4%select{仅|不}4可用'
+H9703DDF7875E: '类型为 %1 的对齐%select{分配|释放}0函数在 %2%select{ %3 或更高版本|}4%select{仅|不}4可用'
 # 'aligned clause will be ignored because the requested alignment is not a power of 2'
-HC3A503B9038C: '将忽略对齐子句，因为请求的对齐值不是2的幂次'
+HC3A503B9038C: '将忽略对齐子句，因为请求的对齐值不是 2 的幂次'
 # 'alignment (%0) of thread-local variable %1 is greater than the maximum supported alignment (%2) for a thread-local variable on this target'
-H9951DC0F93CA: '目标平台上线程局部变量的最大支持对齐值为%2，但线程局部变量%1的对齐值(%0)超过了该限制'
+H9951DC0F93CA: '目标平台上线程局部变量的最大支持对齐值为 %2，但线程局部变量 %1 的对齐值(%0)超过了该限制'
 # "alignment is not a power of 2 in '%0'"
-HB7B2FF437212: "在'%0'中对齐值不是2的幂次"
+HB7B2FF437212: "在 '%0' 中对齐值不是 2 的幂次"
 # 'alignment of .text section'
 H7D89ABD80F0F: '.text 分区的对齐方式'
 # 'alignment of 16 bytes for a struct member is not binary compatible with IBM XL C/C++ for AIX 16.1.0 or older'
-H79A5A88D17D7: '结构体成员的16字节对齐方式与AIX 16.1.0或更早版本的IBM XL C/C++不兼容'
+H79A5A88D17D7: '结构体成员的 16 字节对齐方式与AIX 16.1.0或更早版本的IBM XL C/C++不兼容'
 # 'alignof expressions are incompatible with C++98'
 H5F21C338A420: 'alignof表达式与C++98不兼容'
 # 'all paths through this function will call itself'
@@ -17525,29 +17525,29 @@ H40E0BDFB048F: '通过此函数的所有路径都将调用自身'
 # "allocate directive specifies %select{default|'%1'}0 allocator while previously used %select{default|'%3'}2"
 HC639234B285B: "分配指令指定了%select{默认|'%1'}0分配器，而之前使用了%select{默认|'%3'}2"
 # 'allocated size %0 is not a multiple of size %1 of element type %2'
-H279696362CDE: '分配的大小%0不是元素类型%2大小%1的倍数'
+H279696362CDE: '分配的大小 %0 不是元素类型 %2 大小 %1 的倍数'
 # "allocated with 'new%select{[]|}0' here"
 H1AA44259E5AA: "此处使用'new%select{[]|}0'分配"
 # 'allocating an object of abstract class type %0'
-H07CDBA71F9A5: '尝试分配抽象类类型%0的对象'
+H07CDBA71F9A5: '尝试分配抽象类类型 %0 的对象'
 # 'allocation of %select{incomplete|sizeless}0 type %1'
-HD40A80B2E772: '分配了%select{不完整|无大小}0类型%1'
+HD40A80B2E772: '分配了%select{不完整|无大小}0类型 %1'
 # 'allocation performed here was not deallocated%plural{0:|: (along with %0 other memory leak%s0)}0'
 H04A2F923450C: '此处分配的内存未被释放%plural{0:|:（以及 %0 其他内存泄漏%s0）}0'
 # "allocator must be specified in the 'uses_allocators' clause"
-H6A6EDC2E2834: "必须在'uses_allocators'子句中指定分配器"
+H6A6EDC2E2834: "必须在 'uses_allocators' 子句中指定分配器"
 # "allocator with the 'thread' trait access has unspecified behavior on '%0' directive"
-HDC686C65C1AA: "'%0'指令具有'thread'特性时分配器行为未定义"
+HDC686C65C1AA: "'%0' 指令具有 'thread' 特性时分配器行为未定义"
 # "allocators used in 'uses_allocators' clause cannot appear in other data-sharing or data-mapping attribute clauses"
-H3D9F65EE1204: "'uses_allocators'子句中使用的分配器不能出现在其他数据共享或数据映射属性子句中"
+H3D9F65EE1204: "'uses_allocators' 子句中使用的分配器不能出现在其他数据共享或数据映射属性子句中"
 # 'allow processing of stripped binaries'
 H7C4A1D362E89: '允许处理剥离的二进制文件'
 # 'allow to snippet generator to generate at most that many configs'
 H8A45202314E0: '允许代码片段生成器生成最多指定数量的配置'
 # "allowable client missing from %0: '%1'"
-H1792F22F4481: "%0中缺少允许的客户端：'%1'"
+H1792F22F4481: "%0 中缺少允许的客户端：'%1'"
 # "allowable clients do not match: '%0' (provided) vs '%1' (found)"
-H73C7C1046F8D: "允许的客户端不匹配：'%0'（提供）与'%1'（找到）"
+H73C7C1046F8D: "允许的客户端不匹配：'%0'（提供）与 '%1'（找到）"
 # "already inside '#pragma clang arc_cf_code_audited'"
 H490BE327E34C: "已在'#pragma clang arc_cf_code_audited'作用域内"
 # "already inside '#pragma clang assume_nonnull'"
@@ -17631,7 +17631,7 @@ H75A07B3C23F5: '显式对象参数不能出现在%select{构造函数|析构函�
 # 'an explicit object parameter cannot appear in a %select{static|virtual|non-member}0 %select{function|lambda}1'
 HF679F4DDA00F: '显式对象参数不能出现在%select{静态|虚|非成员}0 %select{函数|lambda}1中'
 # "an explicitly-defaulted %select{copy|move}0 assignment operator may not have 'const'%select{, 'constexpr'|}1 or 'volatile' qualifiers"
-HC61798127DDC: "显式默认的%select{复制|移动}0赋值运算符不能带有'const'%select{, 'constexpr'|}1或'volatile'限定符"
+HC61798127DDC: "显式默认的%select{复制|移动}0赋值运算符不能带有 'const'%select{, 'constexpr'|}1或 'volatile' 限定符"
 # 'an explicitly-defaulted %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}0 cannot be variadic'
 HE8693CE23671: '显式默认的%select{默认构造函数|拷贝构造函数|移动构造函数|拷贝赋值运算符|移动赋值运算符|析构函数}0不能是可变参数'
 # 'an explicitly-defaulted %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}0 cannot have default arguments'
@@ -17645,9 +17645,9 @@ H7294D821E112: '未求值的字符串字面量不能是用户自定义字面量'
 # 'an unevaluated string literal cannot have an encoding prefix'
 HFC8ECFF25368: '未求值的字符串字面量不能带有编码前缀'
 # "analyzer constraint manager 'z3' is only available if LLVM was built with -DLLVM_ENABLE_Z3_SOLVER=ON"
-H156EC948497C: "分析器约束管理器'z3'仅当LLVM用-DLLVM_ENABLE_Z3_SOLVER=ON编译时可用"
+H156EC948497C: "分析器约束管理器 'z3' 仅当LLVM用-DLLVM_ENABLE_Z3_SOLVER=ON编译时可用"
 # "analyzer-config option '%0' has a key but no value"
-H5FB74FAA9043: "分析器配置选项'%0'有键但无值"
+H5FB74FAA9043: "分析器配置选项 '%0' 有键但无值"
 # "analyzer-config option '%0' should contain only one '='"
 HC4A2A9D28ED1: "'analyzer-config'选项 '%0' 应该只包含一个'='"
 # 'angle brackets contain both a %select{type|protocol}0 (%1) and a %select{protocol|type}0 (%2)'
@@ -17655,7 +17655,7 @@ H6C951E1E776A: '尖括号同时包含了一个%select{类型|协议}0（%1）和
 # 'angle-bracketed include <%0> cannot be aliased to double-quoted include "%1"'
 H6DC7B4C3CA94: '尖括号包含的头文件<%0>不能被别名为双引号包含的头文件“%1”'
 # 'annotate %select{%1|anonymous %1}0 with an availability attribute to silence this warning'
-H1B283AC48C5C: '为%select{%1|匿名%1}0添加一个可用性属性以消除此警告'
+H1B283AC48C5C: '为%select{%1|匿名 %1}0添加一个可用性属性以消除此警告'
 # "annotating the 'if %select{constexpr|consteval}0' statement here"
 HE2CC6E318B60: "在此处注释'if %select{constexpr|consteval}0'语句"
 # 'annotating the infinite loop here'
@@ -17669,7 +17669,7 @@ HFF401250AB40: '匿名%select{结构体|联合}0是Microsoft扩展'
 # 'anonymous %select{struct|union}0 can only contain non-static data members'
 H31B46249C247: '匿名%select{结构体|联合}0只能包含非静态数据成员'
 # "anonymous %select{struct|union}0 cannot be '%1'"
-HF58A2EC09112: "匿名%select{结构体|联合}0不能是'%1'"
+HF58A2EC09112: "匿名%select{结构体|联合}0不能是 '%1'"
 # 'anonymous %select{struct|union}0 cannot contain a %select{private|protected}1 data member'
 HA1E08BDB3E65: '匿名%select{结构体|联合}0不能包含%select{私有|受保护}1数据成员'
 # 'anonymous bit-field cannot have a default member initializer'
@@ -17679,15 +17679,15 @@ H6D3AB87CE804: '匿名位字段不能有限定符'
 # 'anonymous bit-field has negative width (%0)'
 HFC2DC27C32DA: '匿名位字段具有负宽度（%0）'
 # 'anonymous bit-field has non-integral type %0'
-HCAEF6F6FBF6D: '匿名位字段具有非整数类型%0'
+HCAEF6F6FBF6D: '匿名位字段具有非整数类型 %0'
 # 'anonymous namespace begins here'
 H131F22F8B917: '匿名命名空间在此处开始'
 # 'anonymous namespaces cannot be exported'
 HD9CECEFAA4C6: '匿名命名空间无法被导出'
 # 'anonymous non-C-compatible type given name for linkage purposes by %select{typedef|alias}0 declaration after its linkage was computed; add a tag name here to establish linkage prior to definition'
-H4E07DEF6B927: '匿名的非C兼容类型通过%select{typedef|alias}0声明为链接目的命名；在定义之前添加一个标签名此处以建立链接'
+H4E07DEF6B927: '匿名的非C兼容类型通过 %select{typedef|alias}0 声明为链接目的命名；在定义之前添加一个标签名此处以建立链接'
 # 'anonymous non-C-compatible type given name for linkage purposes by %select{typedef|alias}0 declaration; add a tag name here'
-H5233EEEB5041: '匿名的非C兼容类型通过%select{typedef|alias}0声明为链接目的命名；此处添加一个标签名'
+H5233EEEB5041: '匿名的非C兼容类型通过 %select{typedef|alias}0 声明为链接目的命名；此处添加一个标签名'
 # 'anonymous property is not supported'
 HBEA1F99304A4: '匿名属性不受支持'
 # 'anonymous structs are a C11 extension'
@@ -17701,43 +17701,43 @@ H7518631D05B0: '类作用域中的匿名联合不能有存储说明符'
 # 'anonymous unions are a C11 extension'
 HDFE9E6E6FE09: '匿名联合是C11的扩展'
 # "anonymous unions at namespace or global scope must be declared 'static'"
-H3FE1C37A16FD: "命名空间或全局作用域中的匿名联合必须声明为'static'"
+H3FE1C37A16FD: "命名空间或全局作用域中的匿名联合必须声明为 'static'"
 # 'append PID to saved profile file name (default: false)'
 HFDE8729E14B7: '将PID附加到保存的配置文件名称（默认：false）'
 # "application of '%select{alignof|sizeof}1' to interface %0 is not supported on this architecture and platform"
-H7F7758BA5771: "对接口%0应用'%select{alignof|sizeof}1'在此架构和平台上不受支持"
+H7F7758BA5771: "对接口 %0 应用'%select{alignof|sizeof}1'在此架构和平台上不受支持"
 # 'apply additional analysis to remove stores (experimental)'
 H0FDD6748AD67: '应用额外分析以移除存储（实验性）'
 # 'apply unchecked-ld-st when the target is definitely within range'
 H75826487B47E: '当目标肯定在范围内时应用 unchecked-ld-st'
 # 'applying attribute %0 to a declaration is deprecated; apply it to the type instead'
-H1F568760A093: '将属性%0应用于声明已被弃用；请将其应用于类型'
+H1F568760A093: '将属性 %0 应用于声明已被弃用；请将其应用于类型'
 # "architecture '%0' does not support '%1' execution mode"
-H341F2DD78603: "架构'%0'不支持执行模式'%1'"
+H341F2DD78603: "架构 '%0' 不支持执行模式 '%1'"
 # "architectures do not match: '%0' (provided) vs '%1' (found)"
-H1E0CF63FB0D6: "架构不匹配：'%0'（指定的架构）与'%1'（检测到的架构）"
+H1E0CF63FB0D6: "架构不匹配：'%0'（指定的架构）与 '%1'（检测到的架构）"
 # 'architectures of the coverage mapping binaries'
 HC4DF8B556ACB: '覆盖映射二进制文件的架构'
 # 'argument %0 is not an unqualified class type'
-H5DB23C0A38DF: '参数%0不是未限定的类类型'
+H5DB23C0A38DF: '参数 %0 不是未限定的类类型'
 # 'argument %0 must be constant integer 1 or -1'
-H4812A4DC04E0: '参数%0必须是常量整数1或-1'
+H4812A4DC04E0: '参数 %0 必须是常量整数 1 或-1'
 # 'argument %0 of type %1 with mismatched bound'
-HDE368B7DDAF1: '类型%1的参数%0具有不匹配的边界'
+HDE368B7DDAF1: '类型 %1 的参数 %0 具有不匹配的边界'
 # 'argument %0 to %1 must be a 2-bit unsigned literal (i.e. 0, 1, 2 or 3)'
-HD2DEDD810BB8: '传递给%1的参数%0必须是2位无符号字面量（即0、1、2或3）'
+HD2DEDD810BB8: '传递给 %1 的参数 %0 必须是 2 位无符号字面量（即 0、1、2或 3）'
 # "argument %0 to 'preferred_name' attribute is not a typedef for a specialization of %1"
-H873B3444BA19: "'preferred_name'属性的参数%0不是%1的特化类型的typedef"
+H873B3444BA19: "'preferred_name' 属性的参数 %0 不是 %1 的特化类型的typedef"
 # 'argument %0 value should represent a contiguous bit field'
-H004B84FF9E91: '参数%0的值应表示连续的位字段'
+H004B84FF9E91: '参数 %0 的值应表示连续的位字段'
 # "argument '%0' is deprecated%select{|, use '%2' instead}1"
 H549CE16A2419: '参数‘%0’已弃用%select{|，请改用‘%2’}1'
 # "argument '%0' is deprecated, %1"
 HFF8BB35E32E8: '参数‘%0’已弃用，%1'
 # "argument '%0' requires profile-guided optimization information"
-HE99C51820EC7: "参数'%0'需要配置文件引导型优化信息"
+HE99C51820EC7: "参数 '%0' 需要配置文件引导型优化信息"
 # "argument '%select{X|Y|Z}0' to numthreads attribute cannot exceed %1"
-H50D13BA82E10: 'numthreads属性的参数%select{X|Y|Z}0不能超过%1'
+H50D13BA82E10: 'numthreads属性的参数 %select{X|Y|Z}0 不能超过 %1'
 # "argument '-Ofast' is deprecated; use '-O3 -ffast-math -fstack-arrays' for the same behavior, or '-O3 -fstack-arrays' to enable only conforming optimizations"
 HBBD3AEA705D1: "参数 '-Ofast' 已弃用；请改用 '-O3 -ffast-math -fstack-arrays' 实现相同行为，或使用 '-O3 -fstack-arrays' 仅启用符合标准的优化"
 # "argument '-Ofast' is deprecated; use '-O3 -ffast-math' for the same behavior, or '-O3' to enable only conforming optimizations"
@@ -17785,15 +17785,15 @@ HBE77A0717D85: "CUDA C/C++ 中 '#pragma unroll' 的参数不应加括号"
 # "argument to '%0' clause must be a %select{non-negative|strictly positive}1 integer value"
 H93740956E9C9: '%0 子句的参数必须是%select{非负|严格正}1整数值'
 # "argument to '%0' is missing (expected %1 value%s1)"
-HEA17C0D34C2C: '%0 的参数缺失（应为%1值%s1）'
+HEA17C0D34C2C: '%0 的参数缺失（应为 %1 值%s1）'
 # "argument to 'gang' clause dimension must be %select{a constant expression|1, 2, or 3: evaluated to %1}0"
-H970EFD35B5B1: "'gang' 子句的维度参数必须是%select{常量表达式|1、2或3：计算得到%1}0"
+H970EFD35B5B1: "'gang' 子句的维度参数必须是%select{常量表达式|1、2或 3：计算得到 %1}0"
 # "argument to 'operator<=>' %select{cannot be narrowed from type %1 to %2|evaluates to %1, which cannot be narrowed to type %2}0"
-HAE154D16E74A: 'operator<=> 的参数%select{不能将类型%1转换为更窄的类型%2|计算结果为类型%1，不能转换为更窄的类型%2}0'
+HAE154D16E74A: 'operator<=> 的参数%select{不能将类型 %1 转换为更窄的类型 %2|计算结果为类型 %1，不能转换为更窄的类型 %2}0'
 # "argument to 'sizeof' in %0 call is the same pointer type %1 as the %select{destination|source}2; expected %3 or an explicit length"
-H35BB4F2B1E83: '在%0 调用中的sizeof参数与%select{目标|源}2的指针类型%1相同；期望%3或显式长度'
+H35BB4F2B1E83: '在 %0 调用中的sizeof参数与%select{目标|源}2的指针类型 %1 相同；期望 %3 或显式长度'
 # 'argument to __builtin_longjmp must be a constant 1'
-HE5F0C7B028D7: '__builtin_longjmp 的参数必须是常量1'
+HE5F0C7B028D7: '__builtin_longjmp 的参数必须是常量 1'
 # 'argument to __builtin_verbose_trap must %select{be a pointer to a constant string|not contain $}0'
 HADE59279CC5F: '__builtin_verbose_trap 的参数必须%select{是指向常量字符串的指针|不包含$}0'
 # "argument to atomic builtin of type '_BitInt' is not supported"
@@ -17801,61 +17801,61 @@ HB64B7DD3183B: '_BitInt 类型的原子内建函数参数不受支持'
 # 'argument to ptrauth_sign_constant must refer to a global variable or function'
 HC3F35A99F4A4: 'ptrauth_sign_constant 的参数必须引用全局变量或函数'
 # "argument type %0 doesn't match specified %1 type tag %select{that requires %3|}2"
-H3BF4CB740E62: '参数类型%0 与指定的%1类型标签%select{需要%3|}2不匹配'
+H3BF4CB740E62: '参数类型 %0 与指定的 %1 类型标签%select{需要 %3|}2不匹配'
 # 'argument type %0 is incomplete'
-HAB2CACB541C5: '参数类型%0 是不完整的'
+HAB2CACB541C5: '参数类型 %0 是不完整的'
 # 'argument type %0 is not a real floating point type'
-H00F62D550C19: '参数类型%0 不是真实的浮点类型'
+H00F62D550C19: '参数类型 %0 不是真实的浮点类型'
 # "argument unused during compilation: '%0'"
 HA1050D6985F0: "编译期间未使用的参数：'%0'"
 # 'argument value %0 is outside the valid range [%1, %2]'
-HB96DE207738E: '参数值%0 超出有效范围[%1, %2]'
+HB96DE207738E: '参数值 %0 超出有效范围[%1, %2]'
 # 'argument value %0 will result in undefined behaviour'
-H274A3E69FEAC: '参数值%0 将导致未定义行为'
+H274A3E69FEAC: '参数值 %0 将导致未定义行为'
 # 'arguments are of different types%diff{ ($ vs $)|}0,1'
 HE1B214C1584C: '参数类型不同%diff{ ($ vs $)|}0,1'
 # "arguments of '#pragma omp %0' cannot be of reference type %1"
-HF10A8B7C87FB: '#pragma omp %0 的参数不能是引用类型%1'
+HF10A8B7C87FB: '#pragma omp %0 的参数不能是引用类型 %1'
 # "arguments of '#pragma omp %0' must have %select{global storage|static storage duration}1"
 H6F3268D97079: '#pragma omp %0 的参数必须具有%select{全局存储|静态存储持续时间}1'
 # "arguments of OpenMP clause '%0' for 'min' or 'max' must be of %select{scalar|arithmetic}1 type"
-HCCCABB9B57BC: "'min'或'max'的OpenMP子句'%0'的参数必须是%select{标量|算术}1类型"
+HCCCABB9B57BC: "'min' 或 'max' 的OpenMP子句 '%0' 的参数必须是%select{标量|算术}1类型"
 # "arguments of OpenMP clause '%0' in '#pragma omp %2' directive cannot be of variably-modified type %1"
-HCB3B0D762A59: "在'#pragma omp %2'指令中，OpenMP子句'%0'的参数不能是可变修改类型%1"
+HCB3B0D762A59: "在'#pragma omp %2'指令中，OpenMP子句 '%0' 的参数不能是可变修改类型 %1"
 # "arguments of OpenMP clause '%0' with bitwise operators cannot be of floating type"
-H7CE92A7D3184: "带有位运算符的OpenMP子句'%0'的参数不能是浮点类型"
+H7CE92A7D3184: "带有位运算符的OpenMP子句 '%0' 的参数不能是浮点类型"
 # 'arguments to __annotation must be wide string constants'
 H123CD58AB412: '__annotation的参数必须是宽字符串常量'
 # "arithmetic involving unrelated objects '%0' and '%1' has unspecified value"
-H620CC2CD5C97: "涉及无关对象'%0'和'%1'的算术运算具有未指定的值"
+H620CC2CD5C97: "涉及无关对象 '%0' 和 '%1' 的算术运算具有未指定的值"
 # 'arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension'
 HBFE8701B60FF: '将空指针视为整数到指针转换的算术运算是一个GNU扩展'
 # 'arithmetic on a pointer to %select{an incomplete|sizeless}0 type %1'
-H81F0120B9A69: '对%select{不完整|无大小}0类型%1的指针进行算术运算'
+H81F0120B9A69: '对%select{不完整|无大小}0类型 %1 的指针进行算术运算'
 # 'arithmetic on addresses of potentially overlapping literals has unspecified value'
 H84236342B8A2: '对可能重叠的字面量地址进行算术运算具有未指定的值'
 # 'arithmetic on pointer to interface %0, which is not a constant size for this architecture and platform'
-H9C9B045DAD4E: '对指针进行算术运算，该指针指向接口%0，而该接口在此架构和平台上不是固定大小'
+H9C9B045DAD4E: '对指针进行算术运算，该指针指向接口 %0，而该接口在此架构和平台上不是固定大小'
 # 'arithmetic on%select{ a|}0 pointer%select{|s}0 to void'
 H58D09A5B5E7F: '对%select{一个|}0 void%select{|s}0指针进行算术运算'
 # 'arithmetic on%select{ a|}0 pointer%select{|s}0 to void is a GNU extension'
 HB4BACD25A732: '对%select{一个|}0 void%select{|s}0指针进行算术运算是一个GNU扩展'
 # 'arithmetic on%select{ a|}0 pointer%select{|s}0 to%select{ the|}2 function type%select{|s}2 %1%select{| and %3}2'
-H1FD9A476B84E: '对%select{一个|}0指向%select{该|}2函数类型%select{|s}2 %1%select{|和%3}2的%select{|s}0指针进行算术运算'
+H1FD9A476B84E: '对%select{一个|}0指向%select{该|}2函数类型%select{|s}2 %1%select{|和 %3}2的%select{|s}0指针进行算术运算'
 # 'arithmetic on%select{ a|}0 pointer%select{|s}0 to%select{ the|}2 function type%select{|s}2 %1%select{| and %3}2 is a GNU extension'
-H94DE585BA344: '对%select{一个|}0指向%select{该|}2函数类型%select{|s}2 %1%select{|和%3}2的%select{|s}0指针进行算术运算是一个GNU扩展'
+H94DE585BA344: '对%select{一个|}0指向%select{该|}2函数类型%select{|s}2 %1%select{|和 %3}2的%select{|s}0指针进行算术运算是一个GNU扩展'
 # 'array %0 declared here'
-HD94D934376D0: '此处声明的数组%0'
+HD94D934376D0: '此处声明的数组 %0'
 # "array 'new' cannot have initialization arguments"
-H5708CAC5AB7B: "数组'new'不能有初始化参数"
+H5708CAC5AB7B: "数组 'new' 不能有初始化参数"
 # 'array argument is too small; %select{contains %0 elements|is of size %0}2, callee requires at least %1'
-H8A66ED6F9EE3: '数组参数太小；%select{包含%0个元素|大小为%0}2，被调用者至少需要%1'
+H8A66ED6F9EE3: '数组参数太小；%select{包含 %0 个元素|大小为 %0}2，被调用者至少需要 %1'
 # 'array backing %select{initializer list subobject of the allocated object|the allocated initializer list}0 will be destroyed at the end of the full-expression'
 H7FC8ADC3508D: '%select{分配对象的已分配初始化列表|初始化列表子对象}0的数组后端将在完整表达式结束时被销毁'
 # 'array bound cannot be deduced from a default member initializer'
 H6E170EF5C23C: '无法从默认成员初始化器推导出数组边界'
 # 'array designator cannot initialize non-array type %0'
-H0BB48B48E929: '数组指定符无法初始化非数组类型%0'
+H0BB48B48E929: '数组指定符无法初始化非数组类型 %0'
 # 'array designator index (%0) exceeds array bounds (%1)'
 HF8952A3F237D: '数组指定符索引(%0)超出数组边界(%1)'
 # 'array designator range [%0, %1] is empty'
@@ -17865,23 +17865,23 @@ H02A61A71BE5A: "数组指定符值 '%0' 为负数"
 # 'array designators are a C99 extension'
 H09604E6E8FF6: '数组指定符是C99的扩展'
 # 'array has %select{incomplete|sizeless}0 element type %1'
-H513D9739D1E9: '数组的元素类型%1%select{不完整|无大小}0'
+H513D9739D1E9: '数组的元素类型 %1%select{不完整|无大小}0'
 # 'array index %0 is before the beginning of the array'
-HE66AD6A3EEDD: '数组索引%0在数组的起始位置之前'
+HE66AD6A3EEDD: '数组索引 %0 在数组的起始位置之前'
 # 'array index %0 is past the end of the array (that has type %1%select{|, cast to %3}2)'
-HB32CD52AC2F7: '数组索引%0超出数组末尾（该数组类型为%1%select{|，转换为 %3}2）'
+HB32CD52AC2F7: '数组索引 %0 超出数组末尾（该数组类型为 %1%select{|，转换为 %3}2）'
 # 'array index %0 refers past the last possible element for an array in %1-bit address space containing %2-bit (%3-byte) elements (max possible %4 element%s5)'
-H8C89DC3E13D9: '地址空间%1位中的数组包含%2位（%3字节）元素，索引%0超出最大%4元素%s5'
+H8C89DC3E13D9: '地址空间 %1 位中的数组包含 %2 位（%3 字节）元素，索引 %0 超出最大 %4 元素%s5'
 # 'array initializer must be an initializer list%select{| or string literal| or wide string literal}0'
 H4C9486DBC430: '数组初始化器必须是初始化列表%select{|或字符串字面量|或宽字符串字面量}0'
 # 'array is too large (%0 elements)'
-H898DDC47DE13: '数组过大（包含%0个元素）'
+H898DDC47DE13: '数组过大（包含 %0 个元素）'
 # 'array of %0 type is invalid in OpenCL'
-H394630398D52: 'OpenCL中%0类型的数组无效'
+H394630398D52: 'OpenCL中 %0 类型的数组无效'
 # 'array of abstract class type %0'
-HD205577BDFE7: '类型为%0的抽象类数组'
+HD205577BDFE7: '类型为 %0 的抽象类数组'
 # 'array of interface %0 is invalid (probably should be an array of pointers)'
-H26CB6BC11BB2: '接口%0的数组无效（可能应为指针数组）'
+H26CB6BC11BB2: '接口 %0 的数组无效（可能应为指针数组）'
 # 'array parameter is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified)'
 HF62708756DE6: '数组参数缺少空安全性类型说明符（_Nonnull、_Nullable 或 _Null_unspecified）'
 # 'array section %select{lower bound|length}0 is not an integer'
@@ -17895,15 +17895,15 @@ HDEBFF7152057: '数组区间未指定最外层维度的长度'
 # 'array section must be a subset of the original array'
 H9DAB88506A15: '数组区间必须是原始数组的子集'
 # 'array shaping dimension is evaluated to a non-positive value %0'
-H6C186AF92991: '数组成形维度计算结果为非正值%0'
+H6C186AF92991: '数组成形维度计算结果为非正值 %0'
 # 'array shaping operation dimension is not an integer'
 H521C171EF9F9: '数组成形操作的维度不是整数'
 # 'array size expression has incomplete class type %0'
-H48253C816CFD: '数组大小表达式具有不完全类类型%0'
+H48253C816CFD: '数组大小表达式具有不完全类类型 %0'
 # 'array size expression must have integral or %select{|unscoped }0enumeration type, not %1'
-H46181D36F61E: '数组大小表达式必须是整型或%select{|未命名 }0枚举类型，而不是%1'
+H46181D36F61E: '数组大小表达式必须是整型或%select{|未命名 }0枚举类型，而不是 %1'
 # 'array size expression of type %0 requires explicit conversion to type %1'
-H08A74EE986A3: '类型%0的数组大小表达式需要显式转换为类型%1'
+H08A74EE986A3: '类型 %0 的数组大小表达式需要显式转换为类型 %1'
 # 'array size is negative'
 H2357C6CBC81F: '数组大小为负数'
 # 'array size must be specified in new expression with no initializer'
@@ -17911,21 +17911,21 @@ HC377DBA39626: '在没有初始化的new表达式中必须指定数组大小'
 # 'array subscript is not an integer'
 HCA57C5D6E89C: '数组下标不是整数'
 # "array subscript is of type 'char'"
-HF94CCD2B1ECE: "数组下标是类型'char'"
+HF94CCD2B1ECE: "数组下标是类型 'char'"
 # 'array type %0 is not assignable'
-H89C95FEC605F: '数组类型%0不可赋值'
+H89C95FEC605F: '数组类型 %0 不可赋值'
 # 'array types cannot be value-initialized'
 HA2673E710254: '数组类型不能进行值初始化'
 # 'array-to-pointer decay of array member without known bound is not supported'
 HAB3F18D32404: '未知边界的数组成员的数组到指针衰减不受支持'
 # "as specified in %select{'collapse'|'ordered'|'collapse' and 'ordered'}0 clause%select{||s}0"
-H1ABDD2AD30EB: "如%select{'collapse'|'ordered'|'collapse'和'ordered'}0子句%select{||s}0中所述"
+H1ABDD2AD30EB: "如%select{'collapse'|'ordered'|'collapse' 和 'ordered'}0子句%select{||s}0中所述"
 # 'ascending'
 HF393CC9965C7: '升序'
 # 'asm constraint has an unexpected number of alternatives: %0 vs %1'
 HF38699D505AA: 'asm约束的替代数意外：%0 vs %1'
 # 'asm operand has incomplete type %0'
-HAA2952BA222F: 'asm操作数具有不完整类型%0'
+HAA2952BA222F: 'asm操作数具有不完整类型 %0'
 # 'asm operand name "%0" first referenced here'
 H8FB938C946B0: 'asm-specifier的输入或输出变量名“%0”首次引用于此'
 # 'asm-specifier for input or output variable conflicts with asm clobber list'
@@ -17941,7 +17941,7 @@ H8135CA913359: '将保留对象赋值给不安全属性；对象将在赋值后�
 # "assigning to 'readonly' return result of an Objective-C message not allowed"
 H87457323E0B9: '不允许将Objective-C消息的只读返回结果进行赋值'
 # 'assigning value of signed enum type %1 to unsigned bit-field %0; negative enumerators of enum %1 will be converted to positive values'
-H03B45829D6A4: '将有符号枚举类型%1的值赋给无符号位字段%0；枚举类型%1的负枚举值将被转换为正数'
+H03B45829D6A4: '将有符号枚举类型 %1 的值赋给无符号位字段 %0；枚举类型 %1 的负枚举值将被转换为正数'
 # 'assignment of a weak-unavailable object to a __weak object'
 H270A68B29DDC: '将弱不可用对象赋值给__weak对象'
 # "assignment to Objective-C's isa is deprecated in favor of object_setClass()"
@@ -17957,29 +17957,29 @@ H4B3BD75DFF9D: '假设条件被评估为假'
 # 'assumption is ignored because it contains (potential) side-effects'
 H2E58C9356572: '因包含（潜在的）副作用，假设条件被忽略'
 # 'at least one argument of MTE builtin function must be a pointer (%0, %1 invalid)'
-H9293CC0B9621: 'MTE内建函数至少有一个参数必须是指针（%0、%1无效）'
+H9293CC0B9621: 'MTE内建函数至少有一个参数必须是指针（%0、%1 无效）'
 # 'at most one defaultmap clause for each variable-category can appear on the directive'
 H95E39CFC8758: '每个变量类别只能出现一个defaultmap子句'
 # "at most one overload for a given name may lack the 'overloadable' attribute"
-H9206D4731FC1: "给定名称最多有一个重载函数可以不带'overloadable'属性"
+H9206D4731FC1: "给定名称最多有一个重载函数可以不带 'overloadable' 属性"
 # "at most three expressions are allowed in '%0' clause in 'target teams ompx_bare' construct"
-HC1194A65DC15: "在'target teams ompx_bare'构造中的'%0'子句最多允许三个表达式"
+HC1194A65DC15: "在'target teams ompx_bare'构造中的 '%0' 子句最多允许三个表达式"
 # 'atomic %select{load|store}0 requires runtime support that is not available for this target'
 HD7BAEC48A8AF: '%select{加载|存储}0原子操作需要目标不支持的运行时支持'
 # "atomic by default property %0 has a user defined %select{getter|setter}1 (property should be marked 'atomic' if this is intended)"
-H5A9A236EC6A5: "默认原子属性%0有用户定义的%select{获取器|设置器}1（若需此行为，请将属性标记为'atomic'）"
+H5A9A236EC6A5: "默认原子属性 %0 有用户定义的%select{获取器|设置器}1（若需此行为，请将属性标记为 'atomic'）"
 # "atomic constraint must be of type 'bool' (found %0)"
-H69DAA34C1AB6: '原子约束必须是类型=bool（发现类型%0）'
+H69DAA34C1AB6: '原子约束必须是类型=bool（发现类型 %0）'
 # 'atomic memory operand must have a power-of-two size'
-HB13C6FA40316: '原子内存操作数必须具有2的幂次方大小'
+HB13C6FA40316: '原子内存操作数必须具有 2 的幂次方大小'
 # 'atomic property of reference type %0 cannot have non-trivial assignment operator'
-HFC34A950A835: '引用类型%0的原子属性不能具有非平凡的赋值运算符'
+HFC34A950A835: '引用类型 %0 的原子属性不能具有非平凡的赋值运算符'
 # "atomic types are not supported in '%0'"
-H97C63071B5D3: "原子类型不被支持在'%0'中使用"
+H97C63071B5D3: "原子类型不被支持在 '%0' 中使用"
 # 'atomic variable can be %select{assigned|initialized}0 to a variable only in global address space'
 HCB0951EAACB6: '原子变量只能在全局地址空间中%select{赋值|初始化}0到另一个变量'
 # 'attempt to call %0 on non-heap %select{object %2|object: block expression|object: lambda-to-function-pointer conversion}1'
-H6E5B5738458E: '尝试在非堆%select{对象 %2|对象：块表达式|对象：lambda到函数指针转换}1上调用%0'
+H6E5B5738458E: '尝试在非堆%select{对象 %2|对象：块表达式|对象：lambda到函数指针转换}1上调用 %0'
 # 'attempt to specialize declaration here'
 HF06CAF52936D: '尝试在此处特化声明'
 # 'attempt to use a deleted function%select{|: %1}0'
@@ -18063,7 +18063,7 @@ H83850ED606E9: '属性声明必须在定义之前'
 # 'attribute is here'
 HD14867328E83: '属性在此处'
 # "attribute is ignored on this statement as it only applies to functions; use '%0' on statements"
-H8C71964DA95C: "该属性被忽略，因为它仅适用于函数；请在语句上使用'%0'"
+H8C71964DA95C: "该属性被忽略，因为它仅适用于函数；请在语句上使用 '%0'"
 # 'attribute only applies to output parameters'
 H05F9B2ABFA42: '该属性仅适用于输出参数'
 # 'attribute with scope specifier cannot follow default scope specifier'
@@ -18083,23 +18083,23 @@ HB0AE642AC2E4: '验证空指针几乎肯定会引发陷阱'
 # 'auto property synthesis is synthesizing property not explicitly synthesized'
 H0B109C7F8F74: '自动属性综合正在综合未显式综合的属性'
 # 'auto property synthesis will not synthesize property %0 because it cannot share an ivar with another synthesized property'
-HB5E0DEB40CE6: '自动属性综合不会合成属性%0，因为它无法与其他综合属性共享实例变量'
+HB5E0DEB40CE6: '自动属性综合不会合成属性 %0，因为它无法与其他综合属性共享实例变量'
 # "auto property synthesis will not synthesize property %0 because it is 'readwrite' but it will be synthesized 'readonly' via another property"
-H2BD61AD864B9: '自动属性综合不会合成属性%0，因为它被标记为"readwrite"，但将通过另一个属性被综合为"readonly"'
+H2BD61AD864B9: '自动属性综合不会合成属性 %0，因为它被标记为"readwrite"，但将通过另一个属性被综合为"readonly"'
 # 'auto property synthesis will not synthesize property %0 declared in protocol %1'
-HA0C341D1A812: '自动属性综合不会合成在协议%1中声明的属性%0'
+HA0C341D1A812: '自动属性综合不会合成在协议 %1 中声明的属性 %0'
 # 'auto property synthesis will not synthesize property %0; it will be implemented by its superclass, use @dynamic to acknowledge intention'
-H0457D53851AF: '自动属性综合不会合成属性%0；它将由超类实现，请使用@dynamic声明此意图'
+H0457D53851AF: '自动属性综合不会合成属性 %0；它将由超类实现，请使用@dynamic声明此意图'
 # 'automatic variable qualified with an%select{| invalid}0 address space'
 H122ACAE25198: '自动变量使用%select{|无效}0地址空间限定'
 # 'autosynthesized property %0 will use %select{|synthesized}1 instance variable %2, not existing instance variable %3'
-H4495EA68D322: '自动综合的属性%0将使用%select{|综合的}1实例变量%2，而非现有实例变量%3'
+H4495EA68D322: '自动综合的属性 %0 将使用%select{|综合的}1实例变量 %2，而非现有实例变量 %3'
 # 'availability does not match previous declaration'
 H583F2A1BC062: '可用性声明与之前的声明不匹配'
 # 'available multilibs are:%0'
 H0F052B7170DD: '可用的多库配置是：%0'
 # "backend data layout '%0' does not match expected target description '%1'"
-H82DEBC38BED7: "后端数据布局'%0'与目标描述'%1'的期望定义不匹配"
+H82DEBC38BED7: "后端数据布局 '%0' 与目标描述 '%1' 的期望定义不匹配"
 # 'backslash and newline separated by space'
 HD4F9A252F950: '反斜杠和换行符被空格分隔'
 # 'bad receiver type %0'
@@ -18145,15 +18145,15 @@ HD9E44C137738: '因为无法使用 %select{<<ERROR>>|构造函数|构造函数|�
 # 'because of ambiguity in conversion %diff{of $ to $|between types}0,1'
 HB064B974A1C3: '因为转换 %diff{类型 $ 到 $|类型之间}0,1 存在歧义'
 # 'because substituted constraint expression is ill-formed%0'
-H708967A94C80: '因为替换后的约束表达式存在语法错误%0'
+H708967A94C80: '因为替换后的约束表达式存在语法错误 %0'
 # 'because the function selected to %select{construct|copy|move|copy|move|destroy}2 %select{base class|field}0 of type %1 is not trivial'
-H1F152D129667: '因为选择用于%select{构造|复制|移动|复制|移动|销毁}2 %select{基类|字段}0 的类型%1的函数不是平凡的'
+H1F152D129667: '因为选择用于%select{构造|复制|移动|复制|移动|销毁}2 %select{基类|字段}0 的类型 %1 的函数不是平凡的'
 # 'because type %0 has a member with %select{no|no|__strong|__weak|__autoreleasing}1 ownership'
-HE992EBFC669B: '因为类型%0有一个成员具有%select{无|无|__strong|__weak|__autoreleasing}1所有权'
+HE992EBFC669B: '因为类型 %0 有一个成员具有%select{无|无|__strong|__weak|__autoreleasing}1所有权'
 # 'because type %0 has a virtual %select{member function|base class}1'
 H45351AACBEF7: '因为类型 %0 包含虚 %select{成员函数|基类}1'
 # "befriending %1 without '%select{struct|interface|union|class|enum}0' keyword is incompatible with C++98"
-HDE958FBB8995: "在没有'%select{struct|interface|union|class|enum}0'关键字的情况下友元声明%1与C++98不兼容"
+HDE958FBB8995: "在没有'%select{struct|interface|union|class|enum}0'关键字的情况下友元声明 %1 与C++98不兼容"
 # 'binary RIFF format'
 H555066C6C2A6: '二进制 RIFF 格式'
 # 'binary fold expression has unexpanded parameter packs in both operands'
@@ -18179,15 +18179,15 @@ HC231E43E4B06: '带有instrumentation映射的二进制文件，或单独的grap
 # 'binary with the instrumrntation map, or a separate instrumentation map'
 H0A39B12683BE: '带有instrumrntation映射的二进制文件，或单独的instrumentation映射'
 # 'binding %0 cannot appear in the initializer of its own decomposition declaration'
-H672061929029: '绑定%0不能出现在其自身分解声明的初始化器中'
+H672061929029: '绑定 %0 不能出现在其自身分解声明的初始化器中'
 # 'binding dereferenced null pointer to reference has undefined behavior'
 H95EC0F6A8A66: '将空指针解引用后绑定到引用具有未定义行为'
 # 'binding reference %diff{of type $ to value of type $|to value}0,1 %select{drops %3 qualifier%plural{1:|2:|4:|:s}4|changes address space|not permitted due to incompatible qualifiers}2'
-H55C0D80172E9: '绑定%diff{类型$到类型$的值|到值}0,1 %select{去除%3 %plural{1:限定符|2:限定符|4:限定符|:s}4|更改地址空间|因不兼容的限定符无法绑定}2'
+H55C0D80172E9: '绑定%diff{类型$到类型$的值|到值}0,1 %select{去除 %3 %plural{1:限定符|2:限定符|4:限定符|:s}4|更改地址空间|因不兼容的限定符无法绑定}2'
 # 'binding reference member %0 to stack allocated %select{variable|parameter}2 %1'
-H6CEDF6C3E571: '将引用成员%0绑定到栈分配的%select{变量|参数}2 %1'
+H6CEDF6C3E571: '将引用成员 %0 绑定到栈分配的%select{变量|参数}2 %1'
 # "binding type '%0' is invalid"
-HD0FB3A3589D6: "绑定类型'%0'无效"
+HD0FB3A3589D6: "绑定类型 '%0' 无效"
 # "binding type '%select{t|u|b|s|c|i}0' cannot be applied more than once"
 H9FC4B2C35AB9: "绑定类型'%select{t|u|b|s|c|i}0'不能重复使用"
 # "binding type '%select{t|u|b|s|c}0' only applies to %select{SRV resources|UAV resources|constant buffer resources|sampler state|numeric variables in the global scope}0"
@@ -18195,9 +18195,9 @@ H9DB6D490A30A: "绑定类型'%select{t|u|b|s|c}0'仅适用于%select{SRV资源|U
 # "binding type '%select{t|u|b|s|c}0' only applies to types containing %select{SRV resources|UAV resources|constant buffer resources|sampler state|numeric types}0"
 H1CE73AE71EA5: "绑定类型'%select{t|u|b|s|c}0'仅适用于包含%select{SRV资源|UAV资源|常量缓冲区资源|采样器状态|数值类型}0的类型"
 # "binding type 'b' only applies to constant buffers. The 'bool constant' binding type is no longer supported"
-HC83E5E495198: "绑定类型'b'仅适用于常量缓冲区。'bool constant'绑定类型已不再支持"
+HC83E5E495198: "绑定类型 'b' 仅适用于常量缓冲区。'bool constant'绑定类型已不再支持"
 # "binding type 'c' ignored in buffer declaration. Did you mean 'packoffset'?"
-H937D8317B6A5: "绑定类型'c'在缓冲区声明中被忽略。您是指'packoffset'吗？"
+H937D8317B6A5: "绑定类型 'c' 在缓冲区声明中被忽略。您是指 'packoffset' 吗？"
 # "binding type 'i' ignored. The 'integer constant' binding type is no longer supported"
 H2F0190E0856D: "绑定类型 'i' 被忽略。'integer constant'（整型常量）绑定类型不再受支持"
 # "bit fields cannot be used to specify storage in a '%0' clause"
@@ -18243,7 +18243,7 @@ HE91DFBCBC336: '块类型不能用作OpenCL三元表达式中的表达式'
 # 'block will be retained by %select{the captured object|an object strongly retained by the captured object}0'
 H659E73E5BC81: '块将被%select{被捕获的对象|该对象强引用的对象}0所保留'
 # 'blocks support disabled - compile with -fblocks or %select{pick a deployment target that supports them|for OpenCL C 2.0 or OpenCL C 3.0 with __opencl_c_device_enqueue feature}0'
-H870F6FD76494: '块功能被禁用 - 编译时需添加-fblocks选项或%select{选择支持块功能的部署目标|使用支持__opencl_c_device_enqueue特性的OpenCL C 2.0或3.0}0'
+H870F6FD76494: '块功能被禁用 - 编译时需添加-fblocks选项或%select{选择支持块功能的部署目标|使用支持__opencl_c_device_enqueue特性的OpenCL C 2.0或 3.0}0'
 # "blocks used in enqueue_kernel call are expected to have parameters of type 'local void*'"
 H5A1C0A69E254: "enqueue_kernel调用中的block参数期望具有类型'local void*'类型"
 # 'blocks with parameters are not accepted in this prototype of enqueue_kernel call'
@@ -18251,7 +18251,7 @@ H6F73FE38020E: '此enqueue_kernel调用的原型不接受带有参数的块'
 # 'body of cpu_dispatch function will be ignored'
 H8CCA48E04008: 'cpu_dispatch函数的函数体将被忽略'
 # "bool literal returned from 'main'"
-H65A070E22BD6: "'main'函数返回了布尔字面量"
+H65A070E22BD6: "'main' 函数返回了布尔字面量"
 # 'both arms of conditional operator are unable to produce a constant expression'
 H42234192A750: '条件运算符的两个分支均无法生成常量表达式'
 # 'boundary to use for alignment of basic blocks'
@@ -18261,7 +18261,7 @@ H98B26CB02BEA: '指定初始化器的花括号省略是C99扩展'
 # 'braces around %select{scalar |}0initializer'
 H5FA1CA5D46EC: '初始化器周围的%select{标量 |}0花括号'
 # 'bracket nesting level exceeded maximum of %0'
-HAE0DB07D013C: '超过最大嵌套层级%0'
+HAE0DB07D013C: '超过最大嵌套层级 %0'
 # 'brackets are not allowed here; to declare an array, place the brackets after the %select{identifier|name}0'
 H9FD98F06E7EB: '此处不允许使用方括号；若要声明数组，请将方括号置于%select{标识符|名称}0之后'
 # 'branch probability threshold in percentage to be considered very likely'
@@ -18271,19 +18271,19 @@ H7FFFD5CE40B4: '当存在配置文件时被视为非常可能的分支概率阈�
 # 'branch relax asm'
 HC2E42E8DC7A2: '分支松弛汇编'
 # "build a shadowed submodule '%0'"
-H9D79CC95EF50: "构建被覆盖的子模块'%0'"
+H9D79CC95EF50: "构建被覆盖的子模块 '%0'"
 # "building module '%0' as '%1'"
-H765D28E7D6EF: "正在构建模块'%0'为'%1'"
+H765D28E7D6EF: "正在构建模块 '%0' 为 '%1'"
 # 'built-in candidate %0'
-H70FA60F84316: '内建候选%0'
+H70FA60F84316: '内建候选 %0'
 # 'builtin %0 is deprecated; use %1 instead'
-H3145BB7C5706: '已弃用的内建函数%0；请改用%1'
+H3145BB7C5706: '已弃用的内建函数 %0；请改用 %1'
 # 'builtin call is not valid when calling from a function without active ZA state'
 H7B974CCBB78F: '从无活动ZA状态的函数调用内建函数无效'
 # 'builtin call is not valid when calling from a function without active ZT0 state'
 H1B7C49833DEE: '从无活动ZT0状态的函数调用内建函数无效'
 # 'builtin can only be called from a %0 function'
-H2DDDDEB70C80: '该内建函数只能从%0类型的函数调用'
+H2DDDDEB70C80: '该内建函数只能从 %0 类型的函数调用'
 # 'builtin feature check macro requires a parenthesized identifier'
 HA88BFEE47095: '内建特性检查宏需要带括号的标识符'
 # 'builtin functions must be directly called'
@@ -18295,7 +18295,7 @@ H6C31A7E5443F: '此目标不支持内建函数'
 # 'builtin requires%select{| at least one of the following extensions}0: %1'
 HBE3E35E72C33: '内建函数需要%select{|以下至少一个扩展}0: %1'
 # "but in %select{'%1'|definition here}0 found %select{%3 referenced %plural{1:protocol|:protocols}3|%ordinal3 referenced protocol with different name %4}2"
-HD3683C05282A: "但在%select{'%1'|此处的定义}0 发现 %select{引用了%3 %plural{1:协议|:协议}3|%ordinal3 参考的协议名称不同%4}2"
+HD3683C05282A: "但在%select{'%1'|此处的定义}0 发现 %select{引用了 %3 %plural{1:协议|:协议}3|%ordinal3 参考的协议名称不同 %4}2"
 # "but in %select{'%1'|definition here}0 found %select{%select{method %4|constructor|destructor}3 that has %5 parameter%s5|%select{method %4|constructor|destructor}3 with %ordinal5 parameter of type %6%select{| decayed from %8}7|%select{method %4|constructor|destructor}3 with %ordinal5 parameter named %6}2"
 HF69A42480F6D: "但在 %select{'%1'|此处定义}0 发现 %select{%select{方法 %4|构造函数|析构函数}3 具有 %5 参数%s5|%select{方法 %4|构造函数|析构函数}3 的第 %ordinal5 参数类型为 %6%select{| 从 %8 衰减而来}7|%select{方法 %4|构造函数|析构函数}3 的第 %ordinal5 参数名为 %6}2"
 # "but in %select{'%1'|definition here}0 found %select{%select{no super class|super class with type %4}3|instance variable '%3' access control is %select{|@private|@protected|@public|@package}4}2"
@@ -18315,11 +18315,11 @@ H86407D9382F4: "但在 '%0' 发现 %select{%2 基 %plural{1:类|:类}2|%2 虚基
 # "but in '%0' found %select{%select{typedef|type alias}2 name %3|%select{typedef|type alias}2 %3 with different underlying type %4}1"
 H5285292325BC: "但在 '%0' 中发现 %select{%select{typedef|类型别名}2 名称 %3|%select{typedef|类型别名}2 %3 具有不同基础类型 %4}1"
 # "but in '%0' found %select{data member with name %2|data member %2 with different type %3|data member %2 with%select{out|}3 an initializer|data member %2 with a different initializer|data member %2 %select{is constexpr|is not constexpr}3}1"
-HB02EC39C6642: "但在 '%0' 中发现 %select{名称为 %2 的数据成员|类型为 %3 的数据成员 %2|%2 数据成员%select{out|}3 具有初始化器|%2 数据成员具有不同初始化器|%2 数据成员%select{是constexpr|不是constexpr}3}1"
+HB02EC39C6642: "但在 '%0' 中发现 %select{名称为 %2 的数据成员|类型为 %3 的数据成员 %2|%2 数据成员 %select{out|}3 具有初始化器|%2 数据成员具有不同初始化器|%2 数据成员%select{是constexpr|不是constexpr}3}1"
 # "but in '%0' found %select{different return type %2|%ordinal2 parameter with name %3|%ordinal2 parameter with type %3%select{| decayed from %5}4|%ordinal2 parameter with%select{out|}3 a default argument|%ordinal2 parameter with a different default argument|a different body}1"
 H926097C3EBA4: "但在 '%0' 中发现 %select{不同返回类型 %2|第 %ordinal2 参数名称 %3|第 %ordinal2 参数类型 %3%select{| 转换自 %5}4|第 %ordinal2 参数带%select{无|}3 默认参数|第 %ordinal2 参数默认参数不同|函数体不同}1"
 # "but in '%0' found %select{enum that is %select{not scoped|scoped}2|enum scoped with keyword %select{struct|class}2|enum %select{without|with}2 specified type|enum with specified type %2|enum with %2 element%s2|%ordinal2 element has name %3|%ordinal2 element %3 %select{has|does not have}4 an initializer|%ordinal2 element %3 has different initializer|}1"
-H44D066860BB7: "但在'%0'中发现%select{枚举类型是%select{非命名空间|命名空间}2|使用%select{struct|class}2关键字作用域的枚举|枚举%select{没有|有}2指定类型|具有指定类型%2的枚举|包含%2个元素%s2的枚举|第%ordinal2个元素名为%3|第%ordinal2个元素%3%select{有|没有}4初始值设定项|第%ordinal2个元素%3具有不同的初始值设定项|}1"
+H44D066860BB7: "但在 '%0' 中发现%select{枚举类型是%select{非命名空间|命名空间}2|使用 %select{struct|class}2 关键字作用域的枚举|枚举%select{没有|有}2指定类型|具有指定类型 %2 的枚举|包含 %2 个元素%s2的枚举|第%ordinal2个元素名为 %3|第%ordinal2个元素 %3%select{有|没有}4初始值设定项|第%ordinal2个元素 %3 具有不同的初始值设定项|}1"
 # "but in '%0' found %select{static assert with different condition|static assert with different message|static assert with %select{|no }2message|%select{method %3|constructor|destructor}2|%select{method %3|constructor|destructor}2 is %select{not deleted|deleted}4|%select{method %3|constructor|destructor}2 is %select{not defaulted|defaulted}4|%select{method %3|constructor|destructor}2 is %select{|pure }4%select{not virtual|virtual}5|%select{method %3|constructor|destructor}2 is %select{not static|static}4|%select{method %3|constructor|destructor}2 is %select{not volatile|volatile}4|%select{method %3|constructor|destructor}2 is %select{not const|const}4|%select{method %3|constructor|destructor}2 is %select{not inline|inline}4|%select{method %3|constructor|destructor}2 with %ordinal4 parameter with%select{out|}5 a default argument|%select{method %3|constructor|destructor}2 with %ordinal4 parameter with a different default argument|%select{method %3|constructor|destructor}2 with %select{no |}4template arguments|%select{method %3|constructor|destructor}2 with %4 template argument%s4|%select{method %3|constructor|destructor}2 with %4 for %ordinal5 template argument|%select{method %3|constructor|destructor}2 with %select{no body|body}4|%select{method %3|constructor|destructor}2 with different body|friend %select{class|function}2|friend %2|friend function %2|function template %2 with %3 template parameter%s3|function template %2 with %ordinal3 template paramter being a %select{type|non-type|template}4 template parameter|function template %2 with %ordinal3 template parameter %select{with no name|named %5}4|function template %2 with %ordinal3 template parameter with %select{no |}4default argument|function template %2 with %ordinal3 template parameter with default argument %4|function template %2 with %ordinal3 template parameter with different type|function template %2 with %ordinal3 template parameter %select{not |}4being a template parameter pack|}1"
 H650FCD73F7BC: "但在 '%0' 中发现 %select{具有不同条件的静态断言|具有不同消息的静态断言|具有%select{|无 }2消息的静态断言|%select{方法 %3|构造函数|析构函数}2|%select{方法 %3|构造函数|析构函数}2 是 %select{未删除|已删除}4|%select{方法 %3|构造函数|析构函数}2 是 %select{未默认|已默认}4|%select{方法 %3|构造函数|析构函数}2 是 %select{|纯 }4%select{非虚|虚}5|%select{方法 %3|构造函数|析构函数}2 是 %select{非静态|静态}4|%select{方法 %3|构造函数|析构函数}2 是 %select{非volatile|volatile}4|%select{方法 %3|构造函数|析构函数}2 是 %select{非const|const}4|%select{方法 %3|构造函数|析构函数}2 是 %select{非内联|内联}4|%select{方法 %3|构造函数|析构函数}2 的第 %ordinal4 参数带有%select{出|}5 默认参数|%select{方法 %3|构造函数|析构函数}2 的第 %ordinal4 参数具有不同默认参数|%select{方法 %3|构造函数|析构函数}2 具有%select{无|有}4模板参数|%select{方法 %3|构造函数|析构函数}2 具有 %4 模板参数%s4|%select{方法 %3|构造函数|析构函数}2 具有 %4 作为第 %ordinal5 模板参数|%select{方法 %3|构造函数|析构函数}2 具有%select{无|有}4函数体|%select{方法 %3|构造函数|析构函数}2 具有不同函数体|友元 %select{类|函数}2|友元 %2|友元函数 %2|函数模板 %2 具有 %3 模板参数%s3|函数模板 %2 具有第 %ordinal3 模板参数是 %select{类型|非类型|模板}4 模板参数|函数模板 %2 具有第 %ordinal3 模板参数%select{无名称|名称为 %5}4|函数模板 %2 具有第 %ordinal3 模板参数%select{无|}4默认参数|函数模板 %2 具有第 %ordinal3 模板参数默认参数 %4|函数模板 %2 具有第 %ordinal3 模板参数类型不同|函数模板 %2 具有第 %ordinal3 模板参数%select{不|}4是模板参数包|}1"
 # "but in '%0' found %select{unnamed template parameter %2|template parameter %3|template parameter with %select{no |}2default argument|template parameter with different default argument}1"
@@ -18345,89 +18345,89 @@ H63B47EF20C66: '调用%select{非静态|显式}0 成员函数时缺少对象参�
 # 'call to %select{placement|class-specific}0 %1'
 H295DBDE7B5BD: '调用%select{placement|类特异性}0 %1'
 # "call to '%0' declared with 'error' attribute: %1"
-HDBB58BF71CEC: "调用用'error'属性声明的'%0'函数： %1"
+HDBB58BF71CEC: "调用用 'error' 属性声明的 '%0' 函数： %1"
 # "call to '%0' declared with 'warning' attribute: %1"
-H3865B6C0D901: "调用用'warning'属性声明的'%0'函数： %1"
+H3865B6C0D901: "调用用 'warning' 属性声明的 '%0' 函数： %1"
 # "call to '%select{__builtin_operator_new|__builtin_operator_delete}0' selects non-usual %select{allocation|deallocation}0 function"
 H676581AF4E96: "调用'%select{__builtin_operator_new|__builtin_operator_delete}0'选择了非常规%select{分配|释放}0函数"
 # "call to '%select{initial_suspend|final_suspend}0' implicitly required by the %select{initial suspend point|final suspend point}0"
-H1C6B1E5ADCED: '在%select{初始挂起点|最终挂起点}0处隐式调用%select{initial_suspend|final_suspend}0'
+H1C6B1E5ADCED: '在%select{初始挂起点|最终挂起点}0处隐式调用 %select{initial_suspend|final_suspend}0'
 # "call to 'await_transform' implicitly required by 'co_await' here"
-HA0503466B398: "'co_await'在此处隐式调用'await_transform'函数"
+HA0503466B398: "'co_await' 在此处隐式调用 'await_transform' 函数"
 # "call to a function that shares state other than 'za' from a function that has live 'za' state requires a spill/fill of ZA, which is not yet implemented"
-H8FF6C74595CF: "从具有活动ZA状态的函数调用共享ZA状态（非'za'）的函数需要保存/恢复ZA状态，但该功能尚未实现"
+H8FF6C74595CF: "从具有活动ZA状态的函数调用共享ZA状态（非 'za'）的函数需要保存/恢复ZA状态，但该功能尚未实现"
 # 'call to a shared ZA function requires the caller to have ZA state'
 H755688EF43BB: '调用共享ZA函数需要调用方具有ZA状态'
 # 'call to a shared ZT0 function requires the caller to have ZT0 state'
 H89ACEBE543C2: '调用共享ZT0函数需要调用方具有ZT0状态'
 # "call to a streaming function requires 'sme'"
-H41309CFB27F8: "调用流式函数需要'sme'"
+H41309CFB27F8: "调用流式函数需要 'sme'"
 # 'call to constructor of %0 is ambiguous'
-H00A38B0315FF: '调用%0构造函数时存在歧义'
+H00A38B0315FF: '调用 %0 构造函数时存在歧义'
 # 'call to deleted constructor of %0%select{|: %2}1'
-HAA8E5FBCBA79: '调用已删除的%0构造函数%select{|： %2}1'
+HAA8E5FBCBA79: '调用已删除的 %0 构造函数%select{|： %2}1'
 # 'call to deleted function call operator in type %0%select{|: %2}1'
-H8F857BEAC26F: '调用类型%0中的已删除函数调用运算符%select{|： %2}1'
+H8F857BEAC26F: '调用类型 %0 中的已删除函数调用运算符%select{|： %2}1'
 # 'call to deleted%select{| member}0 function %1%select{|: %3}2'
-H6B002A51A7D4: '调用已删除%select{|成员}0函数%1%select{|： %3}2'
+H6B002A51A7D4: '调用已删除%select{|成员}0函数 %1%select{|： %3}2'
 # 'call to function %0 that is neither visible in the template definition nor found by argument-dependent lookup'
-H225588528963: '调用在模板定义中不可见且无法通过参数相关查找找到的函数%0'
+H225588528963: '调用在模板定义中不可见且无法通过参数相关查找找到的函数 %0'
 # 'call to global function %0 not configured'
-HC08574A55FB5: '调用未配置的全局函数%0'
+HC08574A55FB5: '调用未配置的全局函数 %0'
 # 'call to implicitly-deleted %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor|function}0 of %1'
-H4C623CF7C837: '调用%1的隐式删除的%select{默认构造函数|拷贝构造函数|移动构造函数|拷贝赋值运算符|移动赋值运算符|析构函数|函数}0'
+H4C623CF7C837: '调用 %1 的隐式删除的%select{默认构造函数|拷贝构造函数|移动构造函数|拷贝赋值运算符|移动赋值运算符|析构函数|函数}0'
 # 'call to member function %0 is ambiguous'
-H60EE3A6ABF6A: '调用成员函数%0 时发生歧义'
+H60EE3A6ABF6A: '调用成员函数 %0 时发生歧义'
 # 'call to object of type %0 is ambiguous'
-H3783B2A8DBDC: '调用类型%0的对象时发生歧义'
+H3783B2A8DBDC: '调用类型 %0 的对象时发生歧义'
 # "call to pointer to member function of type %0 drops '%1' qualifier%s2"
-HC75C3E40313D: "调用类型%0的成员函数指针时丢失'%1'限定符%s2"
+HC75C3E40313D: "调用类型 %0 的成员函数指针时丢失 '%1' 限定符%s2"
 # 'call to pseudo-destructor cannot have any arguments'
 H6ECE40631FC9: '伪析构函数调用不能带有任何参数'
 # 'call to pure virtual member function %0 has undefined behavior; overrides of %0 in subclasses are not available in the %select{constructor|destructor}1 of %2'
-HDC8AD43C5C1C: '调用纯虚成员函数%0 会产生未定义行为；%2的%select{构造函数|析构函数}1 中不可访问子类对%0 的重载'
+HDC8AD43C5C1C: '调用纯虚成员函数 %0 会产生未定义行为；%2 的%select{构造函数|析构函数}1 中不可访问子类对 %0 的重载'
 # 'call to subscript operator of type %0 is ambiguous'
-H1E29AAB6AD84: '类型%0的下标运算符调用发生歧义'
+H1E29AAB6AD84: '类型 %0 的下标运算符调用发生歧义'
 # 'call to undeclared function %0; ISO C99 and later do not support implicit function declarations'
-HEBF384E2E2A6: '调用未声明函数%0；ISO C99及后续标准不支持隐式函数声明'
+HEBF384E2E2A6: '调用未声明函数 %0；ISO C99及后续标准不支持隐式函数声明'
 # "call to undeclared library function '%0' with type %1; ISO C99 and later do not support implicit function declarations"
-HF288A58FA40B: "调用未声明的库函数'%0'（类型%1）；ISO C99及后续标准不支持隐式函数声明"
+HF288A58FA40B: "调用未声明的库函数 '%0'（类型 %1）；ISO C99及后续标准不支持隐式函数声明"
 # 'call to unsupported expression with unknown type'
 H239ACE39DA12: '调用类型未知的不受支持的表达式'
 # 'called by %0'
-HDC9A013B796D: '被%0调用'
+HDC9A013B796D: '被 %0 调用'
 # 'called object type %0 is not a function or function pointer'
-H5E3F97BDB14E: '被调用对象类型%0 不是函数或函数指针'
+H5E3F97BDB14E: '被调用对象类型 %0 不是函数或函数指针'
 # 'callee declares array parameter as static here'
 H80DA3F678F9A: '被调用函数在此处将数组参数声明为static'
 # "calling %0 is a violation of trusted computing base '%1'"
-HF890EA6739C7: "调用%0 违反了可信计算基'%1'"
+HF890EA6739C7: "调用 %0 违反了可信计算基 '%1'"
 # 'calling %0 with incomplete return type %1'
-H218BBBD759BD: '调用具有不完整返回类型的%0（返回类型%1）'
+H218BBBD759BD: '调用具有不完整返回类型的 %0（返回类型 %1）'
 # "calling '%0' with a nonzero argument is unsafe"
-H373CF9276563: "调用'%0'时传入非零参数是不安全的"
+H373CF9276563: "调用 '%0' 时传入非零参数是不安全的"
 # 'calling a %select{private|protected}0 constructor of class %2'
-H1D7B9B5BEE0D: '调用类%2的%select{私有|受保护}0构造函数'
+H1D7B9B5BEE0D: '调用类 %2 的%select{私有|受保护}0构造函数'
 # 'calling a %select{private|protected}1 destructor of class %0'
-H2870B0B82BD7: '调用类%0的%select{私有|受保护}1析构函数'
+H2870B0B82BD7: '调用类 %0 的%select{私有|受保护}1析构函数'
 # "calling function %0 requires negative capability '%1'"
-HB81388BC5C94: "调用函数%0 需要负能力'%1'"
+HB81388BC5C94: "调用函数 %0 需要负能力 '%1'"
 # "calling function %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
-HF6312AC18647: "调用函数%1需要持有%0 %select{'%2'|'%2' 独占}3"
+HF6312AC18647: "调用函数 %1 需要持有 %0 %select{'%2'|'%2' 独占}3"
 # 'calling function with incomplete return type %0'
-H47066D05EDB3: '调用具有不完整返回类型的函数%0'
+H47066D05EDB3: '调用具有不完整返回类型的函数 %0'
 # 'calls the given entry-point on a new thread (jit-kind=orc-lazy only)'
 HD909298BB334: '在新线程上调用给定的入口点（仅jit-kind=orc-lazy适用）'
 # 'calls to OpenMP runtime API are not allowed within a region that corresponds to a construct with an order clause that specifies concurrent'
 HF0FE255D765C: '在对应具有并发指定order子句的构造体的区域内不允许调用OpenMP运行时API'
 # 'can only access this member on an object of type %0'
-H97DBB9710EB7: '只能在类型%0的对象上访问该成员'
+H97DBB9710EB7: '只能在类型 %0 的对象上访问该成员'
 # 'can only poison identifier tokens'
 HBA757282B22F: '只能毒化标识符标记'
 # 'can only provide an explicit specialization for a class template, function template, variable template, or a member function, static data member, %select{or member class|member class, or member enumeration}0 of a class template'
 H705307E2F906: '只能为类模板、函数模板、变量模板或类模板的成员函数、静态数据成员%select{或成员类|成员类、或成员枚举}0提供显式特化'
 # "can only use 'init_priority' attribute on file-scope definitions of objects of class type"
-H2C248D12A320: "只能将'init_priority'属性用于类类型对象的文件作用域定义"
+H2C248D12A320: "只能将 'init_priority' 属性用于类类型对象的文件作用域定义"
 # 'candidate %select{constructor|template}0 ignored: inherited constructor cannot be used to %select{copy|move}1 object'
 HA2E8E747932F: '候选%select{构造函数|模板}0被忽略：继承的构造函数不能用于%select{拷贝|移动}1对象'
 # 'candidate %select{constructor|template}0 ignored: instantiation %select{takes|would take}0 its own class type by value'
@@ -18435,23 +18435,23 @@ H5F81F51806D8: '候选%select{构造函数|模板}0被忽略：实例化%select{
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 has been %select{explicitly made unavailable|explicitly deleted|implicitly deleted}3"
 HDF3920A3A1F2: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1已被%select{显式禁用|显式删除|隐式删除}3"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: %ordinal5 argument (%3) would lose %select{const|restrict|const and restrict|volatile|const and volatile|volatile and restrict|const, volatile, and restrict}4 qualifier%select{||s||s|s|s}4"
-H95E4AEB3B23E: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1不可行：第%ordinal5参数（%3）将丢失%select{const|restrict|const和restrict|volatile|const和volatile|volatile和restrict|const、volatile和restrict}4限定符%select{||s||s|s|s}4"
+H95E4AEB3B23E: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1不可行：第%ordinal5参数（%3）将丢失 %select{const|restrict|const和restrict|volatile|const和volatile|volatile和restrict|const、volatile和restrict}4 限定符%select{||s||s|s|s}4"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: %select{%ordinal7|'this'}6 argument (%3) has %select{no|__unsafe_unretained|__strong|__weak|__autoreleasing}4 ownership, but parameter has %select{no|__unsafe_unretained|__strong|__weak|__autoreleasing}5 ownership"
 H8D414CDC2F4E: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1不可行：%select{第%ordinal7|'this'}6参数（%3）具有%select{无|__unsafe_unretained|__strong|__weak|__autoreleasing}4所有权，但参数需要%select{无|__unsafe_unretained|__strong|__weak|__autoreleasing}5所有权"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: %select{%ordinal7|'this'}6 argument (%3) has %select{no|__weak|__strong}4 ownership, but parameter has %select{no|__weak|__strong}5 ownership"
 HFD1E148AC849: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1不可行：%select{第%ordinal7|'this'}6参数（%3）具有%select{无|__weak|__strong}4所有权，但参数需要%select{无|__weak|__strong}5所有权"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: %select{cannot convert initializer list|too few initializers in list|too many initializers in list}7 argument to %4"
-H4C57102C9323: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1不可行：%select{无法转换初始化列表|列表初始化器太少|列表初始化器过多}7参数到%4"
+H4C57102C9323: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1不可行：%select{无法转换初始化列表|列表初始化器太少|列表初始化器过多}7参数到 %4"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: %select{requires at least|allows at most single|requires single}3 %select{|non-object }6argument %4, but %plural{0:no|:%5}5 arguments were provided"
 H8AD4B8B6097C: "候选 %select{函数|函数|参数顺序反转的函数|构造函数|隐式默认构造函数|隐式拷贝构造函数|隐式移动构造函数|隐式赋值运算符|隐式移动赋值运算符|隐式 'operator=='（对应三向比较运算符）|继承的构造函数}0%select{| 模板| %2}1 不可用：需要 %select{至少|最多一个|一个}3 %select{非对象|}6 参数 %4，但提供 %plural{0:0|:%5}5 个参数"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: 'this' argument has type %3, but method is not marked %select{const|restrict|const or restrict|volatile|const or volatile|volatile or restrict|const, volatile, or restrict}4"
-HE6BBB39EEE68: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1不可行：'this'参数具有类型%3，但方法未标记为%select{const|restrict|const或restrict|volatile|const或volatile|volatile或restrict|const、volatile或restrict}4"
+HE6BBB39EEE68: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1不可行：'this' 参数具有类型 %3，但方法未标记为 %select{const|restrict|const或restrict|volatile|const或volatile|volatile或restrict|const、volatile或restrict}4"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: 'this' object is in %3, but method expects object in %4"
-H7EDBF536C9E0: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1不可行：'this'对象处于%3状态，但方法期望处于%4状态"
+H7EDBF536C9E0: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1不可行：'this' 对象处于 %3 状态，但方法期望处于 %4 状态"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: call to %select{__device__|__global__|__host__|__host__ __device__|invalid}3 function from %select{__device__|__global__|__host__|__host__ __device__|invalid}4 function"
 HB286FD7ADB16: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1不可行：从%select{__device__|__global__|__host__|__host__ __device__|无效}4函数调用%select{__device__|__global__|__host__|__host__ __device__|无效}3函数"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: cannot %select{convert from|convert from|bind}3 %select{base class pointer|superclass|base class object of type}3 %4 to %select{derived class pointer|subclass|derived class reference}3 %5 for %ordinal6 argument"
-H9EF538024430: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1不可行：无法%select{将|将|绑定}3%select{基类指针|基类|基类对象}3 %4转换为%select{派生类指针|派生类|派生类引用}3 %5作为第%ordinal6参数"
+H9EF538024430: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1不可行：无法%select{将|将|绑定}3%select{基类指针|基类|基类对象}3 %4 转换为%select{派生类指针|派生类|派生类引用}3 %5 作为第%ordinal6参数"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: cannot %select{pass pointer to|bind reference in}5 %3 %select{as a pointer to|to object in}5 %4 in %ordinal6 argument"
 HEE13EA6B12B0: "候选%select{函数|函数|参数顺序反转的函数|构造函数|类模板隐式默认构造函数|类模板隐式拷贝构造函数|类模板隐式移动构造函数|隐式拷贝赋值运算符|隐式移动赋值运算符|隐式'operator=='运算符|继承构造函数}0%select{|模板| %2}1不可行：无法%select{将指针转换为|在引用中绑定}5 %3 %select{作为指向|到}5 %4 的%ordinal6参数"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: cannot convert argument of incomplete type %diff{$ to $|to parameter type}3,4 for %select{%ordinal6 argument|object argument}5%select{|; dereference the argument with *|; take the address of the argument with &|; remove *|; remove &}7"
@@ -18469,7 +18469,7 @@ H327F9AFBF1B4: "候选 %select{函数|函数|函数（参数顺序反转）|构�
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: requires%select{ at least| at most|}3 %4 %select{|non-object }6argument%s4, but %5 %plural{1:was|:were}5 provided"
 HE70B20B055FA: "候选 %select{函数|函数|函数（参数顺序反转）|构造函数|构造函数（隐式默认构造函数）|构造函数（隐式拷贝构造函数）|构造函数（隐式移动构造函数）|函数（隐式拷贝赋值运算符）|函数（隐式移动赋值运算符）|函数（为此 'operator<=>' 隐式生成的 'operator=='）|继承的构造函数}0%select{|模板| %2}1 不可用：需要%select{ 至少| 至多|}3 %4 %select{|非对象 }6参数%s4，但提供了 %5 %plural{1:1个|:多个}5"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %3}1%select{| has different class%diff{ (expected $ but has $)|}5,6| has different number of parameters (expected %5 but has %6)| has type mismatch at %ordinal5 parameter%diff{ (expected $ but has $)|}6,7| has different return type%diff{ ($ expected but has $)|}5,6| has different qualifiers (expected %5 but found %6)| has different exception specification}4"
-H8C85DA7348D1: "候选%select{函数|函数|参数顺序反转的函数|构造函数|隐式的默认构造函数|隐式的拷贝构造函数|隐式的移动构造函数|隐式的拷贝赋值运算符|隐式的移动赋值运算符|为该'operator<=>'隐式声明的'operator==|继承的构造函数}0%select{|模板| %3}1%select{| 类型不同%diff{（期望$ 但实际为$)|}5,6| 参数数量不同（期望%5 但实际为%6)| 第%ordinal5个参数类型不匹配%diff{（期望$ 但实际为$)|}6,7| 返回类型不同%diff{（$ 期望但实际为$)|}5,6| 返回类型修饰符不同（期望%5 但实际为%6)| 异常规格说明不同}4"
+H8C85DA7348D1: "候选%select{函数|函数|参数顺序反转的函数|构造函数|隐式的默认构造函数|隐式的拷贝构造函数|隐式的移动构造函数|隐式的拷贝赋值运算符|隐式的移动赋值运算符|为该'operator<=>'隐式声明的'operator==|继承的构造函数}0%select{|模板| %3}1%select{| 类型不同%diff{（期望$ 但实际为$)|}5,6| 参数数量不同（期望 %5 但实际为 %6)| 第%ordinal5个参数类型不匹配%diff{（期望$ 但实际为$)|}6,7| 返回类型不同%diff{（$ 期望但实际为$)|}5,6| 返回类型修饰符不同（期望 %5 但实际为 %6)| 异常规格说明不同}4"
 # 'candidate address cannot be taken because parameter %0 has pass_object_size attribute'
 H9C284929AC5A: '无法获取候选地址，因为参数 %0 具有 pass_object_size 属性'
 # 'candidate constructor ignored: cannot be used to construct an object in address space %0'
@@ -18487,7 +18487,7 @@ H46E51FE9BF5C: '候选被忽略：%select{非函数模板|非外围 %select{类�
 # 'candidate template ignored: cannot deduce a type for %0 that would make %2 equal %1'
 H7E4350C35AB8: '候选模板被忽略：无法推导 %0 的类型以使 %2 等同于 %1'
 # 'candidate template ignored: constraints not satisfied%0'
-H6E9C2A6AF9DA: '候选模板被忽略：约束条件不满足%0'
+H6E9C2A6AF9DA: '候选模板被忽略：约束条件不满足 %0'
 # 'candidate template ignored: could not match %diff{$ against $|types}0,1'
 HBFC6A5130527: '候选模板被忽略：无法将 %diff{$ 与 $ 匹配|类型}0,1'
 # 'candidate template ignored: could not match %q0 against %q1'
@@ -18495,27 +18495,27 @@ H95615A85BC94: '候选模板被忽略：无法将 %q0 与 %q1 匹配'
 # "candidate template ignored: couldn't infer template argument %0"
 H0865F809FC7F: '候选模板被忽略：无法推导模板参数 %0'
 # 'candidate template ignored: deduced %select{conflicting types|conflicting values|conflicting templates|packs of different lengths}0 for parameter %1%diff{ ($ vs. $)|}2,3'
-HC96827B6C1DA: '候选模板被忽略：推导出的%select{冲突的类型|冲突的值|冲突的模板|不同长度的包}0对于参数%1%diff{ ($ vs. $)|}2,3'
+HC96827B6C1DA: '候选模板被忽略：推导出的%select{冲突的类型|冲突的值|冲突的模板|不同长度的包}0对于参数 %1%diff{ ($ vs. $)|}2,3'
 # 'candidate template ignored: deduced too few arguments for expanded pack %0; no argument for %ordinal1 expanded parameter in deduced argument pack %2'
-HCCA72493BB47: '候选模板被忽略：为展开的参数包%0 推断出的参数过少；在推断出的参数包%2 中没有为第%ordinal1 展开的参数提供参数'
+HCCA72493BB47: '候选模板被忽略：为展开的参数包 %0 推断出的参数过少；在推断出的参数包 %2 中没有为第%ordinal1 展开的参数提供参数'
 # 'candidate template ignored: deduced type %diff{$ of %select{|element of }4%ordinal0 parameter does not match adjusted type $ of %select{|element of }4argument|of %select{|element of }4%ordinal0 parameter does not match adjusted type of %select{|element of }4argument}1,2%3'
 HF6006A393B95: '候选模板被忽略：推导出的类型%diff{$ of %select{|element of }4%ordinal0参数与调整后的类型$ of %select{|element of }4实参不匹配|of %select{|element of }4%ordinal0参数与调整后的%select{|element of }4实参类型不匹配}1,2%3'
 # 'candidate template ignored: deduced values %diff{of conflicting types for parameter %0 (%1 of type $ vs. %3 of type $)|%1 and %3 of conflicting types for parameter %0}2,4'
 H300B96CC7A66: '模板候选被忽略：推导值 %diff{为参数 %0 的类型冲突（%1 类型 $ 与 %3 类型 $）|参数 %0 的 %1 和 %3 类型冲突}2,4'
 # 'candidate template ignored: disabled by %0%1'
-H0A4EC193E9D6: '候选模板被忽略：被%0%1禁用'
+H0A4EC193E9D6: '候选模板被忽略：被 %0%1 禁用'
 # 'candidate template ignored: failed template argument deduction'
 HF2D6EBE56EA1: '候选模板被忽略：模板实参推导失败'
 # 'candidate template ignored: invalid explicitly-specified argument for %ordinal0 template parameter'
 H7C80ECA5E832: '候选模板被忽略：为第%ordinal0个模板参数显式指定的实参无效'
 # 'candidate template ignored: invalid explicitly-specified argument for template parameter %0'
-HEDC828688F33: '候选模板被忽略：为模板参数%0显式指定的实参无效'
+HEDC828688F33: '候选模板被忽略：为模板参数 %0 显式指定的实参无效'
 # "candidate template ignored: requirement '%0' was not satisfied%1"
-HB155E3417C9D: '候选模板被忽略：要求‘%0’未满足%1'
+HB155E3417C9D: '候选模板被忽略：要求‘%0’未满足 %1'
 # 'candidate template ignored: substitution exceeded maximum template instantiation depth'
 H6065ACD0EE36: '候选模板被忽略：替换超过了模板实例化深度的最大值'
 # 'candidate template ignored: substitution failure%0%1'
-HF32FE861D856: '候选模板被忽略：替换失败%0%1'
+HF32FE861D856: '候选模板被忽略：替换失败 %0%1'
 # 'candidate template ignored: target attributes do not match'
 H8F2E4648A7AB: '候选模板被忽略：目标属性不匹配'
 # "cannot %select{#include files|import headers}0 inside '#pragma clang arc_cf_code_audited'"
@@ -18531,9 +18531,9 @@ H1D574B1BA9C6: '无法%select{赋值|返回|抛出|下标访问}0 WebAssembly �
 # 'cannot %select{capture|take address of}0 WebAssembly reference'
 H1706BDA5F276: '无法%select{捕获|获取地址}0 WebAssembly 引用'
 # 'cannot %select{decrement|increment}0 expression of enum type %1'
-H9709AF91935B: '无法对枚举类型%1执行%select{递减|递增}0操作'
+H9709AF91935B: '无法对枚举类型 %1 执行%select{递减|递增}0操作'
 # 'cannot %select{decrement|increment}1 value of type %0'
-H7C6ED23E2E9F: '无法对类型%0的%select{递减|递增}1值执行操作'
+H7C6ED23E2E9F: '无法对类型 %0 的%select{递减|递增}1值执行操作'
 # 'cannot %select{form pointer to|form reference to|form array of|form function returning|use parentheses when declaring variable with}0 deduced class template specialization type'
 HAF4CF818160D: '无法 %select{形成指向|形成引用指向|形成数组的|形成返回函数的|在声明变量时使用括号}0 推导的类模板特化类型'
 # 'cannot %select{throw|catch}0 a WebAssembly reference type'
@@ -18577,7 +18577,7 @@ H135A3A08A93B: '无法将复制捕获的变量赋值给非可变的 lambda 中�
 # 'cannot assign to class object (%0 invalid)'
 H25AF70C115F7: '无法将类对象赋值（%0 无效）'
 # "cannot assign to this %select{dictionary|array}1 because assigning method's 2nd parameter of type %0 is not an Objective-C pointer type"
-H33D10E761543: '无法将 this %select{字典|数组}1 赋值，因为类型为%0 的第二个参数不是 Objective-C 指针类型'
+H33D10E761543: '无法将 this %select{字典|数组}1 赋值，因为类型为 %0 的第二个参数不是 Objective-C 指针类型'
 # 'cannot befriend target of using declaration'
 H72752EB56616: '无法与 using 声明的目标建立友元关系'
 # 'cannot bind non-lvalue argument %0 to %select{|in}1out paramemter'
@@ -18615,9 +18615,9 @@ H1C20AF9781FF: '无法将类型 %1 转换为指针类型 %2'
 # "cannot cast non-zero value '%0' to 'event_t'"
 HB63F6FC3F823: "无法将非零值 '%0' 转换为 'event_t'"
 # 'cannot cast object of dynamic type %0 to type %1'
-H29A99B2195B9: '无法将动态类型为%0的对象转换为类型%1'
+H29A99B2195B9: '无法将动态类型为 %0 的对象转换为类型 %1'
 # 'cannot catch %select{|reference to }0sizeless type %1'
-HFDB51E9BFE05: '不能捕获%select{|引用到}0大小不明确的类型%1'
+HFDB51E9BFE05: '不能捕获%select{|引用到}0大小不明确的类型 %1'
 # 'cannot catch an Objective-C object by value'
 HE53524ADBBC8: '不能按值捕获Objective-C对象'
 # 'cannot catch an exception thrown with @throw in C++ in the non-unified exception model'
@@ -18625,49 +18625,49 @@ HA5FD18981E9C: '在非统一异常模型中，无法捕获通过C++中@throw抛�
 # 'cannot catch exceptions by rvalue reference'
 H5BF423F821AB: '不能通过右值引用捕获异常'
 # 'cannot catch incomplete type %0'
-H712DCF7BC1DF: '不能捕获不完整类型%0'
+H712DCF7BC1DF: '不能捕获不完整类型 %0'
 # 'cannot catch pointer to incomplete type %0'
-H555C8CE71019: '不能捕获指向不完整类型%0的指针'
+H555C8CE71019: '不能捕获指向不完整类型 %0 的指针'
 # 'cannot catch reference to incomplete type %0'
-HAB26C8BE4E6D: '不能捕获不完整类型%0的引用'
+HAB26C8BE4E6D: '不能捕获不完整类型 %0 的引用'
 # 'cannot catch variably modified type %0'
-H3E0D097A06D0: '不能捕获变长修饰类型%0'
+H3E0D097A06D0: '不能捕获变长修饰类型 %0'
 # 'cannot combine GNU and %select{SVE|RVV}0 vectors in expression, result is ambiguous (%1 and %2)'
-H6D9DAA9A57DC: '无法在表达式中同时使用GNU和%select{SVE|RVV}0向量，结果不明确（%1和%2）'
+H6D9DAA9A57DC: '无法在表达式中同时使用GNU和 %select{SVE|RVV}0 向量，结果不明确（%1 和 %2）'
 # 'cannot combine fixed-length and sizeless %select{SVE|RVV}0 vectors in expression, result is ambiguous (%1 and %2)'
-H3EDDFBE7A4DF: '无法在表达式中同时使用固定长度和大小不明确的%select{SVE|RVV}0向量，结果不明确（%1和%2）'
+H3EDDFBE7A4DF: '无法在表达式中同时使用固定长度和大小不明确的 %select{SVE|RVV}0 向量，结果不明确（%1 和 %2）'
 # "cannot combine with previous '%0' declaration specifier"
-H4EE2F7A93C38: "无法与之前的'%0'声明说明符合并"
+H4EE2F7A93C38: "无法与之前的 '%0' 声明说明符合并"
 # "cannot combine with previous '%0' declaration specifier. '__vector' must be first"
-H856686567DB2: "无法与之前的'%0'声明说明符合并。'__vector'必须放在首位"
+H856686567DB2: "无法与之前的 '%0' 声明说明符合并。'__vector' 必须放在首位"
 # 'cannot compile this %0 yet'
-H395022428A23: '当前无法编译此%0'
+H395022428A23: '当前无法编译此 %0'
 # 'cannot compress debug sections (%0 not enabled)'
-HB2DFAB48BA84: '无法压缩调试部分（%0未启用）'
+HB2DFAB48BA84: '无法压缩调试部分（%0 未启用）'
 # 'cannot compute offset of bit-field %0'
-H55C2FB73C827: '无法计算位字段%0的偏移量'
+H55C2FB73C827: '无法计算位字段 %0 的偏移量'
 # "cannot constant evaluate '%select{memcpy|memmove}0' between objects of incomplete type %1"
-H474B41288CFB: '无法常量评估类型%1的不完全类型之间的%select{memcpy|memmove}0结果'
+H474B41288CFB: '无法常量评估类型 %1 的不完全类型之间的 %select{memcpy|memmove}0 结果'
 # "cannot constant evaluate '%select{memcpy|memmove}0' between objects of non-trivially-copyable type %1"
-H4AA44A4233D2: '无法常量评估非平凡复制类型的%1之间的%select{memcpy|memmove}0结果'
+H4AA44A4233D2: '无法常量评估非平凡复制类型的 %1 之间的 %select{memcpy|memmove}0 结果'
 # "cannot constant evaluate '%select{memcpy|memmove}0' from object of type %1 to object of type %2"
-H6FAB8AA1F441: '无法常量评估从类型%1到类型%2的%select{memcpy|memmove}0结果'
+H6FAB8AA1F441: '无法常量评估从类型 %1 到类型 %2 的 %select{memcpy|memmove}0 结果'
 # 'cannot constant evaluate the result of adjusting alignment to %0'
-H8F0F0485C85D: '无法计算将对齐方式调整到%0后的结果'
+H8F0F0485C85D: '无法计算将对齐方式调整到 %0 后的结果'
 # 'cannot constant evaluate whether run-time alignment is at least %0'
-H8DC5B278E189: '无法在常量表达式中确定运行时对齐是否至少为%0'
+H8DC5B278E189: '无法在常量表达式中确定运行时对齐是否至少为 %0'
 # 'cannot construct object of type %0 with virtual base class in a constant expression'
-H7DD1FDBBEF06: '无法在常量表达式中构造包含虚基类的%0类型的对象'
+H7DD1FDBBEF06: '无法在常量表达式中构造包含虚基类的 %0 类型的对象'
 # 'cannot convert %0 token to an identifier'
-H18B9F6746EBF: '无法将%0标记转换为标识符'
+H18B9F6746EBF: '无法将 %0 标记转换为标识符'
 # 'cannot convert %1 to %2 without a conversion operator'
-H703415593D2A: '无法在没有转换运算符的情况下将%1转换为%2'
+H703415593D2A: '无法在没有转换运算符的情况下将 %1 转换为 %2'
 # 'cannot convert between %select{scalar|vector}0 type %1 and vector type %2 as implicit conversion would cause truncation'
-HF046F296A9B0: '无法在隐式转换会导致截断的情况下在%select{标量|向量}0类型%1和向量类型%2之间进行转换'
+HF046F296A9B0: '无法在隐式转换会导致截断的情况下在%select{标量|向量}0类型 %1 和向量类型 %2 之间进行转换'
 # 'cannot convert between vector and non-scalar values (%0 and %1)'
-HD81F5D7E2B16: '无法在向量类型和非标量类型之间（%0和%1）进行转换'
+HD81F5D7E2B16: '无法在向量类型和非标量类型之间（%0 和 %1）进行转换'
 # 'cannot convert between vector values of different size (%0 and %1)'
-H8810EF643AA5: '无法在不同大小的向量值之间进行转换（%0和%1）'
+H8810EF643AA5: '无法在不同大小的向量值之间进行转换（%0 和 %1）'
 # 'cannot create __weak reference because the current deployment target does not support weak references'
 H54D605FEB00B: '无法创建__weak引用，因为当前部署目标不支持弱引用'
 # 'cannot create __weak reference in file using manual reference counting'
@@ -18675,9 +18675,9 @@ H98AD8AE899EB: '无法在使用手动引用计数的文件中创建__weak引用'
 # 'cannot create a non-constant pointer to member function'
 H909CEC9754E8: '无法创建非常量的成员函数指针'
 # 'cannot create includes file for module %0: %1'
-H521EA5757B62: '无法为模块%0创建包含文件：%1'
+H521EA5757B62: '无法为模块 %0 创建包含文件：%1'
 # 'cannot create object of function type %0'
-HB6BCDD252F4D: '无法声明无名称的类模板%0'
+HB6BCDD252F4D: '无法声明无名称的类模板 %0'
 # 'cannot declare a class template with no name'
 H86275B9FD8C9: '无法在友元中声明显式特例化'
 # 'cannot declare an explicit specialization in a friend'
@@ -18693,17 +18693,17 @@ H11D626BF5B37: '不能在 @interface 或 @protocol 中声明变量'
 # 'cannot decompose %select{private|protected}0 member %1 of %3'
 HAF5B2F15564E: '不能分解 %select{私有|受保护}0 成员 %1 的 %3'
 # 'cannot decompose %select{union|non-class, non-array}1 type %2'
-HD213477C2A3A: '无法分解%select{联合体|非类、非数组}1类型%2'
+HD213477C2A3A: '无法分解%select{联合体|非类、非数组}1类型 %2'
 # 'cannot decompose class type %0 because it has an anonymous %select{struct|union}1 member'
-H687FA194A579: '无法分解类类型%0，因为它包含匿名%select{结构体|联合体}1成员'
+H687FA194A579: '无法分解类类型 %0，因为它包含匿名%select{结构体|联合体}1成员'
 # 'cannot decompose class type %1: %select{its base classes %2 and|both it and its base class}0 %3 have non-static data members'
 HBC0288C04290: '不能分解类类型 %1：%select{其基类 %2 和|该类及其基类}0 %3 有非静态数据成员'
 # 'cannot decompose lambda closure type'
 H3C6B1EAC26ED: '无法分解lambda闭包类型'
 # 'cannot decompose members of ambiguous base class %1 of %0:%2'
-HE08DBE349649: '无法分解%0的二义性基类%1的成员：%2'
+HE08DBE349649: '无法分解 %0 的二义性基类 %1 的成员：%2'
 # 'cannot decompose members of inaccessible base class %1 of %0'
-HA6ED46C6B298: '无法分解%0的不可访问基类%1的成员'
+HA6ED46C6B298: '无法分解 %0 的不可访问基类 %1 的成员'
 # "cannot decompose this type; 'std::tuple_element<%0>::type' does not name a type"
 H4AD140BFCF3D: "无法分解此类型；'std::tuple_element<%0>::type'不是一个类型名称"
 # "cannot decompose this type; 'std::tuple_size<%0>::value' is not a valid integral constant expression"
@@ -18713,101 +18713,101 @@ H9DABD4A4074A: '不能递减类型为bool的表达式'
 # "cannot deduce 'decltype(auto)' from initializer list"
 H0294CF60338E: "无法从初始化列表推导'decltype(auto)'类型"
 # 'cannot deduce actual type for %1 from %select{parenthesized|nested}0 initializer list'
-H1C99EC9B7047: '无法从%select{括号包围的|嵌套}0初始化列表推导%1的实际类型'
+H1C99EC9B7047: '无法从%select{括号包围的|嵌套}0初始化列表推导 %1 的实际类型'
 # 'cannot deduce actual type for variable %0 with type %1 from initializer list'
-HA7FCCDD3352E: '无法从初始化列表推导变量%0（类型%1）的实际类型'
+HA7FCCDD3352E: '无法从初始化列表推导变量 %0（类型 %1）的实际类型'
 # 'cannot deduce implicit triple value for -Xopenmp-target, specify triple using -Xopenmp-target=<triple>'
-HBB4FDAD01556: '无法推导-Xopenmp-target的隐式目标三元组值，请使用-Xopenmp-target=<triple>指定三元组'
+HBB4FDAD01556: '无法推导-Xopenmp-target的隐式目标三元组值，请使用-Xopenmp-target=<triple> 指定三元组'
 # 'cannot deduce lambda return type from initializer list'
 HBF4499B07FAC: '无法从初始化列表推导lambda返回类型'
 # 'cannot deduce return type %0 for function with no return statements'
-H4A0B0541DA05: '无法为无return语句的函数推导返回类型%0'
+H4A0B0541DA05: '无法为无return语句的函数推导返回类型 %0'
 # 'cannot deduce return type %0 from omitted return expression'
-HF76745F04CDD: '无法从省略的返回表达式推导返回类型%0'
+HF76745F04CDD: '无法从省略的返回表达式推导返回类型 %0'
 # 'cannot deduce return type %0 from returned value of type %1'
-HFF6A0873771C: '无法从类型%1的返回值推导返回类型%0'
+HFF6A0873771C: '无法从类型 %1 的返回值推导返回类型 %0'
 # 'cannot deduce return type from initializer list'
 HD33E533A8026: '无法从初始化列表推导返回类型'
 # 'cannot deduce template arguments for %0 from %1'
-H59FFC4EE513D: '无法为%0从%1推导模板参数'
+H59FFC4EE513D: '无法为 %0 从 %1 推导模板参数'
 # 'cannot deduce type for lambda capture %0 from initializer list'
-HD1B46B897454: '无法从初始化列表推导lambda捕获%0的类型'
+HD1B46B897454: '无法从初始化列表推导lambda捕获 %0 的类型'
 # 'cannot deduce type for lambda capture %0 from initializer of type %2'
-H5BED86131FDB: '无法推导类型%0的lambda捕获类型，因为初始化器的类型为%2'
+H5BED86131FDB: '无法推导类型 %0 的lambda捕获类型，因为初始化器的类型为 %2'
 # 'cannot deduce type for lambda capture %1 from %select{parenthesized|nested}0 initializer list'
-HBAF719ACD121: '无法从%select{括号|嵌套}0初始化列表推导lambda捕获%1的类型'
+HBAF719ACD121: '无法从%select{括号|嵌套}0初始化列表推导lambda捕获 %1 的类型'
 # 'cannot deduce type for variable %1 with type %2 from %select{parenthesized|nested}0 initializer list'
-HDBF6BFDD94D3: '无法从%select{括号|嵌套}0初始化列表推导类型%2的变量%1'
+HDBF6BFDD94D3: '无法从%select{括号|嵌套}0初始化列表推导类型 %2 的变量 %1'
 # 'cannot deduce type of initializer list because std::initializer_list was not found; include <initializer_list>'
-H61AB50323785: '无法推导初始化列表类型，因为未找到std::initializer_list；请包含<initializer_list>'
+H61AB50323785: '无法推导初始化列表类型，因为未找到std::initializer_list；请包含 <initializer_list>'
 # 'cannot define %select{category|class extension}0 for undefined class %1'
-H075CA56C0949: '无法为未定义的类%1定义%select{分类|类扩展}0'
+H075CA56C0949: '无法为未定义的类 %1 定义%select{分类|类扩展}0'
 # 'cannot define a type in a friend declaration'
 H90F602DED3B4: '无法在友元声明中定义类型'
 # 'cannot define friend function %0 in a local class definition; did you mean %3?'
-H40B3F3B5FBB1: '无法在本地类定义中声明友元函数%0；是否应改为%3？'
+H40B3F3B5FBB1: '无法在本地类定义中声明友元函数 %0；是否应改为 %3？'
 # 'cannot define friend function in a local class definition'
 HB60D03F3A5C5: '无法在本地类定义中声明友元函数'
 # 'cannot define non-inline dllimport template specialization'
 HF67617A49B06: '无法定义非内联dllimport模板特化'
 # 'cannot define or redeclare %0 here because namespace %1 does not enclose namespace %2'
-HFA38E82744C2: '无法在此处定义或重新声明%0，因为命名空间%1不包含命名空间%2'
+HFA38E82744C2: '无法在此处定义或重新声明 %0，因为命名空间 %1 不包含命名空间 %2'
 # 'cannot define the implicit copy assignment operator for %0, because non-static %select{reference|const}1 member %2 cannot use copy assignment operator'
-H50812469123A: '无法为%0推导隐式拷贝赋值运算符，因为非静态%select{引用|const}1成员%2无法使用拷贝赋值运算符'
+H50812469123A: '无法为 %0 推导隐式拷贝赋值运算符，因为非静态%select{引用|const}1成员 %2 无法使用拷贝赋值运算符'
 # 'cannot delete expression of type %0'
-H8F9B57A837EE: '无法删除类型%0的表达式'
+H8F9B57A837EE: '无法删除类型 %0 的表达式'
 # "cannot delete expression with pointer-to-'void' type %0"
-HCCFA093E9DE2: "无法删除类型%0的指向'void'指针表达式"
+HCCFA093E9DE2: "无法删除类型 %0 的指向 'void' 指针表达式"
 # 'cannot delete pointer to incomplete type %0'
-H7E32F7F5C2AD: '无法删除指向不完整类型%0的指针'
+H7E32F7F5C2AD: '无法删除指向不完整类型 %0 的指针'
 # "cannot determine %0 architecture: %1; consider passing it via '%2'; environment variable CLANG_TOOLCHAIN_PROGRAM_TIMEOUT specifies the tool timeout (integer secs, <=0 is infinite)"
-H9E1578DA83DB: '无法确定%0架构：%1；建议通过参数"%2"传递；环境变量CLANG_TOOLCHAIN_PROGRAM_TIMEOUT指定工具超时时间（整数秒，≤0表示无限）'
+H9E1578DA83DB: '无法确定 %0 架构：%1；建议通过参数 "%2" 传递；环境变量CLANG_TOOLCHAIN_PROGRAM_TIMEOUT指定工具超时时间（整数秒，≤0表示无限）'
 # 'cannot determine allocated array size from initializer'
 H3573086C6F39: '无法从初始化器确定分配数组的大小'
 # 'cannot determine number of elements for sizeless vectors in a constant expression'
 HAFC6AFA63009: '无法在常量表达式中确定无大小向量的元素数量'
 # 'cannot determine underlying type of incomplete enumeration type %0'
-H486DE8FE7D9E: '无法获取不完整枚举类型%0的底层类型'
+H486DE8FE7D9E: '无法获取不完整枚举类型 %0 的底层类型'
 # 'cannot emit module %0: %select{size|mtime}1 must be explicitly specified for missing header file "%2"'
-H4AFEE6C7D624: '无法生成模块%0：%select{大小|修改时间}1必须显式指定缺失头文件"%2"'
+H4AFEE6C7D624: '无法生成模块 %0：%select{大小|修改时间}1必须显式指定缺失头文件 "%2"'
 # 'cannot evaluate call to virtual function in a constant expression in C++ standards before C++20'
 HC06FC1196550: '无法在C++20之前的C++标准的常量表达式中求值虚函数调用'
 # 'cannot evaluate this expression if rounding mode is dynamic'
 HC673B661CF5A: '如果舍入模式是动态的，则无法求值此表达式'
 # 'cannot export %0 as it is not at namespace scope'
-H49EEB2061C19: '无法导出%0，因为它不在命名空间作用域中'
+H49EEB2061C19: '无法导出 %0，因为它不在命名空间作用域中'
 # 'cannot export redeclaration %0 here since the previous declaration %select{is not exported|has internal linkage|has module linkage}1'
-H805545AFF107: '由于之前的声明%select{未导出|具有内部链接性|具有模块链接性}1，因此无法在此处导出%0的重新声明'
+H805545AFF107: '由于之前的声明%select{未导出|具有内部链接性|具有模块链接性}1，因此无法在此处导出 %0 的重新声明'
 # "cannot find CUDA installation; provide its path via '--cuda-path', or pass '-nocudainc' to build without CUDA includes"
 H483DC86F4594: "无法找到CUDA安装路径；请通过'--cuda-path'提供其路径，或使用'-nocudainc'选项不包含CUDA头文件进行编译"
 # "cannot find HIP Standard Parallelism Acceleration library; provide it via '--hipstdpar-path'"
 H20ABDE201926: "无法找到HIP标准并行加速库；请通过'--hipstdpar-path'提供其路径"
 # "cannot find HIP device library%select{| for %1}0; provide its path via '--hip-path' or '--hip-device-lib-path', or pass '-nogpulib' to build without HIP device library"
-H74B6BE24033A: "无法找到HIP设备库%select{|用于%1}0；请通过'--hip-path'或'--hip-device-lib-path'提供其路径，或使用'-nogpulib'选项不链接HIP设备库进行编译"
+H74B6BE24033A: "无法找到HIP设备库%select{|用于 %1}0；请通过'--hip-path'或'--hip-device-lib-path'提供其路径，或使用'-nogpulib'选项不链接HIP设备库进行编译"
 # "cannot find HIP runtime; provide its path via '--rocm-path', or pass '-nogpuinc' to build without HIP runtime"
 H11EBFA045BE3: "无法找到HIP运行时；请通过'--rocm-path'提供其路径，或使用'-nogpuinc'选项不包含HIP运行时进行编译"
 # "cannot find ROCm device library%select{| for %1| for ABI version %1}0; provide its path via '--rocm-path' or '--rocm-device-lib-path', or pass '-nogpulib' to build without ROCm device library"
-H7B7F4A357272: "无法找到ROCm设备库%select{|用于%1|用于ABI版本%1}0；请通过'--rocm-path'或'--rocm-device-lib-path'提供其路径，或使用'-nogpulib'选项不链接ROCm设备库进行编译"
+H7B7F4A357272: "无法找到ROCm设备库%select{|用于 %1|用于ABI版本 %1}0；请通过'--rocm-path'或'--rocm-device-lib-path'提供其路径，或使用'-nogpulib'选项不链接ROCm设备库进行编译"
 # 'cannot find a valid user-defined mapper for type %0 with name %1'
-H0907A5973C27: '未找到类型%0且名称为%1的有效用户自定义映射器'
+H0907A5973C27: '未找到类型 %0 且名称为 %1 的有效用户自定义映射器'
 # "cannot find end ('%1') of expected %0"
-H53A2AE90D9C0: "无法找到期望%0的结束标记'%1'"
+H53A2AE90D9C0: "无法找到期望 %0 的结束标记 '%1'"
 # 'cannot find interface declaration for %0'
-H7325D139C40F: '未找到%0的接口声明'
+H7325D139C40F: '未找到 %0 的接口声明'
 # 'cannot find interface declaration for %0, superclass of %1'
-HDDF90FE7BE8F: '未找到%0的接口声明（%1的基类）'
+HDDF90FE7BE8F: '未找到 %0 的接口声明（%1 的基类）'
 # 'cannot find interface declaration for %0, superclass of %1; did you mean %2?'
-H691319D1E232: '未找到%0的接口声明（%1的基类）；是否是指%2？'
+H691319D1E232: '未找到 %0 的接口声明（%1 的基类）；是否是指 %2？'
 # 'cannot find interface declaration for %0; did you mean %1?'
-H3FD5BD5869C6: '未找到%0的接口声明；是否是指%1？'
+H3FD5BD5869C6: '未找到 %0 的接口声明；是否是指 %1？'
 # "cannot find libdevice for %0; provide path to different CUDA installation via '--cuda-path', or pass '-nocudalib' to build without linking with libdevice"
-H9C8FBD27D916: "无法找到%0的libdevice；请通过'--cuda-path'提供其他CUDA安装路径，或使用'-nocudalib'选项不链接libdevice进行编译"
+H9C8FBD27D916: "无法找到 %0 的libdevice；请通过'--cuda-path'提供其他CUDA安装路径，或使用'-nocudalib'选项不链接libdevice进行编译"
 # 'cannot find protocol declaration for %0'
-H8559765777E9: '未找到%0的协议声明'
+H8559765777E9: '未找到 %0 的协议声明'
 # 'cannot find protocol declaration for %0; did you mean %1?'
-H39967D7F0C23: '未找到%0的协议声明；是否是指%1？'
+H39967D7F0C23: '未找到 %0 的协议声明；是否是指 %1？'
 # 'cannot find protocol definition for %0'
-H30EC809C2E8C: '未找到%0的协议定义'
+H30EC809C2E8C: '未找到 %0 的协议定义'
 # "cannot find re-exported %select{framework|library}0: '%1'"
 HFF74F7CAAAC8: "无法找到导出的%select{框架|库}0：'%1'"
 # "cannot find rocPrim, which is required by the HIP Standard Parallelism Acceleration library; provide it via '--hipstdpar-prim-path'"
@@ -18815,45 +18815,45 @@ H7420A8DBF79F: "无法找到由HIP标准并行加速库所需的rocPrim；请通
 # "cannot find rocThrust, which is required by the HIP Standard Parallelism Acceleration library; provide it via '--hipstdpar-thrust-path'"
 HF20DC196E1CB: "找不到rocThrust，这是HIP标准并行加速库所必需的；请通过'--hipstdpar-thrust-path'提供它"
 # "cannot find start ('{{') of expected %0"
-H727EB43115FC: "无法找到期望%0的起始标记'{{'"
+H727EB43115FC: "无法找到期望 %0 的起始标记'{{'"
 # "cannot find start of regex ('{{') in %0"
-HD5BDA70A3617: "在%0中找不到正则表达式的起始符（'{{'）"
+HD5BDA70A3617: "在 %0 中找不到正则表达式的起始符（'{{'）"
 # 'cannot find suitable %select{getter|setter}0 for property %1'
-H0F811370E791: '找不到适合属性%1的%select{getter|setter}0'
+H0F811370E791: '找不到适合属性 %1 的 %select{getter|setter}0'
 # "cannot form %select{pointer to|reference to|array of}0 'decltype(auto)'"
 H7F41F0A9CCC7: "无法形成%select{指向|引用|数组}0 'decltype(auto)'"
 # 'cannot form a %select{pointer|reference}0 to a WebAssembly table'
 H3C39E76E28BC: '无法形成指向WebAssembly表的%select{指针|引用}0'
 # 'cannot form a pointer-to-member to member %0 of reference type %1'
-H45A1DB7A6AF3: '无法形成引用类型%1的成员%0的成员指针'
+H45A1DB7A6AF3: '无法形成引用类型 %1 的成员 %0 的成员指针'
 # "cannot form a reference to 'void'"
-H6E82068C4FE4: "无法形成对'void'的引用"
+H6E82068C4FE4: "无法形成对 'void' 的引用"
 # "cannot form member pointer of type %0 without '&' and class name"
-HA98A1BC7CEC4: "无法在没有'&'和类名的情况下形成类型%0的成员指针"
+HA98A1BC7CEC4: "无法在没有'&'和类名的情况下形成类型 %0 的成员指针"
 # 'cannot generate code for reduction on %select{|array section, which requires a }0variable length array'
 H328E15AAC013: '无法为%select{|数组段，需要一个}0变长数组生成代码'
 # 'cannot have both throw() and noexcept() clause on the same function'
 H93A58AAAE480: '同一个函数不能同时使用throw()和noexcept()子句'
 # 'cannot implement a category for class %0 that is only visible via the Objective-C runtime'
-H93EA111FC5EC: '无法为仅通过Objective-C运行时可见的类%0实现类别'
+H93EA111FC5EC: '无法为仅通过Objective-C运行时可见的类 %0 实现类别'
 # 'cannot implement subclass %0 of a superclass %1 that is only visible via the Objective-C runtime'
-H0C79ADD5940E: '无法为仅通过Objective-C运行时可见的超类%1实现子类%0'
+H0C79ADD5940E: '无法为仅通过Objective-C运行时可见的超类 %1 实现子类 %0'
 # 'cannot import unsupported AST node %0'
-H4E75F3A5019B: '无法导入不受支持的AST节点%0'
+H4E75F3A5019B: '无法导入不受支持的AST节点 %0'
 # 'cannot initialize %select{a variable|a parameter|template parameter|return object|statement expression result|an exception object|a member subobject|an array element|a new value|a value|a base class|a constructor delegation|a vector element|a block element|a block element|a complex element|a lambda capture|a compound literal initializer|a related result|a parameter of CF audited function|a structured binding|a member subobject}0 %diff{of type $ with an %select{rvalue|lvalue}2 of type $|with an %select{rvalue|lvalue}2 of incompatible type}1,3%select{|: different classes%diff{ ($ vs $)|}5,6|: different number of parameters (%5 vs %6)|: type mismatch at %ordinal5 parameter%diff{ ($ vs $)|}6,7|: different return type%diff{ ($ vs $)|}5,6|: different qualifiers (%5 vs %6)|: different exception specifications}4'
 H5225AD7ABD6B: '无法初始化 %select{变量|参数|模板参数|返回对象|表达式结果|异常对象|成员子对象|数组元素|新值|值|基类|构造函数委托|向量元素|块元素|块元素|复数元素|lambda 捕获|复合字面量初始化器|相关结果|CF 审计函数参数|结构化绑定|成员子对象}0 %diff{类型为 $ 的 %select{右值|左值}2 类型 $|与类型不兼容的 %select{右值|左值}2}1,3%select{|：不同类%diff{ ($ vs $)|}5,6|：参数数量不同（%5 vs %6）|：第 %ordinal5 参数类型不同%diff{ ($ vs $)|}6,7|：返回类型不同%diff{ ($ vs $)|}5,6|：限定符不同（%5 vs %6）|：异常说明不同}4'
 # 'cannot initialize %select{non-class|reference}0 type %1 with a parenthesized initializer list'
-HE63727C8C08B: '无法用括号括起的初始化列表初始化%select{非类|引用}0类型%1'
+HE63727C8C08B: '无法用括号括起的初始化列表初始化%select{非类|引用}0类型 %1'
 # 'cannot initialize Objective-C class type %0'
-HA709360A8ABC: '无法初始化Objective-C类类型%0'
+HA709360A8ABC: '无法初始化Objective-C类类型 %0'
 # 'cannot initialize array %diff{of type $ with array of type $|with different type of array}0,1'
 HA759EFFA1CC7: '无法初始化数组 %diff{类型 $ 与类型 $ 的数组|数组类型不同}0,1'
 # 'cannot initialize array %diff{of type $ with non-constant array of type $|with different type of array}0,1'
 HAEED299DACD1: '不能用不同类型数组初始化 %diff{类型 $ 的数组与非常量数组类型 $|不同类型的数组}0,1'
 # 'cannot initialize object parameter of type %0 with an expression of type %1'
-H01F0C7FE2242: '无法用类型%1的表达式初始化类型%0的对象参数'
+H01F0C7FE2242: '无法用类型 %1 的表达式初始化类型 %0 的对象参数'
 # 'cannot instantiate %0 yet'
-H3C23130222AC: '无法实例化%0'
+H3C23130222AC: '无法实例化 %0'
 # 'cannot jump from switch statement to this case label'
 H0147E81C1C5E: '无法从switch语句跳转到此case标签'
 # 'cannot jump from this %select{indirect|asm}0 goto statement to one of its possible targets'
@@ -18863,17 +18863,17 @@ HF65BBB33CB19: '无法从此continue语句跳转到循环增量；跳转绕过�
 # 'cannot jump from this goto statement to its label'
 HF7AC509BA0D6: '无法从此goto语句跳转到其标签'
 # 'cannot jump from this goto statement to label %0 inside an inline assembly block'
-HBD667F79ECB9: '无法从此goto语句跳转到内联汇编块内的标签%0'
+HBD667F79ECB9: '无法从此goto语句跳转到内联汇编块内的标签 %0'
 # "cannot link module '%0': %1"
-H957779E89D24: "无法链接模块'%0'：%1"
+H957779E89D24: "无法链接模块 '%0'：%1"
 # 'cannot locate code-completion file %0'
-H00AA0E96170A: '无法定位代码补全文件%0'
+H00AA0E96170A: '无法定位代码补全文件 %0'
 # 'cannot mangle fixed point literals yet'
 H175F8CE0FB1D: '无法对定点字面量进行名称修饰'
 # 'cannot mangle this %0 %1 yet'
-H50F33B0E4B4E: '无法对此%0 %1进行名称修饰'
+H50F33B0E4B4E: '无法对此 %0 %1 进行名称修饰'
 # 'cannot mangle this %0 yet'
-H1C98A95C714E: '无法对此%0进行名称修饰'
+H1C98A95C714E: '无法对此 %0 进行名称修饰'
 # 'cannot mangle this dependent fixed-length RVV vector type yet'
 H01F50B3350B7: '无法对依赖的固定长度RVV向量类型进行名称修饰'
 # 'cannot mangle this dependent fixed-length SVE vector type yet'
@@ -18891,7 +18891,7 @@ HC2203B0385F9: '格式字符串中不能同时使用位置参数和非位置参�
 # 'cannot mix vectors and extended vectors in a vector conditional'
 H0C69F5DF40B4: '向量条件中不能同时使用向量和扩展向量'
 # "cannot nest 'critical' regions having the same name %0"
-HB0FDA4DB5B6B: "不能嵌套具有相同名称%0的'critical'区域"
+HB0FDA4DB5B6B: "不能嵌套具有相同名称 %0 的 'critical' 区域"
 # "cannot open file '%0': %1"
 H7B318395BD4F: '无法打开文件“%0”：%1'
 # "cannot overload a member function %select{without a ref-qualifier|with ref-qualifier '&'|with ref-qualifier '&&'}0 with a member function %select{without a ref-qualifier|with ref-qualifier '&'|with ref-qualifier '&&'}1"
@@ -18901,25 +18901,25 @@ H8D083337F734: '不能覆盖由超类直接声明的方法'
 # 'cannot parenthesize the name of a method when forming a member pointer'
 H733C76C89DE9: '不能在形成成员指针时对方法的名称加括号'
 # 'cannot pass %select{expression of type %1|initializer list}0 to variadic %select{function|block|method|constructor}2'
-H25763FEA732A: '不能将%select{类型%1的表达式|初始化列表}0传递给可变参数%select{函数|块|方法|构造函数}2'
+H25763FEA732A: '不能将%select{类型 %1 的表达式|初始化列表}0传递给可变参数%select{函数|块|方法|构造函数}2'
 # 'cannot pass %select{expression of type %1|initializer list}0 to variadic %select{function|block|method|constructor}2; expected type from format string was %3'
-H6A81C62CC358: '无法将%select{类型%1的表达式|初始化列表}0传递给可变参数%select{函数|块|方法|构造函数}2；格式字符串期望的类型是%3'
+H6A81C62CC358: '无法将%select{类型 %1 的表达式|初始化列表}0传递给可变参数%select{函数|块|方法|构造函数}2；格式字符串期望的类型是 %3'
 # 'cannot pass %select{non-POD|non-trivial}0 object of type %1 to variadic %select{function|block|method|constructor}2; expected type from format string was %3'
-HB3C416B2C325: '无法将%select{非POD|非平凡}0类型%1的对象传递给可变参数%select{函数|块|方法|构造函数}2；格式字符串期望的类型是%3'
+HB3C416B2C325: '无法将%select{非POD|非平凡}0类型 %1 的对象传递给可变参数%select{函数|块|方法|构造函数}2；格式字符串期望的类型是 %3'
 # 'cannot pass a pointer-to-member through register-constrained inline assembly parameter'
 H1A2FFC7DC3D0: '不能通过寄存器约束的内联汇编参数传递成员指针'
 # 'cannot pass bit-field as __auto_type initializer in C'
 HC2EE224C8229: '不能在C中将位域作为__auto_type初始化器'
 # 'cannot pass non-trivial C object of type %0 by value to variadic %select{function|block|method|constructor}1'
-H2C5461696894: '不能通过值传递非平凡C类型%0的对象给可变参数%select{函数|块|方法|构造函数}1'
+H2C5461696894: '不能通过值传递非平凡C类型 %0 的对象给可变参数%select{函数|块|方法|构造函数}1'
 # 'cannot pass object of %select{non-POD|non-trivial}0 type %1 through variadic %select{function|block|method|constructor}2; call will abort at runtime'
-H03C685EEC43F: '不能将%select{非POD|非平凡}0类型%1对象传递给可变参数%select{函数|块|方法|构造函数}2；调用将在运行时终止'
+H03C685EEC43F: '不能将%select{非POD|非平凡}0类型 %1 对象传递给可变参数%select{函数|块|方法|构造函数}2；调用将在运行时终止'
 # 'cannot pass object with interface type %0 by value through variadic %select{function|block|method|constructor}1'
-HFFB4BE108833: '不能通过值传递具有接口类型%0的对象给可变参数%select{函数|块|方法|构造函数}1'
+HFFB4BE108833: '不能通过值传递具有接口类型 %0 的对象给可变参数%select{函数|块|方法|构造函数}1'
 # 'cannot pass object with interface type %1 by value to variadic %select{function|block|method|constructor}2; expected type from format string was %3'
-HFCF01B48F1C2: '无法将接口类型%1的对象按值传递给可变参数%select{函数|块|方法|构造函数}2；格式字符串期望的类型是%3'
+HFCF01B48F1C2: '无法将接口类型 %1 的对象按值传递给可变参数%select{函数|块|方法|构造函数}2；格式字符串期望的类型是 %3'
 # "cannot pass undiscriminated type %0 to '__builtin_ptrauth_type_discriminator'"
-HCF5D52D0F4BA: "无法将未区分的类型%0传递给'__builtin_ptrauth_type_discriminator'"
+HCF5D52D0F4BA: "无法将未区分的类型 %0 传递给 '__builtin_ptrauth_type_discriminator'"
 # 'cannot perform a tail call %select{from|to}0 a %select{constructor|destructor}1'
 H92D6BE5E0D10: '无法在%select{从|到}0%select{构造函数|析构函数}1执行尾调用'
 # 'cannot perform a tail call from this return statement'
@@ -18929,15 +18929,15 @@ H32E425482ACE: '无法对%select{| %1}0函数执行尾调用，因为它使用�
 # 'cannot perform a tail call to function%select{| %1}0 because its signature is incompatible with the calling function'
 HB6791E3481C6: '无法对%select{| %1}0函数执行尾调用，因为其签名与调用函数不兼容'
 # 'cannot perform atomic operation on a pointer to type %0: type has non-trivial ownership'
-H33A9E57472E9: '无法对类型%0的指针执行原子操作：该类型具有非平凡所有权'
+H33A9E57472E9: '无法对类型 %0 的指针执行原子操作：该类型具有非平凡所有权'
 # "cannot read configuration file '%0': %1"
 H0AF7279B0969: '无法读取配置文件“%0”：%1'
 # "cannot read randomize layout seed file '%0'"
-H97BBD89360BC: "无法读取随机化布局种子文件'%0'"
+H97BBD89360BC: "无法读取随机化布局种子文件 '%0'"
 # "cannot rebuild module '%0' as it is already finalized"
-H80C2AA3A79E5: "无法重新构建模块'%0'，因为它已被最终确定"
+H80C2AA3A79E5: "无法重新构建模块 '%0'，因为它已被最终确定"
 # 'cannot redeclare builtin function %0'
-HC3E811B65243: '不能重新声明内建函数%0'
+HC3E811B65243: '不能重新声明内建函数 %0'
 # 'cannot refer to a block inside block'
 HEC4D55F7E1FA: '不能在代码块内引用该代码块内部'
 # 'cannot refer to a non-static member from the handler of a %select{constructor|destructor}0 function try block'
@@ -18949,23 +18949,23 @@ H3ACCC42BDE35: '不能在代码块内引用具有变长类型声明的变量'
 # 'cannot refer to declaration with an array type inside block'
 HBA9381EF3C23: '不能在代码块内引用具有数组类型的声明'
 # 'cannot refer to element %0 of %select{array of %2 element%plural{1:|:s}2|non-array object}1 in a constant expression'
-H97B7B294ED7C: '不能在常量表达式中引用%select{包含%2元素的数组%plural{1:|:s}2|非数组对象}1的元素%0'
+H97B7B294ED7C: '不能在常量表达式中引用%select{包含 %2 元素的数组%plural{1:|:s}2|非数组对象}1的元素 %0'
 # "cannot refer to member %0 in %1 with '%select{.|->}2'"
-HF25CD96D4723: "无法使用'%select{.|->}2'在%1中引用成员%0"
+HF25CD96D4723: "无法使用'%select{.|->}2'在 %1 中引用成员 %0"
 # "cannot refer to type member %0 in %1 with '%select{.|->}2'"
-H982BCA02E9FD: "无法使用'%select{.|->}2'在%1中引用类型成员%0"
+H982BCA02E9FD: "无法使用'%select{.|->}2'在 %1 中引用类型成员 %0"
 # 'cannot reference member of primary template because deduced class template specialization %0 is %select{instantiated from a partial|an explicit}1 specialization'
-HF04074EDD691: '无法引用主模板的成员，因为推导出的类模板特化%0是%select{部分特化|显式}1的特化'
+HF04074EDD691: '无法引用主模板的成员，因为推导出的类模板特化 %0 是%select{部分特化|显式}1的特化'
 # 'cannot resolve lock expression'
 H9831838AB057: '无法解析锁表达式'
 # 'cannot return from %0'
-HDE7181BDC39D: '不能从%0返回'
+HDE7181BDC39D: '不能从 %0 返回'
 # 'cannot set vtable pointer authentication on %0 which is a subclass of polymorphic type %1'
-H8615F820D27E: '不能为多态类型%1的子类%0设置虚表指针认证'
+H8615F820D27E: '不能为多态类型 %1 的子类 %0 设置虚表指针认证'
 # 'cannot set vtable pointer authentication on an incomplete type %0'
-H50389542B8AD: '不能为不完全类型%0设置虚表指针认证'
+H50389542B8AD: '不能为不完全类型 %0 设置虚表指针认证'
 # 'cannot set vtable pointer authentication on monomorphic type %0'
-H365AD22227CA: '不能为单态类型%0设置虚表指针认证'
+H365AD22227CA: '不能为单态类型 %0 设置虚表指针认证'
 # "cannot specialize %select{|(with 'template<>') }0a member of an unspecialized template"
 H21C951459621: "不能特化未特化的模板成员%select{|(使用'template<>' )}0"
 # 'cannot specialize a %select{dependent template|template template parameter}0'
@@ -19025,7 +19025,7 @@ H485C835C56BA: '无法将 @selector 表达式进行类型转换'
 # "cannot use %select{'auto'|<ERROR>|'__auto_type'}0 with %select{initializer list|array}1 in C"
 HE2E4F9E6D620: "不能在 C 中将 %select{'auto'|<ERROR>|'__auto_type'}0 与 %select{初始化列表|数组}1 一起使用"
 # "cannot use %select{C++ 'try'|Objective-C '@try'}0 in the same function as SEH '__try'"
-H455974313E2A: "不能在同一函数中同时使用%select{C++ 'try'|Objective-C '@try'}0和SEH的'__try'"
+H455974313E2A: "不能在同一函数中同时使用%select{C++ 'try'|Objective-C '@try'}0和SEH的 '__try'"
 # 'cannot use %select{dot|arrow}0 operator on a type'
 H546BD63E07E0: '不能对类型使用 %select{点|箭头}0 运算符'
 # "cannot use %select{unicode|wide}0 string literal in 'asm'"
@@ -19049,63 +19049,63 @@ HD41E42BADD92: "不能将 'long double' 与 '__vector' 一起使用"
 # "cannot use 'long' with '__vector'"
 H0DD309217BB4: "不能将 'long' 与 '__vector' 一起使用"
 # "cannot use SEH '__try' in a coroutine when C++ exceptions are enabled"
-H0484D634DF37: "在启用C++异常时，不能在协程中使用SEH的'__try'"
+H0484D634DF37: "在启用C++异常时，不能在协程中使用SEH的 '__try'"
 # "cannot use SEH '__try' in blocks, captured regions, or Obj-C method decls"
-HAED8CA9442A3: "不能在块、捕获区域或Objective-C方法声明中使用SEH的'__try'"
+HAED8CA9442A3: "不能在块、捕获区域或Objective-C方法声明中使用SEH的 '__try'"
 # 'cannot use WebAssembly table as a function parameter'
 H70C162E9FD41: '不能将WebAssembly表用作函数参数'
 # 'cannot use a WebAssembly table within a branch of a conditional expression'
 H4CC748CB0567: '不能在条件表达式的一个分支中使用WebAssembly表'
 # "cannot use a protocol declared 'objc_non_runtime_protocol' in a @protocol expression"
-H22D18CFED6B9: "不能在@protocol表达式中使用标记为'objc_non_runtime_protocol'的协议"
+H22D18CFED6B9: "不能在@protocol表达式中使用标记为 'objc_non_runtime_protocol' 的协议"
 # "cannot use an empty string literal in 'asm'"
-H9269C6D18FCF: "不能在'asm'中使用空字符串字面量"
+H9269C6D18FCF: "不能在 'asm' 中使用空字符串字面量"
 # 'cannot use dynamic_cast to convert from %0 to %1'
-H5749CC5204B8: '不能将dynamic_cast用于从%0到%1的转换'
+H5749CC5204B8: '不能将dynamic_cast用于从 %0 到 %1 的转换'
 # 'cannot use incomplete type %0 as a range'
-H779605C5A805: '不能将不完整类型%0用作范围'
+H779605C5A805: '不能将不完整类型 %0 用作范围'
 # 'cannot use initializer list at the beginning of a macro argument'
 HFB12BDAF6D6F: '不能在宏参数开头使用初始化列表'
 # 'cannot use type %0 as a range'
-H9F644F56E9E3: '不能将类型%0用作范围'
+H9F644F56E9E3: '不能将类型 %0 用作范围'
 # 'cannot use type %0 as an iterator'
-H45599EAAF2D8: '不能将类型%0用作迭代器'
+H45599EAAF2D8: '不能将类型 %0 用作迭代器'
 # "cannot use type '%0' within '#pragma clang fp eval_method'; type is set according to the default eval method for the translation unit"
-HD91CCA267FD1: "不能在'#pragma clang fp eval_method'中使用类型'%0'；该类型由翻译单元的默认求值方法决定"
+HD91CCA267FD1: "不能在'#pragma clang fp eval_method'中使用类型 '%0'；该类型由翻译单元的默认求值方法决定"
 # 'cannot use variable %1 in collapsed imperfectly-nested loop %select{init|condition|increment}0 statement'
-H40887EDB8E4A: '无法在折叠的嵌套循环%select{init|condition|increment}0语句中使用变量%1'
+H40887EDB8E4A: '无法在折叠的嵌套循环 %select{init|condition|increment}0 语句中使用变量 %1'
 # 'cannot use variable-length arrays in %select{__device__|__global__|__host__|__host__ __device__}0 functions'
 H33A7639314BD: '不能在%select{__device__|__global__|__host__|__host__ __device__}0函数中使用变长数组'
 # "cannot write file '%0': %1"
-H57D82DC5A945: '无法写入文件"%0": %1'
+H57D82DC5A945: '无法写入文件 "%0": %1'
 # 'cannot yet @encode type %0'
-H5CF1C5265DEE: '目前无法@encode类型%0'
+H5CF1C5265DEE: '目前无法@encode类型 %0'
 # 'cannot yet compile %0 in this ABI'
-H7B123038B924: '当前ABI无法编译%0'
+H7B123038B924: '当前ABI无法编译 %0'
 # 'cannot yet mangle %0 expression'
-HA255CBB16444: '目前无法对%0表达式进行名称修饰'
+HA255CBB16444: '目前无法对 %0 表达式进行名称修饰'
 # 'cannot yet mangle OpenACC Asterisk Size expression'
 H2D31700B7C49: '目前无法对OpenACC星号大小表达式进行名称修饰'
 # 'cannot yet mangle expression type %0'
-HF4D45A826D3A: '无法对表达式类型%0进行名称修饰'
+HF4D45A826D3A: '无法对表达式类型 %0 进行名称修饰'
 # 'capture %0 by %select{value|reference}1'
-HD0ACA3E1F2BB: '通过%select{值|引用}1捕获%0'
+HD0ACA3E1F2BB: '通过%select{值|引用}1捕获 %0'
 # 'capture default must be first'
 HBD6F708D5FEC: '捕获默认必须放在最前面'
 # 'capture host side class data member by this pointer in device or host device lambda function may result in invalid memory access if this pointer is not accessible on device side'
 HA00333F0A82E: '在设备或混合设备lambda函数中通过this指针捕获主机侧类的数据成员，如果该this指针在设备侧不可访问，可能导致无效内存访问'
 # 'capture host variable %0 by reference in device or host device lambda function'
-H4218AAE93F26: '在设备或混合设备lambda函数中按引用捕获主机变量%0'
+H4218AAE93F26: '在设备或混合设备lambda函数中按引用捕获主机变量 %0'
 # "capture of '*this' by copy is a C++17 extension"
 H9C3948693023: '按值捕获"*this"是C++17扩展'
 # "capture of variable '%0' as type %1 calls %select{private|protected}3 %select{default |copy |move |*ERROR* |*ERROR* |*ERROR* |}2constructor"
-H6489D0544330: '将变量"%0"作为类型%1捕获调用%select{私有|保护}3%select{默认 |拷贝 |移动 |*ERROR* |*ERROR* |*ERROR* |}2构造函数'
+H6489D0544330: '将变量 "%0" 作为类型 %1 捕获调用%select{私有|保护}3%select{默认 |拷贝 |移动 |*ERROR* |*ERROR* |*ERROR* |}2构造函数'
 # 'captured structured bindings are a C++20 extension'
 HED60DD4C6A62: '捕获结构化绑定是C++20扩展'
 # 'captured structured bindings are incompatible with C++ standards before C++20'
 HA1967A579A6F: '捕获结构化绑定与C++20之前的C++标准不兼容'
 # 'capturing %0 strongly in this block is likely to lead to a retain cycle'
-H495EA167E92F: '在此块中强捕获%0可能会导致保留循环'
+H495EA167E92F: '在此块中强捕获 %0 可能会导致保留循环'
 # 'capturing a structured binding is not yet supported in OpenMP'
 H3DD2898A017E: 'OpenMP暂不支持捕获结构化绑定'
 # 'case ranges are a C2y extension'
@@ -19115,11 +19115,11 @@ H0ADA830DF441: 'case范围是GNU扩展'
 # 'case ranges are incompatible with C standards before C2y'
 H94092A9759CB: 'case范围与C2y之前的C标准不兼容'
 # 'case value not in enumerated type %0'
-H4866E4105494: '枚举类型%0中不存在该case值'
+H4866E4105494: '枚举类型 %0 中不存在该case值'
 # 'cast %diff{from $ to $ |}0,1converts to incompatible function type'
 HAE54FE7B3C1C: '将%diff{从$转为$ |}0,1转换为不兼容的函数类型'
 # "cast between incompatible calling conventions '%0' and '%1'; calls through this pointer may abort at runtime"
-HB4A395B83746: '在调用约定类型"%0"和"%1"之间进行转换；通过该指针调用可能在运行时中止'
+HB4A395B83746: '在调用约定类型 "%0" 和 "%1" 之间进行转换；通过该指针调用可能在运行时中止'
 # 'cast between pointer-to-function and pointer-to-object is an extension'
 H276B46B48964: '函数指针和对象指针之间的转换是扩展'
 # 'cast between pointer-to-function and pointer-to-object is incompatible with C++98'
@@ -19129,37 +19129,37 @@ H1D7499C23CFE: '将表达式强制转换为void以消除警告'
 # 'cast from %0 is not allowed in a constant expression %select{in C++ standards before C++2c|because the pointed object type %2 is not similar to the target type %3}1'
 H542ED6DEC45B: '%select{在 C++2c 之前的 C++ 标准中|因为指向对象类型 %2 不与目标类型 %3 兼容}1 不允许将 %0 转换为常量表达式'
 # 'cast from %0 to %1 drops %select{const and volatile qualifiers|const qualifier|volatile qualifier}2'
-HA3B03023258D: '从%0转换到%1会丢失%select{const和volatile限定符|const限定符|volatile限定符}2'
+HA3B03023258D: '从 %0 转换到 %1 会丢失%select{const和volatile限定符|const限定符|volatile限定符}2'
 # 'cast from %0 to %1 increases required alignment from %2 to %3'
 H4A02BB23383F: '将 %0 转换为 %1 需要的对齐从 %2 增加到 %3'
 # 'cast from %0 to %1 must have all intermediate pointers const qualified to be safe'
-HB7DFA89AF07B: '从%0到%1的强制转换必须将所有中间指针用const限定以保证安全'
+HB7DFA89AF07B: '从 %0 到 %1 的强制转换必须将所有中间指针用const限定以保证安全'
 # 'cast from function call of type %0 to non-matching type %1'
-H8CE3B0EB72DC: '将函数调用类型%0强制转换为不匹配的类型%1'
+H8CE3B0EB72DC: '将函数调用类型 %0 强制转换为不匹配的类型 %1'
 # 'cast from pointer to smaller type %2 loses information'
-H60D928000B5D: '将指向较小类型%2的指针强制转换会丢失信息'
+H60D928000B5D: '将指向较小类型 %2 的指针强制转换会丢失信息'
 # 'cast of %select{Objective-C|block|C}0 pointer type %1 to %select{Objective-C|block|C}2 pointer type %3 cannot use %select{__bridge|__bridge_transfer|__bridge_retained}4'
-H2F5F45B60576: '将%select{Objective-C|block|C}0指针类型%1强制转换为%select{Objective-C|block|C}2指针类型%3时不能使用%select{__bridge|__bridge_transfer|__bridge_retained}4'
+H2F5F45B60576: '将 %select{Objective-C|block|C}0 指针类型 %1 强制转换为 %select{Objective-C|block|C}2 指针类型 %3 时不能使用%select{__bridge|__bridge_transfer|__bridge_retained}4'
 # 'cast of type %0 to %1 is deprecated; use sel_getName instead'
-HC7428E5162D0: '将类型%0转换为%1的强制转换已弃用；请改用sel_getName'
+HC7428E5162D0: '将类型 %0 转换为 %1 的强制转换已弃用；请改用sel_getName'
 # 'cast one or both operands to int to silence this warning'
 H49949EF0EEB5: '将其中一个或两个操作数强制转换为int以消除此警告'
 # 'cast to %1 from smaller integer type %0'
-HF29EC08A2098: '将较小的整型%0强制转换为%1'
+HF29EC08A2098: '将较小的整型 %0 强制转换为 %1'
 # 'cast to incomplete type %0'
-HB29014F052FD: '将不完整类型%0进行强制转换'
+HB29014F052FD: '将不完整类型 %0 进行强制转换'
 # 'cast to smaller integer type %1 from %0'
-H3EAB0F6AAF90: '将%0强制转换为较小的整型%1'
+H3EAB0F6AAF90: '将 %0 强制转换为较小的整型 %1'
 # 'cast to union type from type %0 not present in union'
-H26129A704E2A: '将类型%0（该类型未在联合中定义）强制转换为联合类型'
+H26129A704E2A: '将类型 %0（该类型未在联合中定义）强制转换为联合类型'
 # 'cast to union type is a GNU extension'
 H07ADEAB6CDD8: '将联合类型进行强制转换是GNU扩展'
 # 'casting from randomized structure pointer type %0 to %1'
-H760D7A3D8C24: '将随机化结构体指针类型%0强制转换为%1'
+H760D7A3D8C24: '将随机化结构体指针类型 %0 强制转换为 %1'
 # "casting to dereferenceable pointer removes 'noderef' attribute"
 H435CE65222D6: '将指针强制转换为可解引用指针会移除"noderef"属性'
 # 'casting to type %0 is not allowed'
-H05073823504A: '转换为类型%0是不允许的'
+H05073823504A: '转换为类型 %0 是不允许的'
 # 'catch-all handler must come last'
 H18423565AC35: '默认异常处理程序必须放在最后'
 # 'category is implementing a method which will also be implemented by its primary class'
@@ -19175,17 +19175,17 @@ HC31A5632ABB1: '将大小参数更改为目标类型的大小'
 # 'change the argument to be the free space in the destination buffer minus the terminating null byte'
 H66702CDAA7E2: '将参数更改为目标缓冲区的可用空间减去终止空字节'
 # "change this ',' to a ';' to call %0"
-H5A1EAB3B7F87: "将此','改为';'以调用%0"
+H5A1EAB3B7F87: "将此','改为';'以调用 %0"
 # "change type of %0 to '%select{std::span' to preserve bounds information|std::array' to label it for hardening|std::span::iterator' to preserve bounds information}1%select{|, and change %2 to '%select{std::span|std::array|std::span::iterator}1' to propagate bounds information between them}3"
-H1123F3B73559: "将%0的类型更改为'%select{std::span'以保留边界信息|std::array'以标记为强化|std::span::iterator'以保留边界信息}1%select{|，并将%2更改为'%select{std::span|std::array|std::span::iterator}1'以在它们之间传播边界信息}3"
+H1123F3B73559: "将 %0 的类型更改为'%select{std::span'以保留边界信息|std::array'以标记为强化|std::span::iterator'以保留边界信息}1%select{|，并将 %2 更改为'%select{std::span|std::array|std::span::iterator}1'以在它们之间传播边界信息}3"
 # "change type of %0 to '%select{std::span' to preserve bounds information|std::array' to label it for hardening|std::span::iterator' to preserve bounds information}1%select{|, and change %2 to safe types to make function %4 bounds-safe}3"
-H9C76AEF6C221: "将%0的类型更改为'%select{std::span'以保留边界信息|std::array'以标记为强化|std::span::iterator'以保留边界信息}1%select{|，并将%2更改为安全类型以使函数%4具有边界安全性}3"
+H9C76AEF6C221: "将 %0 的类型更改为'%select{std::span'以保留边界信息|std::array'以标记为强化|std::span::iterator'以保留边界信息}1%select{|，并将 %2 更改为安全类型以使函数 %4 具有边界安全性}3"
 # 'char is signed'
 H28989E053B4F: 'char是有符号类型'
 # 'char is unsigned'
 H2C9C5C4D7121: 'char是无符号类型'
 # "character '%0' cannot be specified by a universal character name"
-H9FDECB7636A6: "字符'%0'不能通过通用字符名指定"
+H9FDECB7636A6: "字符 '%0' 不能通过通用字符名指定"
 # 'character <U+%0> not allowed %select{in|at the start of}1 an identifier'
 H0604F74F1073: '字符<U+%0>不允许%select{在|在开头}1标识符中'
 # 'character constant too long for its type'
@@ -19201,11 +19201,11 @@ H374F252BD0E9: '字符化运算符#@是Microsoft扩展'
 # 'check arguments and return values at function call boundaries'
 H68B4A050C0B9: '在函数调用边界检查参数和返回值'
 # "checker '%0' has no option called '%1'"
-H473E877D384D: "检查器'%0'没有名为'%1'的选项"
+H473E877D384D: "检查器 '%0' 没有名为 '%1' 的选项"
 # "checker cannot be enabled with analyzer option '%0' == %1"
-H9705343670F8: "无法通过分析器选项'%0' == %1启用检查器"
+H9705343670F8: "无法通过分析器选项 '%0' == %1 启用检查器"
 # "checker plugin '%0' is not compatible with this version of the analyzer"
-H6AAE762D0724: "检查器插件'%0'与此版本的分析器不兼容"
+H6AAE762D0724: "检查器插件 '%0' 与此版本的分析器不兼容"
 # 'chosen constructor is explicit in copy-initialization'
 H0B94DB59D2D8: '在拷贝初始化中选择的构造函数是显式的'
 # 'circular pointer delegation detected'
@@ -19229,9 +19229,9 @@ HBBA0DBA3D90F: 'clang 离线编译打包选项'
 # 'clang-query options'
 HEE4551CABF87: 'clang 查询选项'
 # 'clang-rename could not find symbol %0'
-H72B95322F623: 'clang-rename无法找到符号%0'
+H72B95322F623: 'clang-rename无法找到符号 %0'
 # 'clang-rename could not find symbol (offset %0)'
-H9B2484C454C5: 'clang-rename无法找到符号（偏移量%0）'
+H9B2484C454C5: 'clang-rename无法找到符号（偏移量 %0）'
 # 'clang-reorder-fields options'
 HB5EDCC7DF359: 'clang-reorder-fields选项'
 # 'clang-tidy options'
@@ -19239,11 +19239,11 @@ H123FF2E74AC8: 'clang-tidy选项'
 # 'clangd compilation flags options'
 H9BB98137F26A: 'clangd编译标志选项'
 # 'class %0 defined without specifying a base class'
-H3A2FB228D84B: '类%0在未指定基类的情况下被定义'
+H3A2FB228D84B: '类 %0 在未指定基类的情况下被定义'
 # 'class %0 has incompatible superclasses'
-HAE8DDB1E1535: '类%0具有不兼容的超类'
+HAE8DDB1E1535: '类 %0 具有不兼容的超类'
 # 'class %0 previously declared with type parameters'
-H5BCC48BDFD6B: '类%0之前使用类型参数声明过'
+H5BCC48BDFD6B: '类 %0 之前使用类型参数声明过'
 # "class already marked '%0'"
 HCB141E8798E7: "类已标记为 '%0'"
 # 'class extension has no primary class'
@@ -19455,13 +19455,13 @@ H0919F4EB4F97: '参数的类型推导与 %diff{$ 和 $|类型}0,1 存在冲突'
 # "conflicting deployment targets, both '%0' and '%1' are present in environment"
 H8F50D7638091: "部署目标存在冲突，环境同时包含 '%0' 和 '%1'"
 # 'conflicting distributed object modifiers on parameter type in declaration of %0'
-H4CB94BB5639A: '在%0的声明中参数类型存在冲突的分布式对象修饰符'
+H4CB94BB5639A: '在 %0 的声明中参数类型存在冲突的分布式对象修饰符'
 # 'conflicting distributed object modifiers on parameter type in implementation of %0'
-HA9E88E86F6C2: '在%0的实现中参数类型存在冲突的分布式对象修饰符'
+HA9E88E86F6C2: '在 %0 的实现中参数类型存在冲突的分布式对象修饰符'
 # 'conflicting distributed object modifiers on return type in declaration of %0'
-HBE23CBB42FFE: '在%0的声明中返回类型存在冲突的分布式对象修饰符'
+HBE23CBB42FFE: '在 %0 的声明中返回类型存在冲突的分布式对象修饰符'
 # 'conflicting distributed object modifiers on return type in implementation of %0'
-HBB60CEE9C2B2: '在%0的实现中返回类型存在冲突的分布式对象修饰符'
+HBB60CEE9C2B2: '在 %0 的实现中返回类型存在冲突的分布式对象修饰符'
 # 'conflicting instance variable names: %0 vs %1'
 H088E6A0E59D6: '冲突的实例变量名：%0 与 %1'
 # 'conflicting loop attribute %0'
@@ -19475,13 +19475,13 @@ HD53AB264ABE6: "选项 '-fcoro-aligned-allocation' 与 '-fno-aligned-allocation'
 # 'conflicting parameter qualifier %0 on parameter %1'
 HC7B786535E39: '参数 %1 上存在冲突的参数限定符 %0'
 # 'conflicting parameter types in declaration of %0%diff{: $ vs $|}1,2'
-HCBD5D6ED758A: '在%0的声明中参数类型冲突%diff{: $ vs $|}1,2'
+HCBD5D6ED758A: '在 %0 的声明中参数类型冲突%diff{: $ vs $|}1,2'
 # 'conflicting parameter types in declaration of %0: %1 vs %2'
-HF405BA99A067: '在%0的声明中参数类型冲突：%1 与 %2'
+HF405BA99A067: '在 %0 的声明中参数类型冲突：%1 与 %2'
 # 'conflicting parameter types in implementation of %0%diff{: $ vs $|}1,2'
-H64F50A39ECB1: '在%0的实现中参数类型冲突%diff{: $ vs $|}1,2'
+H64F50A39ECB1: '在 %0 的实现中参数类型冲突%diff{: $ vs $|}1,2'
 # 'conflicting parameter types in implementation of %0: %1 vs %2'
-HC0C8356B7475: '在%0的实现中参数类型冲突：%1 与 %2'
+HC0C8356B7475: '在 %0 的实现中参数类型冲突：%1 与 %2'
 # 'conflicting pass_object_size attributes on parameters'
 H99CE421CA443: '参数上的 pass_object_size 属性冲突'
 # 'conflicting prototype is here'
@@ -19489,35 +19489,35 @@ HF896EFD79698: '冲突的原型在此处'
 # "conflicting re-export of module '%0' as '%1' or '%2'"
 H8B0F3A29C0A1: "冲突的模块重导出：'%0' 作为 '%1' 或 '%2'"
 # 'conflicting return type in declaration of %0%diff{: $ vs $|}1,2'
-H2BB3153B6C50: '在%0的声明中返回类型冲突%diff{: $ vs $|}1,2'
+H2BB3153B6C50: '在 %0 的声明中返回类型冲突%diff{: $ vs $|}1,2'
 # 'conflicting return type in declaration of %0: %1 vs %2'
-H5D783A189DCF: '在%0的声明中返回类型冲突：%1 与 %2'
+H5D783A189DCF: '在 %0 的声明中返回类型冲突：%1 与 %2'
 # 'conflicting return type in implementation of %0%diff{: $ vs $|}1,2'
-HEB354C372ED1: '在%0的实现中返回类型冲突%diff{: $ vs $|}1,2'
+HEB354C372ED1: '在 %0 的实现中返回类型冲突%diff{: $ vs $|}1,2'
 # 'conflicting return type in implementation of %0: %1 vs %2'
-H5C54E8625E6A: '在%0的实现中返回类型冲突：%1 与 %2'
+H5C54E8625E6A: '在 %0 的实现中返回类型冲突：%1 与 %2'
 # 'conflicting super class name %0'
-HF493EF2E1E41: '父类名称%0冲突'
+HF493EF2E1E41: '父类名称 %0 冲突'
 # 'conflicting types for %0'
-H5E0475C2D7BC: '%0的类型冲突'
+H5E0475C2D7BC: '%0 的类型冲突'
 # 'conflicting types for alias %0'
-HCE7DAE70AA85: '别名%0的类型冲突'
+HCE7DAE70AA85: '别名 %0 的类型冲突'
 # 'conflicting variadic declaration of method and its implementation'
 H2A0A12EA2AF3: '方法及其实现的可变参数声明冲突'
 # 'conformance of forward class %0 to protocol %1 cannot be confirmed'
-H978A4E78BB8C: '无法确认前向类%0对协议%1的符合性'
+H978A4E78BB8C: '无法确认前向类 %0 对协议 %1 的符合性'
 # "consecutive right angle brackets are incompatible with C++98 (use '> >')"
 H77515E521F08: "连续的右尖括号与C++98不兼容（请使用'> >'）"
 # 'conservative handling of inline assembly'
 H316430B34522: '内联汇编的保守处理'
 # "consider adding '%0' to the header search path"
-HCE15ED850DE4: "考虑将'%0'添加到头文件搜索路径"
+HCE15ED850DE4: "考虑将 '%0' 添加到头文件搜索路径"
 # "consider defining %0 with the '%1' calling convention"
-H6A4F6FD30F2D: "考虑使用'%1'调用约定定义%0"
+H6A4F6FD30F2D: "考虑使用 '%1' 调用约定定义 %0"
 # 'consider making the bit-field type %select{unsigned|signed}0'
-HDAE81431A685: '考虑将位域类型设置为%select{unsigned|signed}0'
+HDAE81431A685: '考虑将位域类型设置为 %select{unsigned|signed}0'
 # "consider using __builtin_trap() or qualifying pointer with 'volatile'"
-H002E765592F2: "考虑使用__builtin_trap()或用'volatile'修饰指针"
+H002E765592F2: "考虑使用__builtin_trap()或用 'volatile' 修饰指针"
 # 'consider using vld1_%0%1() to initialize a vector from memory, or vcreate_%0%1() to initialize from an integer constant'
 H3E54619F1458: '考虑使用vld1_%0%1()从内存初始化向量，或使用vcreate_%0%1()从整数常量初始化'
 # 'consider using vld1q_%0%1() to initialize a vector from memory, or vcombine_%0%1(vcreate_%0%1(), vcreate_%0%1()) to initialize from integer constants'
@@ -19525,21 +19525,21 @@ H0B91FFD90BE8: '考虑使用vld1q_%0%1()从内存初始化向量，或使用vcom
 # 'const variable cannot be emitted on device side due to dynamic initialization'
 H2D4E40F2FA4A: '由于动态初始化，const变量无法在设备端生成'
 # 'const-qualified list item cannot be %0'
-HABDF81BBC813: 'const限定的列表项不能是%0'
+HABDF81BBC813: 'const限定的列表项不能是 %0'
 # 'const-qualified variable cannot be %0'
-H02E8DDC8D310: 'const限定的变量不能是%0'
+H02E8DDC8D310: 'const限定的变量不能是 %0'
 # 'const-qualified variable without mutable fields cannot be %0'
-HF38DA802B6DD: '没有可变字段的const限定变量不能是%0'
+HF38DA802B6DD: '没有可变字段的const限定变量不能是 %0'
 # 'constant evaluation of %0 between arrays of types %1 and %2 is not supported; only arrays of narrow character types can be compared'
-H42EAC15FC487: '在类型%1和%2的数组之间对%0进行常量求值不受支持；仅窄字符类型的数组可以比较'
+H42EAC15FC487: '在类型 %1 和 %2 的数组之间对 %0 进行常量求值不受支持；仅窄字符类型的数组可以比较'
 # 'constant evaluation of %0 on array of type %1 is not supported; only arrays of narrow character types can be searched'
-HCF9A8296188E: '在类型%1的数组上对%0进行常量求值不受支持；仅窄字符类型的数组可以搜索'
+HCF9A8296188E: '在类型 %1 的数组上对 %0 进行常量求值不受支持；仅窄字符类型的数组可以搜索'
 # 'constant expression evaluates to %0 which cannot be narrowed to type %1'
-HE08100927247: '常量表达式求值为%0，无法窄化为类型%1'
+HE08100927247: '常量表达式求值为 %0，无法窄化为类型 %1'
 # 'constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11'
-H3A70E9ED4BE6: '常量表达式计算结果为%0，在C++11中无法转换为类型%1'
+H3A70E9ED4BE6: '常量表达式计算结果为 %0，在C++11中无法转换为类型 %1'
 # 'consteval function %0 cannot override a non-consteval function'
-HD9788F98961F: 'consteval函数%0不能覆盖非consteval函数'
+HD9788F98961F: 'consteval函数 %0 不能覆盖非consteval函数'
 # 'consteval if is a C++23 extension'
 H32DA4F52DDFE: 'consteval if是C++23的扩展'
 # 'consteval if is always true in an %select{unevaluated|immediate}0 context'
@@ -19549,7 +19549,7 @@ H3BF3B6976984: 'consteval if与C++23之前的版本不兼容'
 # 'constexpr %select{member function|constructor}0 not allowed in %select{struct|interface|class}1 with virtual base %plural{1:class|:classes}2'
 HA87030D3447E: 'constexpr %select{成员函数|构造函数}0 不允许出现在包含虚基 %plural{1:类|:类}2 的%select{结构体|接口|类}1 中'
 # 'constexpr bit cast involving type %0 is not yet supported'
-H93DC3AD734F6: '涉及类型%0的constexpr位转换尚不支持'
+H93DC3AD734F6: '涉及类型 %0 的constexpr位转换尚不支持'
 # 'constexpr bit_cast involving bit-field is not yet supported'
 HCF05A23F6C40: '涉及位域的constexpr bit_cast尚不支持'
 # 'constexpr constructor that does not initialize all members is a C++20 extension'
@@ -19557,7 +19557,7 @@ H6D6AAEF0CE01: '未初始化所有成员的constexpr构造函数是C++20的扩�
 # 'constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20'
 H6CD8A3688EC0: '未初始化所有成员的constexpr构造函数与C++20之前的版本不兼容'
 # 'constexpr evaluation exceeded maximum depth of %0 calls'
-H71A1AF77C8D7: 'constexpr求值超过%0层的最大深度'
+H71A1AF77C8D7: 'constexpr求值超过 %0 层的最大深度'
 # 'constexpr evaluation hit maximum call limit'
 H2D336AD5FC66: 'constexpr求值达到最大调用限制'
 # 'constexpr evaluation hit maximum heap allocation limit'
@@ -19565,7 +19565,7 @@ HEA6F0C77C92E: 'constexpr求值达到最大堆分配限制'
 # 'constexpr evaluation hit maximum step limit; possible infinite loop?'
 H3A9C6A5C602B: 'constexpr求值达到最大步数限制；可能存在无限循环？'
 # 'constexpr function %0 without __host__ or __device__ attributes cannot overload __device__ function with the same signature; add a __host__ attribute, or build with -fno-cuda-host-device-constexpr'
-HAF2225A9BAA0: '不带__host__或__device__属性的constexpr函数%0不能重载具有相同签名的__device__函数；添加__host__属性，或使用-fno-cuda-host-device-constexpr编译'
+HAF2225A9BAA0: '不带__host__或__device__属性的constexpr函数 %0 不能重载具有相同签名的__device__函数；添加__host__属性，或使用-fno-cuda-host-device-constexpr编译'
 # 'constexpr function with no return statements is incompatible with C++ standards before C++14'
 H60A27D48D081: '没有返回语句的constexpr函数与C++14之前的版本不兼容'
 # 'constexpr if condition is not a constant expression'
@@ -19575,9 +19575,9 @@ H8C78EE861C25: 'constexpr if是C++17的扩展'
 # 'constexpr if is incompatible with C++ standards before C++17'
 H518345725A13: 'constexpr if与C++17之前的版本不兼容'
 # 'constexpr initializer evaluates to %0 which is not exactly representable in type %1'
-HFD7668DF8CE8: 'constexpr初始化器计算结果为%0，无法在类型%1中精确表示'
+HFD7668DF8CE8: 'constexpr初始化器计算结果为 %0，无法在类型 %1 中精确表示'
 # 'constexpr initializer for type %0 is of type %1'
-H57EA50C1B712: '类型%0的constexpr初始值为类型%1'
+H57EA50C1B712: '类型 %0 的constexpr初始值为类型 %1'
 # 'constexpr on lambda expressions is incompatible with C++ standards before C++17'
 H2F64715F9E19: '在C++17之前的C++标准中，lambda表达式上的constexpr不兼容'
 # 'constexpr pointer initializer is not null'
@@ -19587,59 +19587,59 @@ HDA9656DF3125: '不初始化任何成员的constexpr联合构造函数是C++20�
 # 'constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20'
 H42AB5A6736FE: '不初始化任何成员的constexpr联合构造函数与C++20之前的C++标准不兼容'
 # 'constexpr variable %0 must be initialized by a constant expression'
-H22D6867A6C46: 'constexpr变量%0必须由常量表达式初始化'
+H22D6867A6C46: 'constexpr变量 %0 必须由常量表达式初始化'
 # 'constexpr variable %0 must have constant destruction'
-H0CB1A9F457E9: 'constexpr变量%0必须具有常量销毁'
+H0CB1A9F457E9: 'constexpr变量 %0 必须具有常量销毁'
 # 'constexpr variable cannot have non-literal type %0'
-H8CA68B10BD1E: 'constexpr变量不能具有非字面类型%0'
+H8CA68B10BD1E: 'constexpr变量不能具有非字面类型 %0'
 # 'constexpr variable cannot have type %0'
-H9CBE3FDAF244: 'constexpr变量不能具有类型%0'
+H9CBE3FDAF244: 'constexpr变量不能具有类型 %0'
 # 'constexpr variable declaration must be a definition'
 H28D5C206A058: 'constexpr变量声明必须是一个定义'
 # 'constrained by %select{|implicitly }1%select{private|protected}0 inheritance here'
-HA215ECA901D4: '受%select{|隐式 }1%select{private|protected}0继承的约束'
+HA215ECA901D4: '受%select{|隐式 }1%select{private|protected}0 继承的约束'
 # "constrained placeholder types other than simple 'auto' on non-type template parameters not supported yet"
-HA5CE432D2BF4: "非类型模板参数上的非简单'auto'约束占位类型尚未支持"
+HA5CE432D2BF4: "非类型模板参数上的非简单 'auto' 约束占位类型尚未支持"
 # "constraint '%0' is already present here"
-HDBC0B5C441D3: "约束'%0'在此处已存在"
+HDBC0B5C441D3: "约束 '%0' 在此处已存在"
 # 'constraint depends on a previously diagnosed expression'
 HE3836E579C9B: '约束依赖于之前诊断过的表达式'
 # 'constraint variable %0 cannot be used in an evaluated context'
-H553F40E512D9: '约束变量%0不能在求值上下文中使用'
+H553F40E512D9: '约束变量 %0 不能在求值上下文中使用'
 # 'constraints not satisfied for %select{class template|function template|variable template|alias template|template template parameter|template}0 %1%2'
 H81A668F064ED: '约束条件未满足%select{类模板|函数模板|变量模板|别名模板|模板模板参数|模板}0 %1%2'
 # "construct '%0' not allowed in a region associated with a directive with 'order' clause"
-HC4C995E5BA30: "在与带有'order'子句的指令关联的区域中不允许构造'%0'"
+HC4C995E5BA30: "在与带有 'order' 子句的指令关联的区域中不允许构造 '%0'"
 # 'construction of individual component of complex number is not yet supported in constant expressions'
 H0E4CD910394F: '复数的各个分量的构造在常量表达式中尚未支持'
 # 'constructor call from initializer list is incompatible with C++98'
 HB192963D1DEE: '来自初始化列表的构造函数调用与C++98不兼容'
 # "constructor cannot be declared '%0'"
-HC6A3768462FF: "构造函数不能声明为'%0'"
+HC6A3768462FF: "构造函数不能声明为 '%0'"
 # 'constructor cannot be redeclared'
 H55F24B0BC81F: '构造函数不能被重新声明'
 # 'constructor cannot have a return type'
 H859AAE558539: '构造函数不能有返回类型'
 # 'constructor for %0 creates a delegation cycle'
-H475456925F83: '%0的构造函数创建了委托循环'
+H475456925F83: '%0 的构造函数创建了委托循环'
 # 'constructor from base class %0 inherited here'
-H1711561364CF: '从基类%0继承的构造函数'
+H1711561364CF: '从基类 %0 继承的构造函数'
 # 'constructor inherited by %0 from base class %1 is implicitly deleted'
-H97CFC0CC7D39: '%0从基类%1继承的构造函数被隐式删除'
+H97CFC0CC7D39: '%0 从基类 %1 继承的构造函数被隐式删除'
 # 'constructor inherited from base class %0 cannot be used in a constant expression; derived class cannot be implicitly initialized'
-HC12464115FAE: '从基类%0继承的构造函数不能用于常量表达式；派生类无法隐式初始化'
+HC12464115FAE: '从基类 %0 继承的构造函数不能用于常量表达式；派生类无法隐式初始化'
 # 'constructor initializer %0 does not name a class'
-HCFC849237163: '构造函数初始化项%0未命名一个类'
+HCFC849237163: '构造函数初始化项 %0 未命名一个类'
 # 'constructor of %0 inherited from multiple base class subobjects'
-HC9F4CC1EE50E: '%0的构造函数从多个基类子对象继承'
+HC9F4CC1EE50E: '%0 的构造函数从多个基类子对象继承'
 # 'constructor of base class %0 is not called'
-H3174F7100ABA: '基类%0的构造函数未被调用'
+H3174F7100ABA: '基类 %0 的构造函数未被调用'
 # 'constructor parameter %0 shadows the field %1 of %2'
-H11CEF1CBDAF0: '构造函数参数%0遮蔽了%2的字段%1'
+H11CEF1CBDAF0: '构造函数参数 %0 遮蔽了 %2 的字段 %1'
 # "constructs with the same name must have a 'hint' clause with the same value"
-H0760234C4455: "具有相同名称的构造必须带有值相同的'hint'子句"
+H0760234C4455: "具有相同名称的构造必须带有值相同的 'hint' 子句"
 # "consumed analysis attribute is attached to member of class %0 which isn't marked as consumable"
-H05C072713E0E: 'consumed分析属性附加到未标记为可消耗的类%0的成员'
+H05C072713E0E: 'consumed分析属性附加到未标记为可消耗的类 %0 的成员'
 # 'container access result unused - container access should not be used for side effects'
 H8AF2586DAD21: '容器访问结果未被使用 - 容器访问不应用于副作用'
 # 'context %select{set|selector|property}0 options are: %1'
@@ -19647,17 +19647,17 @@ H10E910F395AC: '上下文%select{设置|选择器|属性}0选项为：%1'
 # 'continue even if build-ids in input binary and perf.data mismatch'
 HF64C3EBD8AC2: '即使输入二进制文件和perf.data的build-ids不匹配也继续执行'
 # 'control flows through the definition of a %select{static|thread_local}0 variable'
-HBD024CE03438: '控制流经过一个%select{static|thread_local}0变量的定义'
+HBD024CE03438: '控制流经过一个 %select{static|thread_local}0 变量的定义'
 # 'control reached end of constexpr function'
 HE6815340E241: '控制到达constexpr函数的末尾'
 # 'controlling expression type %0 compatible with %1 generic association types'
-HB8A1ADD97071: '控制表达式类型%0与%1泛型关联类型兼容'
+HB8A1ADD97071: '控制表达式类型 %0 与 %1 泛型关联类型兼容'
 # 'controlling expression type %0 not compatible with any generic association type'
-H55E9ACCD45B7: '控制表达式类型%0与任何泛型关联类型不兼容'
+H55E9ACCD45B7: '控制表达式类型 %0 与任何泛型关联类型不兼容'
 # "convenience initializer missing a 'self' call to another initializer"
 HF14170AD5005: '便利初始化器缺少对另一个初始化器的self调用'
 # "convenience initializer should not invoke an initializer on 'super'"
-HA39139A75170: "便利初始化器不应在'super'上调用另一个初始化器"
+HA39139A75170: "便利初始化器不应在 'super' 上调用另一个初始化器"
 # 'conversion %diff{from $ to $|between types}0,1 is ambiguous'
 HDD7803D6F7A1: '转换 %diff{从 $ 到 $|在类型之间}0,1 是模棱两可的'
 # 'conversion between fixed point and %0 is not yet supported'
@@ -19701,93 +19701,93 @@ HC22DB2DAD0D5: '将 %0 转换为其自身的转换函数将永远不会被使用
 # 'conversion function must be a non-static member function'
 HCACC98687D9A: '转换函数必须是非静态成员函数'
 # 'conversion to %select{integral|enumeration}0 type %1'
-H52D400CB1F4D: '转换为%select{整型|枚举}0类型%1'
+H52D400CB1F4D: '转换为%select{整型|枚举}0类型 %1'
 # 'conversion to %select{integral|enumeration}0 type %1 declared here'
-H126F1D6252B2: '转换为%select{整型|枚举}0类型%1，该类型在这里声明'
+H126F1D6252B2: '转换为%select{整型|枚举}0类型 %1，该类型在这里声明'
 # 'conversion to pointer type %0'
-H88631D898FE3: '转换为指针类型%0'
+H88631D898FE3: '转换为指针类型 %0'
 # 'convert moves with rbp stack memory operand (unsafe, must be off for binaries compiled with -fomit-frame-pointer)'
 H9F1E879B6ED5: '转换包含rbp栈内存操作数的移动指令（不安全，使用-fomit-frame-pointer编译的二进制文件必须关闭此选项）'
 # 'convert moves with stack memory operand (potentially unsafe)'
 HC5050FEB738B: '转换包含栈内存操作数的移动指令（可能不安全）'
 # 'converting delete expression from type %0 to type %1 invokes an explicit conversion function'
-HFA594BB552D0: '将类型%0的delete表达式转换为类型%1会调用显式转换函数'
+HFA594BB552D0: '将类型 %0 的delete表达式转换为类型 %1 会调用显式转换函数'
 # 'converting the enum constant to a boolean'
 HC26D67935F61: '将枚举常量转换为布尔值'
 # "converting the result of '<<' to a boolean always evaluates to %select{false|true}0"
-H66F90B0804A0: "将运算符'<<'的结果转换为布尔值始终会计算为%select{false|true}0"
+H66F90B0804A0: "将运算符'<<'的结果转换为布尔值始终会计算为 %select{false|true}0"
 # "converting the result of '<<' to a boolean; did you mean '(%0) != 0'?"
 HB5F0E9F35B11: "将运算符'<<'的结果转换为布尔值；是否想表达'(%0) != 0'？"
 # "converting the result of '?:' with integer constants to a boolean always evaluates to 'true'"
-H0B52D2457927: "将带有整型常量的运算符'?:'的结果转换为布尔值始终会计算为'true'"
+H0B52D2457927: "将带有整型常量的运算符'?:'的结果转换为布尔值始终会计算为 'true'"
 # 'converting to boxing syntax requires casting %0 to %1'
-HDE90319BAAF3: '转换为装箱语法需要将%0转换为%1'
+HDE90319BAAF3: '转换为装箱语法需要将 %0 转换为 %1'
 # 'coprocessor %0 must be configured as %select{GCP|CDE}1'
-H4C456D50EC55: '协处理器%0必须配置为%select{GCP|CDE}1'
+H4C456D50EC55: '协处理器 %0 必须配置为 %select{GCP|CDE}1'
 # 'copy %select{constructor|assignment operator}0 is implicitly deleted because %1 has a user-declared move %select{constructor|assignment operator}2'
-HBE99D1D6F119: '复制%select{构造函数|赋值运算符}0被隐式删除，因为%1声明了用户自定义的移动%select{构造函数|赋值运算符}2'
+HBE99D1D6F119: '复制%select{构造函数|赋值运算符}0被隐式删除，因为 %1 声明了用户自定义的移动%select{构造函数|赋值运算符}2'
 # 'copy constructor must pass its first argument by reference'
 H3ABFF716FBF3: '复制构造函数必须通过引用传递其第一个参数'
 # 'copy constructor of %0 is implicitly deleted because field %1 is of rvalue reference type %2'
-H5B9C818EF5D6: '%0的复制构造函数被隐式删除，因为字段%1是右值引用类型%2'
+H5B9C818EF5D6: '%0 的复制构造函数被隐式删除，因为字段 %1 是右值引用类型 %2'
 # 'copying a temporary object of incomplete type %0'
-H4C050E15C304: '复制不完整类型%0的临时对象'
+H4C050E15C304: '复制不完整类型 %0 的临时对象'
 # "coroutine %0 cannot be declared 'noreturn' as it always returns a coroutine handle"
-H7F1772343EA2: '协程%0不能声明为noreturn，因为它始终返回协程句柄'
+H7F1772343EA2: '协程 %0 不能声明为noreturn，因为它始终返回协程句柄'
 # "could not acquire lock file for module '%0': %1"
-H0C3259D0CAD4: "无法为模块'%0'获取锁文件：%1"
+H0C3259D0CAD4: "无法为模块 '%0' 获取锁文件：%1"
 # "could not build module '%0'"
-H0F4C1C79774B: "无法构建模块'%0'"
+H0F4C1C79774B: "无法构建模块 '%0'"
 # "could not calculate number of iterations calling 'operator-' with upper and lower loop bounds"
 H55F92FED58CA: '无法通过调用带有循环上下限的operator-计算迭代次数'
 # 'could not determine the original source location for %0:%1:%2'
-H596D1B547578: '无法确定%0:%1:%2的原始源代码位置'
+H596D1B547578: '无法确定 %0:%1:%2 的原始源代码位置'
 # "could not find ';' after @import"
 H808D2C4625A0: "在@import后找不到';'"
 # 'could not find Objective-C class %0 to convert %1 to %2'
-H8A434A2F54F7: '找不到Objective-C类%0来将%1转换为%2'
+H8A434A2F54F7: '找不到Objective-C类 %0 来将 %1 转换为 %2'
 # 'could not match %diff{$ against $|types}0,1'
 HB17669DA1C41: '无法匹配%diff{$ against $|types}0,1'
 # "could not open '%0' for embedding"
-HF452E067B4E2: "无法打开'%0'用于嵌入"
+HF452E067B4E2: "无法打开 '%0' 用于嵌入"
 # "could not read %0 input list '%1': %2"
-H67879BBD7E88: "无法读取%0输入列表'%1'：%2"
+H67879BBD7E88: "无法读取 %0 输入列表 '%1'：%2"
 # "could not read directory '%0': %1"
-HBA8BA2C7E279: "无法读取目录'%0'：%1"
+HBA8BA2C7E279: "无法读取目录 '%0'：%1"
 # "could not remap file '%0' to the contents of file '%1'"
-H154079BD4163: "无法将文件'%0'重映射为文件'%1'的内容"
+H154079BD4163: "无法将文件 '%0' 重映射为文件 '%1' 的内容"
 # 'covariant thunk required by %0'
-H96E8ACBA5464: '%0需要协变thunk'
+H96E8ACBA5464: '%0 需要协变thunk'
 # "cpu '%0' does not support rv%select{32|64}1"
-HB22CC79010F2: "CPU '%0'不支持rv%select{32|64}1"
+HB22CC79010F2: "CPU '%0' 不支持rv%select{32|64}1"
 # 'create a static PC table'
 HA9821FD0C9F2: '创建静态PC表'
 # "current API version is '%0', but plugin was compiled with version '%1'"
-H399ED19E4A74: "当前API版本是'%0'，但插件是使用版本'%1'编译的"
+H399ED19E4A74: "当前API版本是 '%0'，但插件是使用版本 '%1' 编译的"
 # 'current file is older than dependency %0'
-HCE89B30434E7: '当前文件比依赖项%0更旧'
+HCE89B30434E7: '当前文件比依赖项 %0 更旧'
 # "current handling of vector bool and vector pixel types in this context are deprecated; the default behaviour will soon change to that implied by the '-altivec-compat=xl' option"
 H2144886C992F: "在此上下文中处理向量布尔类型和向量像素类型的方式已弃用；默认行为将很快更改为由'-altivec-compat=xl'选项暗示的行为"
 # "current_version does not match: '%0' (provided) vs '%1' (found)"
-H84F45A8B13FB: "current_version不匹配：提供的'%0'与找到的'%1'"
+H84F45A8B13FB: "current_version不匹配：提供的 '%0' 与找到的 '%1'"
 # "cycle in acquired_before/after dependencies, starting with '%0'"
-HCB49175AA5FC: "在acquired_before/after依赖项中存在循环，起始于'%0'"
+HCB49175AA5FC: "在acquired_before/after依赖项中存在循环，起始于 '%0'"
 # "cyclic dependency in module '%0': %1"
-H2C783846485B: "模块'%0'中存在循环依赖：%1"
+H2C783846485B: "模块 '%0' 中存在循环依赖：%1"
 # 'data argument not used by format string'
 HB79E446EA7A1: '数据参数未被格式字符串使用'
 # "data argument position '%0' exceeds the number of data arguments (%1)"
-H3A25FAA1F4B4: "数据参数位置'%0'超过了数据参数的数量(%1)"
+H3A25FAA1F4B4: "数据参数位置 '%0' 超过了数据参数的数量(%1)"
 # 'data layout string to use'
 HBFBB6DFFCFDF: '要使用的数据布局字符串'
 # 'data member instantiated with function type %0'
-HE2AF1A6B9D7C: '用函数类型%0实例化的数据成员'
+HE2AF1A6B9D7C: '用函数类型 %0 实例化的数据成员'
 # "data-sharing attribute '%0' in '%1' clause requires OpenMP version %2 or above"
-H12FB4E840EF7: "'%1'子句中的数据共享属性'%0'需要OpenMP版本%2或更高"
+H12FB4E840EF7: "'%1' 子句中的数据共享属性 '%0' 需要OpenMP版本 %2 或更高"
 # 'dbx'
 H362301DA6431: 'dbx'
 # "dealloc return type must be correctly specified as 'void' under ARC, instead of %0"
-HF5C8E84C253E: "在ARC下，dealloc的返回类型必须正确指定为'void'，而不是%0"
+HF5C8E84C253E: "在ARC下，dealloc的返回类型必须正确指定为 'void'，而不是 %0"
 # 'debug'
 H32FAAECAC742: '调试'
 # "debug information option '%0' is not supported for target '%1'"
@@ -19803,9 +19803,9 @@ H29FF2691850E: '调试打印由实例化单元定义的隐藏符号'
 # 'debug stack'
 HF8D202225993: '调试堆栈'
 # "declaration %0 attached to named module '%1' cannot be attached to other modules"
-H238E4BEFC413: '已附加到命名模块‘%1’的声明%0无法附加到其他模块'
+H238E4BEFC413: '已附加到命名模块‘%1’的声明 %0 无法附加到其他模块'
 # "declaration %0 is detected to be defined in multiple module units, first is from '%1' and second is from '%2'; the compiler may not be good at merging the definitions. "
-H96F07A99E632: '检测到声明%0在多个模块单元中定义，第一个来自‘%1’，第二个来自‘%2’；编译器可能无法有效合并这些定义。'
+H96F07A99E632: '检测到声明 %0 在多个模块单元中定义，第一个来自‘%1’，第二个来自‘%2’；编译器可能无法有效合并这些定义。'
 # "declaration '%0' is %select{weak defined|thread local}1, but symbol is not in dynamic library"
 HFB32CBE0F1C5: '声明‘%0’是%select{弱定义|线程局部}1，但符号不在动态库中'
 # "declaration '%0' is marked %select{available|unavailable}1, but symbol is %select{not |}2exported in dynamic library"
@@ -19915,35 +19915,35 @@ H98D954FCA941: '此处用 %0 属性声明'
 # "declared with class '%0' here"
 HA2F652501D84: "此处用类 '%0' 声明"
 # 'declared with index %0 here'
-H29E8DAE209C5: '此处用索引%0声明'
+H29E8DAE209C5: '此处用索引 %0 声明'
 # 'declaring function parameter of type %0 is not allowed%select{; did you forget * ?|}1'
-H45BA30613376: '不允许声明类型为%0的函数参数%select{; 是否忘记添加*？|}1'
+H45BA30613376: '不允许声明类型为 %0 的函数参数%select{; 是否忘记添加*？|}1'
 # 'declaring function return value of type %0 is not allowed %select{; did you forget * ?|}1'
-HC0F56D942DA5: '不允许声明类型为%0的函数返回值%select{; 是否忘记添加*？|}1'
+HC0F56D942DA5: '不允许声明类型为 %0 的函数返回值%select{; 是否忘记添加*？|}1'
 # "declaring overloaded %0 as 'static' is a C++23 extension"
-H3416DF62F662: "将重载的%0声明为'static'是C++23扩展"
+H3416DF62F662: "将重载的 %0 声明为 'static' 是C++23扩展"
 # "declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23"
-HE846DD4F137C: "将重载的%0声明为'static'与C++23之前的标准不兼容"
+HE846DD4F137C: "将重载的 %0 声明为 'static' 与C++23之前的标准不兼容"
 # 'declaring variable of type %0 is not allowed'
-HCC1ADB51903E: '不允许声明类型为%0的变量'
+HCC1ADB51903E: '不允许声明类型为 %0 的变量'
 # 'decode probes section from binary'
 H61AE631A7106: '从二进制文件解码探针节'
 # 'decomposition declaration %0 requires an initializer'
-H745CF12AB2DC: '分解声明%0需要初始值设定项'
+H745CF12AB2DC: '分解声明 %0 需要初始值设定项'
 # 'decomposition declaration cannot be a template'
 H12444CAF9EB2: '分解声明不能是模板'
 # "decomposition declaration cannot be declared %plural{1:'%1'|:with '%1' specifiers}0"
-HEDAF4E9407D4: "分解声明不能被声明%plural{1:'%1'|:具有'%1'说明符}0"
+HEDAF4E9407D4: "分解声明不能被声明%plural{1:'%1'|:具有 '%1' 说明符}0"
 # "decomposition declaration cannot be declared with constrained 'auto'"
-H33CAEB57113F: "分解声明不能被声明为具有约束条件的'auto'"
+H33CAEB57113F: "分解声明不能被声明为具有约束条件的 'auto'"
 # 'decomposition declaration cannot be declared with parentheses'
 H02314396E4F0: '分解声明不能用括号声明'
 # "decomposition declaration cannot be declared with type %0; declared type must be 'auto' or reference to 'auto'"
-H3DD0947995B7: "分解声明声明的类型%0无效；声明类型必须为'auto'或'auto'的引用"
+H3DD0947995B7: "分解声明声明的类型 %0 无效；声明类型必须为 'auto' 或 'auto' 的引用"
 # "decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is a C++20 extension"
-HED6397EE7170: "分解声明被声明%plural{1:'%1'|:具有'%1'说明符}0是C++20扩展"
+HED6397EE7170: "分解声明被声明%plural{1:'%1'|:具有 '%1' 说明符}0是C++20扩展"
 # "decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20"
-H3B1B7DD7D4A6: "分解声明被声明%plural{1:'%1'|:具有'%1'说明符}0与C++20之前的标准不兼容"
+H3B1B7DD7D4A6: "分解声明被声明%plural{1:'%1'|:具有 '%1' 说明符}0与C++20之前的标准不兼容"
 # 'decomposition declaration must be the only declaration in its group'
 H36F7861E46A5: '分解声明必须是其组中的唯一声明'
 # 'decomposition declaration not permitted in this context'
@@ -19959,23 +19959,23 @@ H03080CBC4C1A: '推导出模板参数 %1 的不完整包 %0'
 # 'deduced non-type template argument does not have the same type as the corresponding template parameter%diff{ ($ vs $)|}0,1'
 H6489085BE16C: '推导出的非类型模板实参与对应的模板参数类型不一致%diff{ ($ vs $)|}0,1'
 # "deduced return type for defaulted %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator must be 'auto', not %1"
-H209B0E7EFC40: "默认实现的%select{<ERROR>|equality|three-way|equality|relational}0比较运算符的推导返回类型必须为'auto'，而非%1"
+H209B0E7EFC40: "默认实现的%select{<ERROR>|equality|three-way|equality|relational}0比较运算符的推导返回类型必须为 'auto'，而非 %1"
 # 'deduced return types are a C++14 extension'
 HB07F9BCAC63A: '推导返回类型是C++14扩展'
 # 'deduced type %0 does not satisfy %1'
-H9431BF910A33: '推导出的类型%0不满足%1'
+H9431BF910A33: '推导出的类型 %0 不满足 %1'
 # 'deduced type %1 of deduction guide is not %select{|written as }2a specialization of template %0'
-H902D2FE80122: '推导指引的推导类型%1不是%select{|以}2模板%0的特化形式'
+H902D2FE80122: '推导指引的推导类型 %1 不是%select{|以}2模板 %0 的特化形式'
 # 'deduction guide cannot be %select{explicitly instantiated|explicitly specialized}0'
 HA3A632F69A86: '推导指引不能%select{显式实例化|显式特化}0'
 # "deduction guide cannot be declared '%0'"
-HF6365CFA8B89: "推导指引不能被声明为'%0'"
+HF6365CFA8B89: "推导指引不能被声明为 '%0'"
 # 'deduction guide cannot have a function definition'
 H7D3F7544A5EA: '推导指引不能有函数定义'
 # 'deduction guide declaration without trailing return type'
 H4EE056EE4349: '推导指引声明缺少尾随返回类型'
 # 'deduction guide declared %0 by intervening access specifier'
-HBCF8F59E9812: '推导指引被%0的访问说明符声明'
+HBCF8F59E9812: '推导指引被 %0 的访问说明符声明'
 # 'deduction guide has different access from the corresponding member template'
 H1030B70A50CA: '推导指引与对应的成员模板的访问权限不同'
 # 'deduction guide must be declared in the same scope as template %q0'
@@ -19989,13 +19989,13 @@ HDB8C50704025: '函数的默认对齐方式'
 # 'default argument declared here'
 HDD61CA193DBE: '默认参数在这里声明'
 # 'default argument not permitted on an explicit %select{instantiation|specialization}0 of function %1'
-HA5116018194A: '显式%select{实例化|特化}0的函数%1不允许有默认参数'
+HA5116018194A: '显式%select{实例化|特化}0的函数 %1 不允许有默认参数'
 # "default argument references 'this'"
-H743C3B172B68: "默认参数引用了'this'"
+H743C3B172B68: "默认参数引用了 'this'"
 # 'default argument references local variable %0 of enclosing function'
-HAA8CD5949FC3: '默认参数引用了外部函数的局部变量%0'
+HAA8CD5949FC3: '默认参数引用了外部函数的局部变量 %0'
 # 'default argument references parameter %0'
-H573EB7C93602: '默认参数引用了参数%0'
+H573EB7C93602: '默认参数引用了参数 %0'
 # 'default argument used here'
 H2C2A14271D90: '默认参数在此处使用'
 # 'default arguments can only be specified for parameters in a function declaration'
@@ -20007,25 +20007,25 @@ H2A1897D12086: '不能为%select{类模板|类模板的部分特化|模板中的
 # 'default arguments not allowed for parameters of a requires expression'
 H8AAADF6A99AF: '不允许为requires表达式参数的默认参数'
 # 'default assign attribute on property %0 which implements NSCopying protocol is not appropriate with -fobjc-gc[-only]'
-H8248EDB07821: '实现了NSCopying协议的属性%0的默认assign属性与-fobjc-gc[-only]不兼容'
+H8248EDB07821: '实现了NSCopying协议的属性 %0 的默认assign属性与-fobjc-gc[-only]不兼容'
 # 'default capture by %select{value|reference}0'
 H472BB89BA278: '默认按%select{值|引用}0捕获'
 # 'default constructed field %0 declared here'
-H948E9DA6EBAF: '默认构造的字段%0在此处声明'
+H948E9DA6EBAF: '默认构造的字段 %0 在此处声明'
 # 'default exception handling model'
 H9659057B9931: '默认异常处理模型'
 # 'default initialization of an object of const type %0%select{| without a user-provided default constructor}1'
-H303212CBDF84: 'const类型%0%select{|没有用户提供的默认构造函数}1的默认初始化'
+H303212CBDF84: 'const类型 %0%select{|没有用户提供的默认构造函数}1的默认初始化'
 # 'default initialization of an object of const type %0%select{| without a user-provided default constructor}1 is a Microsoft extension'
-H48E5A1B64C89: 'const类型%0%select{|没有用户提供的默认构造函数}1的默认初始化是Microsoft扩展'
+H48E5A1B64C89: 'const类型 %0%select{|没有用户提供的默认构造函数}1的默认初始化是Microsoft扩展'
 # 'default label in switch which covers all enumeration values'
 HF1A67825B6F5: 'switch中的默认标签覆盖所有枚举值'
 # 'default member initializer declared here'
 H09B30FC3540B: '默认成员初始值设定项在此处声明'
 # 'default member initializer for %0 uses itself'
-H62A9561A4498: '成员%0的默认初始值设定项使用了自身'
+H62A9561A4498: '成员 %0 的默认初始值设定项使用了自身'
 # 'default member initializer for %1 needed within definition of enclosing class %0 outside of member functions'
-HB4FBDC93A96D: '在外部类%0的成员函数外部定义时，需要为%1的默认成员初始值设定项'
+HB4FBDC93A96D: '在外部类 %0 的成员函数外部定义时，需要为 %1 的默认成员初始值设定项'
 # 'default member initializer for bit-field is a C++20 extension'
 H960B2B591D79: '位字段的默认成员初始值设定项是C++20扩展'
 # 'default member initializer for bit-field is incompatible with C++ standards before C++20'
@@ -20035,7 +20035,7 @@ HB1974A6508C8: '非静态数据成员的默认成员初始值设定项是C++11�
 # 'default member initializer for non-static data members is incompatible with C++98'
 H75DECF5B5D30: '非静态数据成员的默认成员初始值设定项与C++98标准不兼容'
 # "default property attribute 'assign' not appropriate for object"
-HBAC11B3F8368: "对象的默认属性'assign'不适用"
+HBAC11B3F8368: "对象的默认属性 'assign' 不适用"
 # 'default scope specifier for attributes is a C++17 extension'
 H9959B28B39FE: '属性的默认作用域限定符是C++17扩展'
 # 'default scope specifier for attributes is incompatible with C++ standards before C++17'
@@ -20051,21 +20051,21 @@ H94B1EDF48980: '函数模板的默认模板实参是C++11扩展'
 # 'default template arguments for a function template are incompatible with C++98'
 H688888558286: '函数模板的默认模板实参与C++98不兼容'
 # 'defaulted %0 is implicitly deleted because %2 is a %select{union-like class|union}1 with variant members'
-HAADBD633A7F2: '默认的%0因隐式删除，因为%2是具有变体成员的%select{类似联合的类|联合}1'
+HAADBD633A7F2: '默认的 %0 因隐式删除，因为 %2 是具有变体成员的%select{类似联合的类|联合}1'
 # 'defaulted %0 is implicitly deleted because a builtin comparison function using this conversion would be the best match for the comparison'
-H6F959181B71C: '默认的%0因隐式删除，因为使用该转换的内建比较函数会成为比较的最佳匹配'
+H6F959181B71C: '默认的 %0 因隐式删除，因为使用该转换的内建比较函数会成为比较的最佳匹配'
 # 'defaulted %0 is implicitly deleted because class %1 has a reference member'
-HDDAEEF62F6DD: '默认的%0因隐式删除，因为类%1有引用成员'
+HDDAEEF62F6DD: '默认的 %0 因隐式删除，因为类 %1 有引用成员'
 # "defaulted %0 is implicitly deleted because implied %select{|'==' |'<' }1comparison %select{|for member %3 |for base class %3 }2is ambiguous"
-H8204A4BEFE67: "默认的%0因隐式删除，因为隐含的%select{|'==' |'<' }1比较%select{|对于成员%3 |对于基类%3 }2是模棱两可的"
+H8204A4BEFE67: "默认的 %0 因隐式删除，因为隐含的%select{|'==' |'<' }1比较%select{|对于成员 %3 |对于基类 %3 }2是模棱两可的"
 # 'defaulted %0 is implicitly deleted because it would invoke a %select{private|protected}3 %4%select{ member of %6| member of %6 to compare member %2| to compare base class %2}1'
-HA2763C071EBA: '默认的%0因隐式删除，因为它会调用%select{private|protected}3 %4%select{ 的%6成员|的%6成员来比较成员%2|来比较基类%2}1'
+HA2763C071EBA: '默认的 %0 因隐式删除，因为它会调用 %select{private|protected}3 %4%select{ 的 %6 成员|的 %6 成员来比较成员 %2|来比较基类 %2}1'
 # 'defaulted %0 is implicitly deleted because it would invoke a deleted comparison function%select{| for member %2| for base class %2}1'
 H73AE2279ECF2: '默认的 %0 被隐式删除，因为它会调用已删除的比较函数%select{|的成员 %2|的基类 %2}1'
 # "defaulted %0 is implicitly deleted because there is no viable %select{three-way comparison function|'operator=='}1 for %select{|member |base class }2%3"
-HC9957DD8DD53: "默认的%0因隐式删除，因为%select{|成员 |基类 }2%3没有可用的%select{三向比较函数|'operator=='}1"
+HC9957DD8DD53: "默认的 %0 因隐式删除，因为%select{|成员 |基类 }2%3 没有可用的%select{三向比较函数|'operator=='}1"
 # 'defaulted %0 is implicitly deleted because this non-rewritten comparison function would be the best match for the comparison'
-H5A66B2776E93: '默认的%0因隐式删除，因为此未重写的比较函数会成为比较的最佳匹配'
+H5A66B2776E93: '默认的 %0 因隐式删除，因为此未重写的比较函数会成为比较的最佳匹配'
 # 'defaulted comparison function must not be volatile'
 H50500CCE550F: '默认的比较函数不能声明为volatile'
 # 'defaulted comparison operators are a C++20 extension'
@@ -20073,13 +20073,13 @@ H17EA10D2ACC2: '默认比较运算符是C++20扩展'
 # 'defaulted comparison operators are incompatible with C++ standards before C++20'
 H38C2AF56B86F: '默认比较运算符与C++20之前的C++标准不兼容'
 # "defaulted definition of %select{%select{<ERROR>|equality|three-way|equality|relational}1 comparison operator|three-way comparison operator}0 cannot be declared %select{constexpr|consteval}2 because %select{it|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function"
-HDA596C603C53: '默认的%select{%select{<ERROR>|相等性|三向|相等性|关系性}1比较运算符|三向比较运算符}0不能声明为%select{constexpr|consteval}2，因为%select{它|对应隐式operator==的}0调用了非constexpr比较函数'
+HDA596C603C53: '默认的%select{%select{<ERROR>|相等性|三向|相等性|关系性}1比较运算符|三向比较运算符}0不能声明为 %select{constexpr|consteval}2，因为%select{它|对应隐式operator==的}0调用了非constexpr比较函数'
 # 'defaulted definition of %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}0 cannot be marked %select{constexpr|consteval}1 before C++23'
-H5C1B0C179374: '默认的%select{默认构造函数|拷贝构造函数|移动构造函数|拷贝赋值运算符|移动赋值运算符|析构函数}0在C++23之前不能标记为%select{constexpr|consteval}1'
+H5C1B0C179374: '默认的%select{默认构造函数|拷贝构造函数|移动构造函数|拷贝赋值运算符|移动赋值运算符|析构函数}0在C++23之前不能标记为 %select{constexpr|consteval}1'
 # 'defaulted member %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator must be const-qualified'
 H8A22F945F946: '默认的%select{<ERROR>|相等性|三向|相等性|关系性}0比较运算符必须有const限定符'
 # 'defaulted move assignment operator of %0 will move assign virtual base class %1 multiple times'
-HC302B71D801C: '类型%0的默认移动赋值运算符将多次移动赋值虚基类%1'
+HC302B71D801C: '类型 %0 的默认移动赋值运算符将多次移动赋值虚基类 %1'
 # "defaulting %select{this %select{<ERROR>|equality|three-way|equality|relational}1 comparison operator|the corresponding implicit 'operator==' for this defaulted 'operator<=>'}0 would delete it after its first declaration"
 HCBD1D13B7A08: "默认实现%select{这个 %select{<ERROR>|相等性|三向|相等性|关系}1 比较运算符|对应隐式 'operator==' 的这个默认 'operator<=>' }0 会删除其首次声明后的实现"
 # 'defaulting this %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator is not allowed because it was already declared outside the class'
@@ -20101,7 +20101,7 @@ H6A431AA48FA1: "%0 的定义在闭合的 '}' 之前未完成"
 # 'definition of a %select{static|thread_local}1 variable in a constexpr %select{function|constructor}0 is a C++23 extension'
 H398F375C6A6A: '在constexpr %select{函数|构造函数}0中定义一个%select{静态|thread_local}1变量是C++23扩展'
 # 'definition of a %select{static|thread_local}1 variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23'
-HE9C5585842AA: '在constexpr %select{function|constructor}0中定义一个%select{static|thread_local}1变量与C++23之前的C++标准不兼容'
+HE9C5585842AA: '在constexpr %select{function|constructor}0 中定义一个 %select{static|thread_local}1 变量与C++23之前的C++标准不兼容'
 # 'definition of a variable of non-literal type in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23'
 H53017D331C6A: '在constexpr %select{函数|构造函数}0 中定义非字面量类型的变量与C++23之前的版本不兼容'
 # 'definition of builtin function %0'
@@ -20123,27 +20123,27 @@ H423281D39FA7: '%0 的隐式拷贝 %select{构造函数|赋值运算符}1 已弃
 # 'definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-provided copy %select{assignment operator|constructor}1'
 H3C23BCA5B3D2: '%0 的隐式拷贝 %select{构造函数|赋值运算符}1 已弃用，因为其包含用户提供的拷贝 %select{赋值运算符|构造函数}1'
 # 'definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-provided destructor'
-H396EB4CE9202: '隐式拷贝的%select{构造函数|赋值运算符}1的定义对%0已被弃用，因为其提供了用户定义的析构函数'
+H396EB4CE9202: '隐式拷贝的%select{构造函数|赋值运算符}1的定义对 %0 已被弃用，因为其提供了用户定义的析构函数'
 # 'definition of implicitly declared %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor|function}1'
 H86596A04E020: '隐式声明的%select{默认构造函数|拷贝构造函数|移动构造函数|拷贝赋值运算符|移动赋值运算符|析构函数|函数}1的定义'
 # 'definition of macro %0 does not match definition in precompiled header'
-H79B9B4BA8FFF: '宏%0的定义与预编译头中的定义不匹配'
+H79B9B4BA8FFF: '宏 %0 的定义与预编译头中的定义不匹配'
 # "definition of macro '%0' differs between the AST file '%3' ('%1') and the command line ('%2')"
-H40BB23B29C3F: "宏'%0'在AST文件'%3'（'%1'）和命令行（'%2'）中的定义不同"
+H40BB23B29C3F: "宏 '%0' 在AST文件 '%3'（'%1'）和命令行（'%2'）中的定义不同"
 # "definition of module '%0' is not available; use -fmodule-file= to specify path to precompiled module interface"
-H1ED33479DE5D: "模块'%0'的定义不可用；请使用-fmodule-file=指定预编译模块接口的路径"
+H1ED33479DE5D: "模块 '%0' 的定义不可用；请使用-fmodule-file=指定预编译模块接口的路径"
 # 'definition of type %0 conflicts with %select{typedef|type alias}1 of the same name'
-H5C3C4CCA94AB: '类型%0的定义与同名的%select{typedef|类型别名}1冲突'
+H5C3C4CCA94AB: '类型 %0 的定义与同名的%select{typedef|类型别名}1冲突'
 # 'definition of variable with array type needs an explicit size or an initializer'
 H79E09A4784DB: '具有数组类型的变量定义需要显式指定大小或初始化器'
 # 'definition or redeclaration of %0 cannot name the global scope'
-H3AC58FC9EA5A: '%0的定义或重新声明不允许出现在全局作用域'
+H3AC58FC9EA5A: '%0 的定义或重新声明不允许出现在全局作用域'
 # 'definition or redeclaration of %0 not allowed inside a block'
-HD4328CF55600: '%0的定义或重新声明不允许出现在块内部'
+HD4328CF55600: '%0 的定义或重新声明不允许出现在块内部'
 # 'definition or redeclaration of %0 not allowed inside a function'
-H26DE3CAC54F0: '%0的定义或重新声明不允许出现在函数内部'
+H26DE3CAC54F0: '%0 的定义或重新声明不允许出现在函数内部'
 # "definition with same mangled name '%0' as another definition"
-H9CD626C8B999: "与另一个定义具有相同的装饰名称'%0'"
+H9CD626C8B999: "与另一个定义具有相同的装饰名称 '%0'"
 # 'defsym must be of the form: sym=value: %0'
 H633B95A139C3: 'defsym必须采用形式：sym=value: %0'
 # 'delegating constructors are incompatible with C++98'
@@ -20151,21 +20151,21 @@ H57A554A5A2B8: '委派构造函数与C++98不兼容'
 # 'delegating constructors are permitted only in C++11'
 H859BD39058E0: '仅允许在C++11中使用委派构造函数'
 # 'delete of object with dynamic type %1 through pointer to base class type %0 with non-virtual destructor'
-H2817C3914B5E: '通过基类类型%0的指针删除动态类型为%1的对象，而该基类未声明虚析构函数'
+H2817C3914B5E: '通过基类类型 %0 的指针删除动态类型为 %1 的对象，而该基类未声明虚析构函数'
 # "delete of pointer '%0' that does not point to a heap-allocated object"
-H8B4F3ED0F000: "删除指向非堆分配对象的指针'%0'"
+H8B4F3ED0F000: "删除指向非堆分配对象的指针 '%0'"
 # 'delete of pointer that has already been deleted'
 H42BC8DFBCECC: '删除已被释放的指针'
 # "delete of pointer%select{ to subobject|}1 '%0' %select{|that does not point to complete object}1"
-H4DFF941C0746: '删除%select{子对象|}1的指针%select{|不指向完整对象}1的指针%0'
+H4DFF941C0746: '删除%select{子对象|}1的指针%select{|不指向完整对象}1的指针 %0'
 # 'deleted definition must be first declaration'
 H0F602982588E: '被删除的定义必须是首次声明'
 # 'deleted function %0 cannot override a non-deleted function'
-H3FCDC44C217B: '被删除的函数%0不能覆盖非删除函数'
+H3FCDC44C217B: '被删除的函数 %0 不能覆盖非删除函数'
 # 'deleting incomplete class type %0; no conversions to pointer type'
-H9074591E0AF3: '删除不完整类类型%0；无法转换为指针类型'
+H9074591E0AF3: '删除不完整类类型 %0；无法转换为指针类型'
 # 'deleting pointer to incomplete type %0 is incompatible with C++2c and may cause undefined behavior'
-H0FC4BDC8CA1F: '删除指向不完整类型%0的指针与C++2c不兼容，可能导致未定义行为'
+H0FC4BDC8CA1F: '删除指向不完整类型 %0 的指针与C++2c不兼容，可能导致未定义行为'
 # 'delimited escape sequence cannot be empty'
 H5E38AA141B13: '界定转义序列不能为空'
 # 'delimited escape sequences are incompatible with C standards before C2y'
@@ -20181,27 +20181,27 @@ HBDD387FC03A4: '非正规数的处理方式未知'
 # 'dense YAML representation'
 HA97D8413D319: '密集的YAML表示形式'
 # "depend modifier cannot be used with 'sink' or 'source' depend type"
-H92A125FCC1F2: "depend修饰符不能与'sink'或'source' depend类型一起使用"
+H92A125FCC1F2: "depend修饰符不能与 'sink' 或 'source' depend类型一起使用"
 # 'dependent %select{__if_not_exists|__if_exists}0 declarations are ignored'
 H7E0205C30EB0: '依赖的%select{__if_not_exists|__if_exists}0声明被忽略'
 # 'dependent nested name specifier %0 for friend class declaration is not supported; turning off access control for %1'
-H6C7EBDCCA541: '依赖的嵌套名称指定符%0用于友元类声明不受支持；禁用%1的访问控制'
+H6C7EBDCCA541: '依赖的嵌套名称指定符 %0 用于友元类声明不受支持；禁用 %1 的访问控制'
 # 'dependent nested name specifier %0 for friend template declaration is not supported; ignoring this friend declaration'
-H5BCC077F4A6E: '依赖的嵌套名称指定符%0用于友元模板声明不受支持；忽略此友元声明'
+H5BCC077F4A6E: '依赖的嵌套名称指定符 %0 用于友元模板声明不受支持；忽略此友元声明'
 # "dependent using declaration resolved to type without 'typename'"
-H9473A34B51B9: "依赖的using声明解析为不带'typename'的类型"
+H9473A34B51B9: "依赖的using声明解析为不带 'typename' 的类型"
 # 'dereference of pointer to incomplete type %0'
-H2DF43C211998: '解引用指向不完整类型%0的指针'
+H2DF43C211998: '解引用指向不完整类型 %0 的指针'
 # 'dereference of type %1 that was reinterpret_cast from type %0 has undefined behavior'
-H90FCF362143A: '对类型%0经reinterpret_cast转换为类型%1后的解引用会导致未定义行为'
+H90FCF362143A: '对类型 %0 经reinterpret_cast转换为类型 %1 后的解引用会导致未定义行为'
 # 'dereferenced pointer past the end of %select{|subobject of }0%select{temporary|%2}1 is not a constant expression'
 H22AD60D3A378: '解引用超出%select{|子对象的 }0%select{临时对象|%2}1末尾的指针不是一个常量表达式'
 # "dereferencing %0; was declared with a 'noderef' type"
-H77B30DE9BC36: "解引用%0；该类型被声明为'noderef'"
+H77B30DE9BC36: "解引用 %0；该类型被声明为 'noderef'"
 # 'dereferencing a __weak pointer is not allowed due to possible null value caused by race condition, assign it to strong variable first'
 H69A87CE8BA55: '由于竞态条件可能导致空值，不允许解引用__weak指针，请先将其赋值给strong变量'
 # "dereferencing expression marked as 'noderef'"
-HB6D67B14D60F: "解引用标记为'noderef'的表达式"
+HB6D67B14D60F: "解引用标记为 'noderef' 的表达式"
 # 'derived class must specify the same code segment as its base classes'
 HF7C9EF85294D: '派生类必须指定与基类相同的代码段'
 # 'descending'
@@ -20209,9 +20209,9 @@ H486093918FF3: '降序'
 # 'designated initializer invoked a non-designated initializer'
 H504DCC34F2E8: '命名初始化器调用了非命名初始化器'
 # "designated initializer missing a 'super' call to a designated initializer of the super class"
-H94AB45A96460: "命名初始化器缺少对超类命名初始化器的'super'调用"
+H94AB45A96460: "命名初始化器缺少对超类命名初始化器的 'super' 调用"
 # "designated initializer should only invoke a designated initializer on 'super'"
-H2306DCB92F88: "命名初始化器应仅在'super'上调用命名初始化器"
+H2306DCB92F88: "命名初始化器应仅在 'super' 上调用命名初始化器"
 # 'designated initializers are a C++20 extension'
 H868FB6A7DCFA: '命名初始化器是C++20扩展'
 # 'designated initializers are a C99 feature'
@@ -20219,11 +20219,11 @@ HCE690B2EFB92: '指定初始化器是C99的特性'
 # 'designated initializers are incompatible with C++ standards before C++20'
 HB212F1F17A19: '指定初始化器与C++20之前的C++标准不兼容'
 # 'designator in initializer for %select{scalar|indivisible sizeless}0 type %1'
-HDC0C952FB90A: '%select{标量|不可分割且无大小}0类型%1的初始化器中的指定符'
+HDC0C952FB90A: '%select{标量|不可分割且无大小}0类型 %1 的初始化器中的指定符'
 # 'designator into flexible array member subobject'
 H596716C96072: '指定符进入柔性数组成员子对象'
 # "destroying object '%0' whose lifetime has already ended"
-H480FFC7A6CDF: "销毁生命周期已结束的对象'%0'"
+H480FFC7A6CDF: "销毁生命周期已结束的对象 '%0'"
 # 'destroying operator delete can have only an optional size and optional alignment parameter'
 H05866AB32F25: '销毁用的operator delete只能有可选的大小和可选的对齐参数'
 # 'destruction of individual component of complex number is not yet supported in constant expressions'
@@ -20233,13 +20233,13 @@ HBC86CD58BD53: '正在销毁已被销毁的对象'
 # 'destructor cannot be declared %select{<ERROR>|constexpr|consteval|constinit}0'
 H39B25D41B01F: '析构函数不能声明为%select{<ERROR>|constexpr|consteval|constinit}0'
 # 'destructor cannot be declared %select{<ERROR>|constexpr|consteval|constinit}0 because %select{data member %2|base class %3}1 does not have a constexpr destructor'
-HEA62090F1654: '析构函数不能声明为%select{<ERROR>|constexpr|consteval|constinit}0，因为%select{数据成员%2|基类%3}1没有constexpr析构函数'
+HEA62090F1654: '析构函数不能声明为%select{<ERROR>|constexpr|consteval|constinit}0，因为%select{数据成员 %2|基类 %3}1没有constexpr析构函数'
 # "destructor cannot be declared '%0'"
-H18788E54B072: "析构函数不能声明为'%0'"
+H18788E54B072: "析构函数不能声明为 '%0'"
 # 'destructor cannot be declared as a template'
 H2A9016676C0B: '析构函数不能声明为模板'
 # 'destructor cannot be declared using a %select{typedef|type alias}1 %0 of the class name'
-HD2E86EDB043A: '不能使用类名的%select{typedef|类型别名}1 %0来声明析构函数'
+HD2E86EDB043A: '不能使用类名的%select{typedef|类型别名}1 %0 来声明析构函数'
 # 'destructor cannot be redeclared'
 H7C102E557BD9: '析构函数不能被重新声明'
 # 'destructor cannot be variadic'
@@ -20249,15 +20249,15 @@ HB61BE667BB0D: '析构函数不能有返回类型'
 # 'destructor cannot have any parameters'
 H27289F072FC5: '析构函数不能有任何参数'
 # 'destructor for %0 is not trivial because it is virtual'
-H695A7FB4C51A: '%0的析构函数不是平凡的，因为它为虚析构函数'
+H695A7FB4C51A: '%0 的析构函数不是平凡的，因为它为虚析构函数'
 # 'destructor must be a non-static member function'
 HE5AA51DEFC74: '析构函数必须是一个非静态成员函数'
 # 'destructor name %0 does not refer to a template'
-H6A0A4776F7D0: '析构函数名%0不指向一个模板'
+H6A0A4776F7D0: '析构函数名 %0 不指向一个模板'
 # 'destructor of class %0 is ambiguous'
-H29DC1463BFE1: '类%0的析构函数存在二义性'
+H29DC1463BFE1: '类 %0 的析构函数存在二义性'
 # 'destructor type %0 in object destruction expression does not match the type %1 of the object being destroyed'
-HCA02CE698CF6: '对象销毁表达式中的析构函数类型%0与被销毁对象的类型%1不匹配'
+HCA02CE698CF6: '对象销毁表达式中的析构函数类型 %0 与被销毁对象的类型 %1 不匹配'
 # 'detect use after scope within function'
 H76CE675503B0: '检测函数内作用域结束后使用'
 # 'detected while default synthesizing properties in class implementation'
@@ -20279,41 +20279,41 @@ H1318B5E4A90B: '诊断信息：%0'
 # 'diagtool find-diagnostic-id options'
 H0E16FA84CCEE: 'diagtool查找诊断ID选项'
 # "did not expect %0 '%2' to be managed by '%1'"
-H41E6876DEC05: "未期望%0 '%2' 由 '%1' 管理"
+H41E6876DEC05: "未期望 %0 '%2' 由 '%1' 管理"
 # "did not find header '%0' in framework '%1' (loaded from '%2')"
-H33EA4C9E31A5: '在框架"%1"（从"%2"加载）中未找到头文件"%0"'
+H33EA4C9E31A5: '在框架 "%1"（从 "%2" 加载）中未找到头文件 "%0"'
 # "did you forget ';'?"
 H5762CA5BE293: '是否漏掉了";"？'
 # "did you intend to use '#pragma pack (pop)' instead of '#pragma pack()'?"
 H38F2C3CF1911: '是否应使用"#pragma pack(pop)"而不是"#pragma pack()"？'
 # "did you mean %0 ('%2' U+%1)?"
-H034E19BAF4DB: '是否是指%0（"%2" U+%1）？'
+H034E19BAF4DB: '是否是指 %0（"%2" U+%1）？'
 # 'did you mean %0?'
-H0AFE75F407BD: '是否是指%0？'
+H0AFE75F407BD: '是否是指 %0？'
 # 'did you mean %select{struct|interface|class}0 here?'
-H2F94B54CE3AD: '此处是否是指%select{struct|interface|class}0？'
+H2F94B54CE3AD: '此处是否是指 %select{struct|interface|class}0？'
 # "did you mean '%0'?"
-HC2D29273BC0C: '是否是指"%0"？'
+HC2D29273BC0C: '是否是指 "%0"？'
 # "did you mean 'using namespace'?"
 H7384271A4FC4: '是否是指"using namespace"？'
 # "did you mean to %select{dereference the argument to 'sizeof' (and multiply it by the number of elements)|remove the addressof in the argument to 'sizeof' (and multiply it by the number of elements)|provide an explicit length}0?"
 H206E38ACCE90: '是否应%select{对"sizeof"的参数进行解引用（并乘以元素数量）|移除"sizeof"参数中的取地址运算符（并乘以元素数量）|提供显式的长度}0？'
 # 'did you mean to call the %0 method?'
-H0FF3D4ADDC94: '是否应调用%0方法？'
+H0FF3D4ADDC94: '是否应调用 %0 方法？'
 # 'did you mean to compare the result of %0 instead?'
-HA27A0B6056FB: '是否应比较%0的结果？'
+HA27A0B6056FB: '是否应比较 %0 的结果？'
 # "did you mean to use '%0'?"
-H18F66684E290: '是否应使用"%0"？'
+H18F66684E290: '是否应使用 "%0"？'
 # "did you mean to use '.' instead?"
 HE2F23CD42B59: '是否应使用"."？'
 # "did you mean to use '\\u'?"
 H8EB1B38F64B3: '您是否想使用‘\\u’？'
 # "did you mean to use 'typename'?"
-HA177681AD789: "您是否想使用'typename'？"
+HA177681AD789: "您是否想使用 'typename'？"
 # 'did you mean to use __block %0?'
 H6A59F85FFA80: '您是否想使用__block %0？'
 # "differing user-defined suffixes ('%0' and '%1') in string literal concatenation"
-HD69068F6D5EE: "字符串字面量连接时用户定义的后缀不同（'%0'和'%1'）"
+HD69068F6D5EE: "字符串字面量连接时用户定义的后缀不同（'%0' 和 '%1'）"
 # 'digit separator cannot appear at %select{start|end}0 of digit sequence'
 HC90158811A8B: '数字分隔符不能出现在数字序列的%select{开始|结束}0处'
 # 'digit separators are incompatible with C standards before C23'
@@ -20325,9 +20325,9 @@ H7ABEC48E09A3: '维度表达式未计算为常量无符号整数'
 # "direct access to Objective-C's isa is deprecated in favor of object_getClass()"
 H9F7CC297D241: '直接访问Objective-C的isa已弃用，建议使用object_getClass()'
 # 'direct attribute on property %0 ignored (not implemented by this Objective-C runtime)'
-H4EFEDE46DF56: '属性%0的direct属性被忽略（此Objective-C运行时未实现该功能）'
+H4EFEDE46DF56: '属性 %0 的direct属性被忽略（此Objective-C运行时未实现该功能）'
 # 'direct base %0 is inaccessible due to ambiguity:%1'
-HB8D80890A48E: '直接基类%0由于以下歧义不可访问：%1'
+HB8D80890A48E: '直接基类 %0 由于以下歧义不可访问：%1'
 # 'direct comparison of %select{an array literal|a dictionary literal|a numeric literal|a boxed expression|}0 has undefined behavior'
 HB492D0D3EB6E: '直接比较%select{数组字面量|字典字面量|数值字面量|包装表达式|}0会导致未定义行为'
 # 'direct comparison of a string literal has undefined behavior'
@@ -20335,7 +20335,7 @@ H32F54A871B25: '直接比较字符串字面量会导致未定义行为'
 # 'direct member declared here'
 H29E544F12128: '直接成员在此处声明'
 # 'direct method %0 declared here'
-HFC16D00B1613: '直接方法%0在此处声明'
+HFC16D00B1613: '直接方法 %0 在此处声明'
 # 'direct method implementation was previously declared not direct'
 HD4855D6E8730: '直接方法实现之前声明为非直接'
 # 'direct method was declared in %select{the primary interface|an extension|a category}0 but is implemented in %select{the primary interface|a category|a different category}1'
@@ -20343,9 +20343,9 @@ HE6AB93C50673: '在%select{主接口|扩展|分类}0中声明而在%select{主�
 # 'direct property cannot be @dynamic'
 HE7907E55F6FD: '直接属性不能为@dynamic'
 # "directive '#pragma omp %0' cannot contain more than one '%1' clause%select{| with '%3' name modifier| with 'source' dependence}2"
-H4FF8713761CF: "指令'#pragma omp %0'不能包含超过一个'%1'子句%select{|带有'%3'名称修饰符|带有'source'依赖}2"
+H4FF8713761CF: "指令'#pragma omp %0'不能包含超过一个 '%1' 子句%select{|带有 '%3' 名称修饰符|带有 'source' 依赖}2"
 # "directive '#pragma omp %0' cannot contain more than one 'seq_cst',%select{ 'relaxed',|}1 'acq_rel', 'acquire' or 'release' clause"
-HAC63F783B13F: "指令'#pragma omp %0'不能包含超过一个'seq_cst',%select{ 'relaxed',|}1 'acq_rel', 'acquire'或'release'子句"
+HAC63F783B13F: "指令'#pragma omp %0'不能包含超过一个 'seq_cst',%select{ 'relaxed',|}1 'acq_rel', 'acquire' 或 'release' 子句"
 # "directive '#pragma omp %0' requires the '%1' clause"
 H54115AA95D6F: "指令 '#pragma omp %0' 需要 '%1' 子句"
 # "directive '#pragma omp atomic%select{ %0|}1' cannot be used with '%2' clause"
@@ -20373,7 +20373,7 @@ H90AD861FB58A: '禁用在内存访问操作上附加TBAA标签以覆盖Flang的�
 # 'disable attributor runs'
 H6B93977370B5: '禁用attributor阶段的运行'
 # 'disable automatically generated 32byte paired vector stores'
-H37D64DB7E6AE: '禁用自动生成32字节配对向量存储'
+H37D64DB7E6AE: '禁用自动生成 32 字节配对向量存储'
 # 'disable constant hoisting on PPC'
 H653549C49999: '在PPC上禁用常量提升'
 # 'disable debug output'
@@ -20433,7 +20433,7 @@ H3B01C53C285F: '以嵌套树视图显示结果'
 # 'display the results with a nested pipeline view'
 HD3FB89799811: '以嵌套流水线视图显示结果'
 # 'div and rem instructions on integers with more than <N> bits are expanded.'
-H9085E8D323A2: '当整数位数超过<N>位时，展开div和rem指令'
+H9085E8D323A2: '当整数位数超过 <N> 位时，展开div和rem指令'
 # 'division by zero'
 H3658877899CE: '除以零'
 # 'division by zero in preprocessor expression'
@@ -20475,7 +20475,7 @@ H04276D1D8088: '域参数 %0 不指向 NSString 或 CFString 常量'
 # 'domain argument %select{|%1 }0does not refer to global constant'
 H427CD3AEDAC3: '域参数 %select{|%1 }0 不指向全局常量'
 # "don't always align innermost loop to 32 bytes on ppc"
-H8446540436C8: '在PPC架构上不对最内层循环始终进行32字节对齐'
+H8446540436C8: '在PPC架构上不对最内层循环始终进行 32 字节对齐'
 # "don't demangle symbols"
 HFD596F32C278: '不进行符号解码'
 # "don't report bad accesses via pointers with this tag"
@@ -20799,11 +20799,11 @@ HFB264777D8F6: "未求值的字符串字面量上的编码前缀 '%0' 没有效�
 # 'end tag'
 HE76165194C35: '结束标签'
 # "entering module '%0' due to this pragma"
-H00CF7F723C1C: "由于此#pragma指令进入模块'%0'"
+H00CF7F723C1C: "由于此#pragma指令进入模块 '%0'"
 # 'enum %0 was explicitly specialized here'
-H888313DD02EB: '枚举%0在这里被显式特化'
+H888313DD02EB: '枚举 %0 在这里被显式特化'
 # 'enumeration %0 is incomplete'
-HACD4B99390E7: '枚举类型%0是不完整的'
+HACD4B99390E7: '枚举类型 %0 是不完整的'
 # 'enumeration cannot be a template'
 H0777CF5091AE: '枚举类型不能作为模板'
 # 'enumeration previously declared as %select{un|}0scoped'
@@ -20811,9 +20811,9 @@ H979505490BD1: '枚举之前被声明为%select{非|}0作用域'
 # 'enumeration previously declared with %select{non|}0fixed underlying type'
 H8C078F2C2E0F: '枚举之前被声明为带有%select{非|}0固定底层类型'
 # 'enumeration redeclared with different underlying type %0 (was %1)'
-H67E555152513: '枚举被重新声明为不同的底层类型%0（原为%1）'
+H67E555152513: '枚举被重新声明为不同的底层类型 %0（原为 %1）'
 # 'enumeration type %0 is not allowed in a vector conditional'
-H71F136014B3C: '枚举类型%0不允许在向量条件中使用'
+H71F136014B3C: '枚举类型 %0 不允许在向量条件中使用'
 # 'enumeration type in nested name specifier is incompatible with C++98'
 HA088A8B3CD7F: '嵌套名称限定符中的枚举类型与C++98不兼容'
 # 'enumeration types with a fixed underlying type are a C++11 extension'
@@ -20827,27 +20827,27 @@ H39FE50255F32: '带有固定底层类型的枚举类型与C23之前的C标准不
 # 'enumeration types with a fixed underlying type are incompatible with C++98'
 H73924A0CCAED: '带有固定底层类型的枚举类型与C++98不兼容'
 # 'enumeration value %0 is out of range of flags in enumeration type %1'
-H4F8DF0E727E1: '枚举值%0超出枚举类型%1的标志范围'
+H4F8DF0E727E1: '枚举值 %0 超出枚举类型 %1 的标志范围'
 # 'enumeration values exceed range of largest integer'
 HC084754F6A8B: '枚举值超出最大整数类型的范围'
 # 'enumerations cannot be explicitly instantiated'
 H997CA3993586: '枚举类型不能显式实例化'
 # 'enumerator %0 does not exist in instantiation of %1'
-H3D7F75D140F9: '枚举常量%0在实例化%1时不存在'
+H3D7F75D140F9: '枚举常量 %0 在实例化 %1 时不存在'
 # 'enumerator %0 with value %1 here'
-HD8CCFA398CFA: '此处枚举常量%0的值为%1'
+HD8CCFA398CFA: '此处枚举常量 %0 的值为 %1'
 # 'enumerator value %0 is not representable in the underlying type %1'
-HAB7EC95F417E: '枚举常量%0的值无法用底层类型%1表示'
+HAB7EC95F417E: '枚举常量 %0 的值无法用底层类型 %1 表示'
 # 'enumerator value is not representable in the underlying type %0'
-H9CDAE4E68DA9: '枚举值无法用底层类型%0表示'
+H9CDAE4E68DA9: '枚举值无法用底层类型 %0 表示'
 # 'enums in the Microsoft ABI are signed integers by default; consider giving the enum %0 an unsigned underlying type to make this code portable'
-HB2071E0C6A67: 'Microsoft ABI中的枚举默认是带符号整数；请考虑为枚举%0指定无符号底层类型以增强代码的可移植性'
+HB2071E0C6A67: 'Microsoft ABI中的枚举默认是带符号整数；请考虑为枚举 %0 指定无符号底层类型以增强代码的可移植性'
 # "environment '%0' is not supported: '%1'"
 H88874600742B: "不支持的环境 '%0'：'%1'"
 # "environment variable 'SOURCE_DATE_EPOCH' ('%0') must be a non-negative decimal integer <= %1"
-H4F81D6E33B46: "环境变量 'SOURCE_DATE_EPOCH' ('%0') 必须是小于等于%1的非负十进制整数"
+H4F81D6E33B46: "环境变量 'SOURCE_DATE_EPOCH' ('%0') 必须是小于等于 %1 的非负十进制整数"
 # 'environment variable CC_PRINT_HEADERS_%select{FORMAT|FILTERING}0 has invalid value %1'
-H69C68EA8FAC0: '环境变量 CC_PRINT_HEADERS_%select{FORMAT|FILTERING}0 的值%1无效'
+H69C68EA8FAC0: '环境变量 CC_PRINT_HEADERS_%select{FORMAT|FILTERING}0 的值 %1 无效'
 # 'epsilon for benchmark point clustering'
 HA3C9480C7F62: '基准点聚类的epsilon值'
 # 'epsilon for detection of when the cluster is different from the LLVM schedule profile values'
@@ -20859,17 +20859,17 @@ H461F5EF9D3AE: '存在多余的括号的相等性比较'
 # 'error in backend: %0'
 H5E9564F574A6: '后端错误：%0'
 # "error in loading module '%0' from prebuilt module path"
-H9CB0C604EFA6: "从预构建模块路径加载模块'%0'时出错"
+H9CB0C604EFA6: "从预构建模块路径加载模块 '%0' 时出错"
 # "error opening '%0': %1"
-H14F257DDD829: "打开'%0'时出错：%1"
+H14F257DDD829: "打开 '%0' 时出错：%1"
 # "error opening '%0': required by the CrossTU functionality"
-HD1F59176156D: "打开'%0'时出错：该文件由跨翻译单元功能所需"
+HD1F59176156D: "打开 '%0' 时出错：该文件由跨翻译单元功能所需"
 # "error opening file '%0': %1"
-H36FA208EA1D0: "打开文件'%0'时出错：%1"
+H36FA208EA1D0: "打开文件 '%0' 时出错：%1"
 # "error parsing index file: '%0' line: %1 '<USR-Length>:<USR> <File-Path>' format expected"
-HDAED7E913418: "索引文件解析错误：'%0' 第%1行应为'<USR-Length>:<USR> <File-Path>'格式"
+HDAED7E913418: "索引文件解析错误：'%0' 第 %1 行应为'<USR-Length>:<USR> <File-Path>'格式"
 # "error reading '%0': %1"
-HB78815388E3E: "读取'%0'时出错：%1"
+HB78815388E3E: "读取 '%0' 时出错：%1"
 # 'error reading stdin: %0'
 HFD3376140ADC: '读取标准输入时出错：%0'
 # 'escaped newline between */ characters at block comment end'
@@ -20877,19 +20877,19 @@ H16A52D2449DE: '块注释末尾的*/字符之间存在转义换行符'
 # 'exact handling of relational integer ICmp'
 H083F931E8E9B: '关系整数ICmp的精确处理'
 # "exactly one '%0' directive must appear in the loop body of an enclosing directive"
-H3C9E45F0564B: "外围指令的循环体内必须出现恰好一个'%0'指令"
+H3C9E45F0564B: "外围指令的循环体内必须出现恰好一个 '%0' 指令"
 # "exactly one of 'depend', 'destroy', or 'update' clauses is expected"
-H41134C7D7A6A: "必须且只能指定'depend'、'destroy'或'update'子句中的一个"
+H41134C7D7A6A: "必须且只能指定 'depend'、'destroy' 或 'update' 子句中的一个"
 # "exactly one of 'inclusive' or 'exclusive' clauses is expected"
-H43DE08BE23B9: "必须且只能指定'inclusive'或'exclusive'子句中的一个"
+H43DE08BE23B9: "必须且只能指定 'inclusive' 或 'exclusive' 子句中的一个"
 # 'exception declarator cannot be qualified'
 H9E73B1CE7174: '异常声明符不能被限定'
 # 'exception model'
 HB1632BFA78F0: '异常模型'
 # 'exception object of type %0 has %select{private|protected}1 destructor'
-H45EFA39B1650: '类型为%0的异常对象具有%select{私有|受保护}1的析构函数'
+H45EFA39B1650: '类型为 %0 的异常对象具有%select{私有|受保护}1的析构函数'
 # 'exception of type %0 will be caught by earlier handler'
-H63736AC525A3: '类型为%0的异常将被更早的处理程序捕获'
+H63736AC525A3: '类型为 %0 的异常将被更早的处理程序捕获'
 # 'exception specification in declaration does not match previous declaration'
 H02068091298F: '当前声明的异常规范与之前的声明不匹配'
 # 'exception specification in explicit instantiation does not match instantiated one'
@@ -20897,9 +20897,9 @@ HB42947FF7AB7: '显式实例化中的异常规范与实例化后的规范不匹�
 # 'exception specification is not available until end of class definition'
 HD568DD20B09E: '异常规范在类定义结束前不可用'
 # 'exception specification needed for member of incomplete class %0'
-H64C22CA14EC7: '不完整类%0的成员需要异常规范'
+H64C22CA14EC7: '不完整类 %0 的成员需要异常规范'
 # 'exception specification of %0 uses itself'
-H8B7B4ED4974B: '%0的异常规范使用自身'
+H8B7B4ED4974B: '%0 的异常规范使用自身'
 # "exception specification of '...' is a Microsoft extension"
 H50C368DB8633: "'...'的异常规范是Microsoft扩展"
 # 'exception specification of overriding function is more lax than base version'
@@ -20915,19 +20915,19 @@ H6B059251CDF0: '%select{数组|向量|标量|联合|结构体}0初始化器存�
 # 'excess elements in char array initializer'
 H65240A881DB2: '字符数组初始化器存在多余元素'
 # 'excess elements in initializer for indivisible sizeless type %0'
-HF6B0539A54ED: '不可分割无尺寸类型%0的初始化器存在多余元素'
+HF6B0539A54ED: '不可分割无尺寸类型 %0 的初始化器存在多余元素'
 # 'excess precision is requested but the target does not support excess precision which may result in observable differences in complex division behavior%select{|, additional uses where the requested higher precision cannot be honored were found but not diagnosed}0'
 H46192DCC4FC7: '请求额外精度但目标架构不支持额外精度，可能导致复数除法行为差异%select{|, 在其他需要更高精度的位置未诊断出无法满足的情况}0'
 # 'exe called with module IR after each pass that changes it'
 H9DCF33C92D4F: '在每次修改模块的pass后，执行带有该模块IR的exe'
 # 'execute only is not supported for the %0 sub-architecture'
-H355C6C44365F: '%0子架构不支持执行仅模式'
+H355C6C44365F: '%0 子架构不支持执行仅模式'
 # 'existing instance variable %1 for __weak property %0 must be __weak'
-HBE1A4247ED95: '__weak属性%0的现有实例变量%1必须为__weak'
+HBE1A4247ED95: '__weak属性 %0 的现有实例变量 %1 必须为__weak'
 # 'existing instance variable %1 for property %0 with %select{unsafe_unretained|assign}2 attribute must be __unsafe_unretained'
-H45768C1508E1: '属性%0的%select{unsafe_unretained|assign}2属性对应的实例变量%1必须为__unsafe_unretained'
+H45768C1508E1: '属性 %0 的 %select{unsafe_unretained|assign}2 属性对应的实例变量 %1 必须为__unsafe_unretained'
 # 'existing instance variable %1 for strong property %0 may not be %select{|__unsafe_unretained||__weak}2'
-H98A6ABD1A54E: '强属性%0的现有实例变量%1不能为%select{|__unsafe_unretained||__weak}2'
+H98A6ABD1A54E: '强属性 %0 的现有实例变量 %1 不能为%select{|__unsafe_unretained||__weak}2'
 # 'existing instance variable %1 for strong property %0 may not be __weak'
 HD554DEC7881B: '强属性 %0 的现有实例变量 %1 可能不能是 __weak'
 # 'exit after writing aggregated data file'
@@ -20941,37 +20941,37 @@ H97F2144252C9: '此处请求展开宏 %0'
 # "expansion of predefined identifier '%0' to a string literal is a Microsoft extension"
 H89888E84B8EB: "将预定义标识符 '%0' 扩展为字符串字面量是 Microsoft 扩展"
 # 'expected "FILENAME" or <FILENAME>'
-H6038B7E6D091: "期望'FILENAME'或<FILENAME>"
+H6038B7E6D091: "期望 'FILENAME' 或 <FILENAME>"
 # "expected #pragma pack parameter to be '1', '2', '4', '8', or '16'"
-HA00C06644234: "#pragma pack参数应为'1'、'2'、'4'、'8'或'16'"
+HA00C06644234: "#pragma pack参数应为 '1'、'2'、'4'、'8' 或 '16'"
 # 'expected %0'
 H1C2353E37609: '期望 %0'
 # 'expected %0 at end of module'
-H0F6B0905AE5F: '模块末尾期望%0'
+H0F6B0905AE5F: '模块末尾期望 %0'
 # "expected %0 in OpenMP clause '%1'"
-HC79E103ACDFE: "在OpenMP子句'%1'中期望%0"
+HC79E103ACDFE: "在OpenMP子句 '%1' 中期望 %0"
 # 'expected %0 or %1'
-HC08F459555DA: '期望%0或%1'
+HC08F459555DA: '期望 %0 或 %1'
 # 'expected %0; %1 is a keyword in Objective-C++'
-H62A445966708: '期望%0; %1是Objective-C++中的关键字'
+H62A445966708: '期望 %0; %1 是Objective-C++中的关键字'
 # 'expected %1 after %0'
-H5879CE8F4818: '在%0之后期望%1'
+H5879CE8F4818: '在 %0 之后期望 %1'
 # "expected %select{'enable', 'disable', 'begin' or 'end'|'disable'}0 - ignoring"
-H1B18CF6CA096: "期望%select{'enable', 'disable', 'begin'或'end'|'disable'}0 - 忽略"
+H1B18CF6CA096: "期望%select{'enable', 'disable', 'begin' 或 'end'|'disable'}0 - 忽略"
 # "expected %select{'match'|'match', 'adjust_args', or 'append_args'}0 clause on 'omp declare variant' directive"
-HED7B3D66D419: "期望%select{'match'|'match', 'adjust_args'或'append_args'}0子句在'omp declare variant'指令上"
+HED7B3D66D419: "期望%select{'match'|'match', 'adjust_args' 或 'append_args'}0子句在'omp declare variant'指令上"
 # "expected %select{'val' modifier|one of 'ref', val' or 'uval' modifiers}0"
-HCC26F8F297FB: "期望%select{'val'修饰符|'ref', 'val'或'uval'修饰符之一}0"
+HCC26F8F297FB: "期望%select{'val' 修饰符|'ref', 'val' 或 'uval' 修饰符之一}0"
 # 'expected %select{assignment|assignment, compound assignment, increment, or decrement}0 expression'
 H2BC7EE32B904: '期望%select{赋值|赋值、复合赋值、递增或递减}0表达式'
 # "expected %select{identifier after '.' in |}0module name"
-HF095089F6D4D: '期望%select{.后的标识符|}0模块名称'
+HF095089F6D4D: '期望模块名称%select{中 '.' 后应为标识符|}0'
 # 'expected %select{identifier|unqualified-id}0'
 HC1969BE019B7: '期望%select{标识符|未限定的标识符}0'
 # 'expected %select{library|framework}0 name as a string'
 H5FD987168935: '期望%select{库|框架}0名称作为字符串'
 # "expected %select{module exclusion with 'exclude'|'export *'}0"
-H4175E9BAE37D: "期望%select{带有'exclude'的模块排除|'export *'}0"
+H4175E9BAE37D: "期望%select{带有 'exclude' 的模块排除|'export *'}0"
 # "expected '#pragma omp end declare %select{target|variant}0'"
 H7B3C6216417A: "期望'#pragma omp end declare %select{target|variant}0'"
 # "expected '#pragma omp end declare target' at end of file to match '#pragma omp %0'"
@@ -20979,19 +20979,19 @@ H25BEC71CAA92: "期望在文件末尾有'#pragma omp end declare target'来匹�
 # "expected '#pragma unused' argument to be a variable name"
 HE4429A749432: "'#pragma unused'参数应为变量名"
 # "expected '%0' after the %1; '%0' assumed"
-HB08F71D9B939: "在%1之后期望'%0'；假设了'%0'"
+HB08F71D9B939: "在 %1 之后期望 '%0'；假设了 '%0'"
 # "expected '%0' clause with an argument on '#pragma omp %1' construct"
-HA803E7993B4F: "在'#pragma omp %1'结构中期望带参数的'%0'子句"
+HA803E7993B4F: "在'#pragma omp %1'结构中期望带参数的 '%0' 子句"
 # "expected '(' after '%0'"
-HA365863454FD: "在'%0'后期望'('"
+HA365863454FD: "在 '%0' 后期望'('"
 # "expected '(' for function-style cast or type construction"
 H95D0E6661AB2: "期望'('用于函数式类型转换或类型构造"
 # "expected ')' after '%0'"
-H068274655B04: "在'%0'后期望')'"
+H068274655B04: "在 '%0' 后期望')'"
 # "expected ')' in preprocessor expression"
 H9FA29BAED1EF: "预处理表达式中期望')'"
 # "expected ')' or ',' after '%0'"
-HD115318388CA: "在'%0'后期望')'或','"
+HD115318388CA: "在 '%0' 后期望')'或','"
 # "expected ')' or ',' in '#pragma %0'"
 H97FBD869E75F: "在'#pragma %0'中期望')'或','"
 # "expected '+' or '-' operation"
@@ -21007,7 +21007,7 @@ H5B885E53A966: "在迭代器说明符后期望','或')'"
 # "expected ',' or ')' at end of property accessor list"
 H90761748BDB7: "在属性存取器列表末尾期望','或')'"
 # "expected ',' or ')' in '%0' %select{clause|directive}1"
-H27E43F9D4E4C: "在'%0' %select{子句|指令}1中期望','或')'"
+H27E43F9D4E4C: "在 '%0' %select{子句|指令}1中期望','或')'"
 # "expected ',' or '>' in template-parameter-list"
 HE6FA48C9A81A: "在模板参数列表中期望','或'>'"
 # "expected ',' or ']' in lambda capture list"
@@ -21015,13 +21015,13 @@ H01C14BB9E6E5: 'lambda捕获列表中期望","或"]"'
 # "expected '->' before expression type requirement"
 H25053402E92B: '在表达式类型要求前期望"->"'
 # "expected '.' after pragma attribute namespace %0"
-H6D0DBF9112AD: '在pragma属性命名空间%0后期望"."'
+H6D0DBF9112AD: '在pragma属性命名空间 %0 后期望"."'
 # "expected '::' after '__super'"
 HFBD8EE4CC424: '在"__super"后期望"::"'
 # "expected ';' after %0 statement"
-H26F61B7787AD: '"%0语句后期望";"'
+H26F61B7787AD: '"%0 语句后期望";"'
 # "expected ';' after '%0'"
-HC22BB7A01636: "期望在'%0'后有';'"
+HC22BB7A01636: "期望在 '%0' 后有';'"
 # "expected ';' after attribute list"
 HC367299E9BFD: "期望在属性列表后有';'"
 # "expected ';' after expression"
@@ -21043,13 +21043,13 @@ HA684210D419F: "期望在声明列表结尾处有';'"
 # "expected ';' at end of requirement"
 HDCCCFEC70AB1: "期望在约束条件结尾处有';'"
 # "expected ';' in 'for' statement specifier"
-H2C47358FD75D: "期望在'for'语句说明符中有';'"
+H2C47358FD75D: "期望在 'for' 语句说明符中有';'"
 # "expected '<' after '%0'"
-H1010291C9C7B: "期望在'%0'后有'<'"
+H1010291C9C7B: "期望在 '%0' 后有'<'"
 # "expected '= constant-expression' or end of enumerator definition"
 H01AC9A3D13F6: "期望'= 常量表达式'或枚举器定义结束"
 # "expected '=' after '%0'"
-H46EA9025A033: "期望在'%0'后有'='"
+H46EA9025A033: "期望在 '%0' 后有'='"
 # "expected '=' after diagnostic option"
 HEF7733E47109: "在诊断选项后期望 '=' 符号"
 # "expected '=' following '#pragma %select{align|options align}0' - ignored"
@@ -21079,7 +21079,7 @@ H0C6E25C16A3C: "在概念名称后期望 'auto' 或 'decltype(auto)'"
 # "expected 'begin' or 'end'"
 HE7122B95D2E3: "期望 'begin' 或 'end'"
 # "expected 'bind' clause for 'loop' construct without an enclosing OpenMP construct"
-H5C3B8520C88C: "期望在没有包含的OpenMP结构时，'loop'结构使用'bind'子句"
+H5C3B8520C88C: "期望在没有包含的OpenMP结构时，'loop' 结构使用 'bind' 子句"
 # "expected 'case' keyword before expression"
 H2E3235608C64: "在表达式前期望 'case' 关键字"
 # "expected 'compare' clause with the '%0' modifier"
@@ -21137,37 +21137,37 @@ HE811DCDC9E5C: "期望一个字段指定符，例如'.field = 4'"
 # 'expected a foldable binary operator in fold expression'
 H442801240371: '折叠表达式中需要一个可折叠的二元操作符'
 # "expected a for, while, or do-while loop to follow '%0'"
-H6905E348753C: "在'%0'之后需要跟随一个for、while 或 do-while 循环"
+H6905E348753C: "在 '%0' 之后需要跟随一个for、while 或 do-while 循环"
 # "expected a header attribute name ('size' or 'mtime')"
-H7FCC0389B837: "期望一个头文件属性名称（如'size'或'mtime'）"
+H7FCC0389B837: "期望一个头文件属性名称（如 'size' 或 'mtime'）"
 # "expected a header name after '%0'"
-HC5548A9AEA32: "在'%0'之后需要指定一个头文件名称"
+HC5548A9AEA32: "在 '%0' 之后需要指定一个头文件名称"
 # 'expected a memory order clause'
 H8A1509342CF4: '需要一个内存顺序子句'
 # "expected a message describing the conflict with '%0'"
-H3712B62CAC8D: "需要描述与'%0'冲突的说明信息"
+H3712B62CAC8D: "需要描述与 '%0' 冲突的说明信息"
 # 'expected a module map file name'
 H34A1748EFBBA: '需要一个模块映射文件名称'
 # "expected a module name after '%select{module|import}0'"
 H60B4E74C4DAA: "在'%select{module|import}0'之后期望一个模块名称"
 # "expected a module name in '__building_module' expression"
-H3E7D4309A80A: "在'__building_module'表达式中需要一个模块名称"
+H3E7D4309A80A: "在 '__building_module' 表达式中需要一个模块名称"
 # "expected a module name or '*'"
 HA872E74CF2C8: "需要一个模块名称或'*'"
 # 'expected a platform name here'
 HB3E385166F04: '此处需要一个平台名称'
 # "expected a platform name, e.g., 'macos'"
-H451496142CA8: "期望一个平台名称，例如'macos'"
+H451496142CA8: "期望一个平台名称，例如 'macos'"
 # 'expected a property name in @synthesize'
 HFCD01091BCD1: "'@synthesize'中需要指定属性名称"
 # "expected a qualified name after 'typename'"
-H3D60DB7C4A2E: "在'typename'之后需要一个限定名称"
+H3D60DB7C4A2E: "在 'typename' 之后需要一个限定名称"
 # "expected a reference to a parameter specified in a 'uniform' clause"
-HE4C3AD103D8E: "期望'uniform'子句中指定的参数的引用"
+HE4C3AD103D8E: "期望 'uniform' 子句中指定的参数的引用"
 # 'expected a reference to an integer-typed parameter'
 HD574D7423FC7: '需要一个指向整型参数的引用'
 # "expected a related Objective-C class name, e.g., 'NSColor'"
-H1B15D42F8530: "期望一个相关的Objective-C类名，例如'NSColor'"
+H1B15D42F8530: "期望一个相关的Objective-C类名，例如 'NSColor'"
 # "expected a stack label or a string literal for the section name in '#pragma %0' - ignored"
 HC98188AB663C: "在'#pragma %0'中期望一个栈标签或字符串字面量作为段名称 - 已忽略"
 # "expected a string literal for the section name in '#pragma %0' - ignored"
@@ -21213,25 +21213,25 @@ H294E4D252009: '期望与属性对象规则对应的标识符'
 # "expected an integer argument in '#pragma %0'"
 H8B88B2FBB6B4: "在'#pragma %0'中期望整数参数"
 # "expected an integer or a pointer type of the outer loop counter '%0' for non-rectangular nests"
-H7B769AB4785B: "在非矩形嵌套中，外层循环计数器'%0'的类型应为整数或指针类型"
+H7B769AB4785B: "在非矩形嵌套中，外层循环计数器 '%0' 的类型应为整数或指针类型"
 # "expected at least one %0 clause for '#pragma omp %1'"
-H7235197EF029: "在'#pragma omp %1'中期望至少一个%0子句"
+H7235197EF029: "在'#pragma omp %1'中期望至少一个 %0 子句"
 # "expected at least one %select{'enter' or 'link'|'enter', 'link' or 'indirect'}0 clause"
-H068B5F15FD0D: "期望至少一个%select{'enter'或'link'|'enter', 'link'或'indirect'}0子句"
+H068B5F15FD0D: "期望至少一个%select{'enter' 或 'link'|'enter', 'link' 或 'indirect'}0子句"
 # "expected at least one %select{'to' or 'link'|'to', 'link' or 'indirect'}0 clause"
-HCCB831884601: "期望至少一个%select{'to'或'link'|'to', 'link'或'indirect'}0子句"
+HCCB831884601: "期望至少一个%select{'to' 或 'link'|'to', 'link' 或 'indirect'}0子句"
 # "expected at least one 'to' clause or 'from' clause specified to '#pragma omp target update'"
-HD1F834BB93F7: "在'#pragma omp target update'中需要指定至少一个'to'子句或'from'子句"
+HD1F834BB93F7: "在'#pragma omp target update'中需要指定至少一个 'to' 子句或 'from' 子句"
 # "expected at least one clause on '#pragma omp %0' directive"
 HF2F95AA7B57B: "在'#pragma omp %0'指令中需要至少一个子句"
 # "expected attribute subject set specifier 'apply_to'"
-H235FBF52B9D6: "期望属性对象设置说明符'apply_to'"
+H235FBF52B9D6: "期望属性对象设置说明符 'apply_to'"
 # 'expected binary operation on right hand side of assignment operator'
 H56333C6C1143: '期望赋值运算符右侧存在二元操作'
 # 'expected body of lambda expression'
 HD20C4511EEC4: '期望lambda表达式体'
 # "expected canonical name for private module '%0'"
-H1D8AC0E6D7DF: "期望私有模块'%0'的规范名称"
+H1D8AC0E6D7DF: "期望私有模块 '%0' 的规范名称"
 # 'expected catch'
 H0CF63E912EE1: '期望catch'
 # 'expected class member or base class name'
@@ -21247,7 +21247,7 @@ H5D07B2CBA3F4: '期望带有可选参数的概念名称'
 # "expected configuration macro name after ','"
 HAB95DA27DF2F: '期望逗号后的配置宏名称'
 # "expected constant sized array of 'omp_alloctrait_t' elements, not %0"
-H05FAEDD71E4D: "期望'omp_alloctrait_t'元素的固定大小数组，而非%0"
+H05FAEDD71E4D: "期望 'omp_alloctrait_t' 元素的固定大小数组，而非 %0"
 # "expected declarator on 'omp declare mapper' directive"
 HB22F9750894D: "期望'omp declare mapper'指令中的说明符"
 # 'expected depobj expression'
@@ -21269,7 +21269,7 @@ HC14A3D6A28C9: '期望外部声明'
 # 'expected function body after function declarator'
 HF961A21CDC61: '函数说明符后需跟函数主体'
 # "expected function or lambda declaration for 'routine' construct"
-H6E72FAB495F6: "期望为'routine' 结构声明函数或lambda表达式"
+H6E72FAB495F6: "期望为 'routine' 结构声明函数或lambda表达式"
 # "expected identifier in '#pragma %0' - ignored"
 H05B1FBF9EBC9: '在"#pragma %0"中期望标识符 - 被忽略'
 # 'expected identifier in macro parameter list'
@@ -21287,13 +21287,13 @@ H4FF5B028471D: '期望表示属性名称的标识符'
 # 'expected initializer'
 HC06E564F6549: '期望初始化器'
 # "expected integer between %0 and %1 inclusive in '#pragma %2' - ignored"
-HD3B45551DCCD: '在"#pragma %2"中期望%0到%1之间的整数（含边界） - 被忽略'
+HD3B45551DCCD: '在"#pragma %2"中期望 %0 到 %1 之间的整数（含边界） - 被忽略'
 # "expected integer literal as value for header attribute '%0'"
-H664A6DF4E15C: "期望头属性'%0'的值为整数字面量"
+H664A6DF4E15C: "期望头属性 '%0' 的值为整数字面量"
 # "expected integer or identifier in '#pragma pack' - ignored"
 H76DF3F452A3B: '在"#pragma pack"中期望整数或标识符 - 被忽略'
 # 'expected integral or pointer type as the iterator-type, not %0'
-H630D7FF60D9F: '期望迭代器类型为整型或指针类型，而非%0'
+H630D7FF60D9F: '期望迭代器类型为整型或指针类型，而非 %0'
 # "expected interop type: 'target' and/or 'targetsync'"
 H4B471B15641F: "期望互操作类型：'target' 和/或 'targetsync'"
 # 'expected iterator specification as depend modifier'
@@ -21339,15 +21339,15 @@ H8611A8451129: "具有静态存储的变量期望预定义的分配器之一：'
 # 'expected parameter declarator'
 HE400FE627646: '期望参数声明符'
 # 'expected parentheses around type name in %0 expression'
-H29C3C3BEE053: '在%0表达式中期望类型名称周围的括号'
+H29C3C3BEE053: '在 %0 表达式中期望类型名称周围的括号'
 # "expected parenthesized parameter pack name in 'sizeof...' expression"
 H872448706A49: "在'sizeof...'表达式中期望括号括起的参数包名称"
 # "expected pointer in '%0' clause, type is %1"
-HA28C1D2864FB: "在'%0'子句中期望指针，类型为%1"
+HA28C1D2864FB: "在 '%0' 子句中期望指针，类型为 %1"
 # "expected pointer or reference to pointer in 'use_device_ptr' clause"
-H8CE170DA7DFD: "在'use_device_ptr'子句中期望指针或引用到指针"
+H8CE170DA7DFD: "在 'use_device_ptr' 子句中期望指针或引用到指针"
 # 'expected pointer to struct as %ordinal0 argument to %1, found %2'
-H2E1D0CCC5B02: '期望%1的%ordinal0参数是指向结构的指针，但找到的是%2'
+H2E1D0CCC5B02: '期望 %1 的%ordinal0参数是指向结构的指针，但找到的是 %2'
 # "expected pointer, array, reference to pointer, or reference to array in 'is_device_ptr clause'"
 H529E9DB350DF: "在'is_device_ptr子句中期望指针、数组、指向指针的引用或指向数组的引用"
 # 'expected property name'
@@ -21357,7 +21357,7 @@ H4F1921BA3641: "在'#pragma %0'中期望push、pop或段名字符串字面量 - 
 # 'expected quoted string after equals sign'
 H2D60229D01D0: '在等号后面期望字符串字面量'
 # "expected reference to one of the parameters of function %0%select{| or 'this'}1"
-HD78611AD5D12: "期望函数%0%select{|或 'this'}1的参数之一的引用"
+HD78611AD5D12: "期望函数 %0%select{|或 'this'}1的参数之一的引用"
 # 'expected selector for Objective-C %select{setter|getter}0'
 HFB2F00048645: 'Objective-C %select{设置器|获取器}0期望选择器'
 # 'expected selector for Objective-C method'
@@ -21365,9 +21365,9 @@ HC4CCDD47D676: 'Objective-C方法期望选择器'
 # 'expected statement'
 HFEEF58AA5565: '期望语句'
 # "expected string literal %select{in %1|for diagnostic message in static_assert|for optional message in 'availability' attribute|for %select{language name|source container name|USR}1 in 'external_source_symbol' attribute|as argument of '%1' attribute}0"
-HD61709E5D47F: "期望字符串字面量 %select{在%1中|在static_assert的诊断消息中|在'availability'属性的可选消息中|在'external_source_symbol'属性的%select{语言名称|源容器名称|USR}1中|作为'%1'属性的参数}0"
+HD61709E5D47F: "期望字符串字面量 %select{在 %1 中|在static_assert的诊断消息中|在 'availability' 属性的可选消息中|在 'external_source_symbol' 属性的%select{语言名称|源容器名称|USR}1中|作为 '%1' 属性的参数}0"
 # "expected string literal %select{or parenthesized constant expression |}0in 'asm'"
-H87FD9C867F0C: "在'asm'中期望字符串字面量 %select{或括号内的常量表达式 |}0"
+H87FD9C867F0C: "在 'asm' 中期望字符串字面量 %select{或括号内的常量表达式 |}0"
 # "expected string literal in '#pragma %0' - ignoring"
 H0A31A7BE2E40: "在'#pragma %0'中期望字符串字面量 - 忽略"
 # "expected string literal in 'clause %0' - ignoring"
@@ -21375,7 +21375,7 @@ H25BCA649E0CB: "在'clause %0'子句中期望字符串字面量 - 忽略"
 # 'expected template'
 H15B15916EEBA: '期望模板'
 # "expected template name after 'template' keyword in nested name specifier"
-H49E8E5AAE6BB: "在嵌套名称限定符中的'template'关键字后期望模板名称"
+H49E8E5AAE6BB: "在嵌套名称限定符中的 'template' 关键字后期望模板名称"
 # 'expected template parameter'
 H112129FF4EB6: '期望模板参数'
 # "expected the class name after '~' to name the enclosing class"
@@ -21387,13 +21387,13 @@ H009E83554F48: '期望类型参数名称'
 # 'expected umbrella, header, submodule, or module export'
 H13F866613F7D: '表达式中期望值'
 # 'expected valid context selector in %0'
-HF9402AD88CE1: '在%0中期望有效的上下文选择器'
+HF9402AD88CE1: '在 %0 中期望有效的上下文选择器'
 # 'expected value in expression'
-HC052EF0BAA44: "期望变量名或'this'在lambda捕获列表中"
+HC052EF0BAA44: "期望变量名或 'this' 在lambda捕获列表中"
 # 'expected variable name as a base of the array %select{subscript|section}0'
 HBE410C345F41: '期望变量名%select{|或当前类的数据成员}0'
 # "expected variable name or 'this' in lambda capture list"
-H9A94F049DF94: "在lambda捕获列表中期望变量名称或'this'"
+H9A94F049DF94: "在lambda捕获列表中期望变量名称或 'this'"
 # 'expected variable name%select{| or data member of current class}0'
 H829F4F463842: '期望变量名%select{|或当前类的数据成员}0'
 # 'expected variable name%select{|, data member of current class}0, array element or array section'
@@ -21409,7 +21409,7 @@ H9F489F0C181E: '期望%select{| %1}0 循环迭代变量'
 # "expected%select{| non-const}0 variable of type 'omp_interop_t'"
 H7FA31289BDF2: '期望%select{|非const}0 类型为 omp_interop_t 的变量'
 # 'expected%select{| one of}0 %1 directive name modifier%select{|s}0'
-HF9EF92E2746A: '期望%select{|一个}0 %1指令名称修饰符%select{|s}0'
+HF9EF92E2746A: '期望%select{|一个}0 %1 指令名称修饰符%select{|s}0'
 # "expecting %0 '%1' to be held at start of each loop"
 HFDC07BD9FDE6: "期望在每个循环的开头保持 %0 '%1'"
 # "expecting %0 '%1' to be held at the end of function"
@@ -21449,39 +21449,39 @@ HD5DCEA693BA1: "显式实例化不能为 'inline'"
 # 'explicit instantiation cannot have a storage class'
 H2C3AA857F69D: '显式实例化不能具有存储类'
 # "explicit instantiation declaration (with 'extern') follows explicit instantiation definition (without 'extern')"
-HB1AC2FFED2CF: "显式实例化声明（带有'extern'）跟随显式实例化定义（不带'extern'）"
+HB1AC2FFED2CF: "显式实例化声明（带有 'extern'）跟随显式实例化定义（不带 'extern'）"
 # 'explicit instantiation declaration of %0 with internal linkage'
-HF062EFD01A1B: '具有内部链接性的%0的显式实例化声明'
+HF062EFD01A1B: '具有内部链接性的 %0 的显式实例化声明'
 # 'explicit instantiation declaration requires a name'
 HB6C2B5BBA7F4: '显式实例化声明需要一个名称'
 # "explicit instantiation declaration should not be 'dllexport'"
-H2015D0FC9EDD: "显式实例化声明不应是'dllexport'"
+H2015D0FC9EDD: "显式实例化声明不应是 'dllexport'"
 # 'explicit instantiation definition is here'
 H296BCB0F591A: '显式实例化定义在这里'
 # 'explicit instantiation has dependent template arguments'
 H0CCD42687978: '显式实例化的模板参数依赖于模板参数'
 # 'explicit instantiation of %0 does not refer to a function template, variable template, member function, member class, or static data member'
-H33CB49EB02C6: '%0的显式实例化不指向一个函数模板、变量模板、成员函数、成员类或静态数据成员'
+H33CB49EB02C6: '%0 的显式实例化不指向一个函数模板、变量模板、成员函数、成员类或静态数据成员'
 # 'explicit instantiation of %0 in class scope'
-HC730DBDD7AE4: '%0的显式实例化在类作用域内'
+HC730DBDD7AE4: '%0 的显式实例化在类作用域内'
 # 'explicit instantiation of %0 must occur at global scope'
-H0F240F08C055: '%0的显式实例化必须出现在全局作用域'
+H0F240F08C055: '%0 的显式实例化必须出现在全局作用域'
 # 'explicit instantiation of %0 not in a namespace enclosing %1'
-HE49D377AF72F: '%0的显式实例化不在包含%1的命名空间中'
+HE49D377AF72F: '%0 的显式实例化不在包含 %1 的命名空间中'
 # 'explicit instantiation of %0 that occurs after an explicit specialization has no effect'
-HB36244473793: '在显式特化之后出现的%0的显式实例化无效'
+HB36244473793: '在显式特化之后出现的 %0 的显式实例化无效'
 # 'explicit instantiation of %q0 must occur in namespace %1'
-HB00768729F8E: '%q0的显式实例化必须出现在命名空间%1'
+HB00768729F8E: '%q0的显式实例化必须出现在命名空间 %1'
 # 'explicit instantiation of %q0 must specify a template argument list'
 HE88FD9250BA0: '%q0的显式实例化必须指定模板参数列表'
 # 'explicit instantiation of non-templated type %0'
-H31C2727CC2AA: '%0的显式实例化是一个非模板类型'
+H31C2727CC2AA: '%0 的显式实例化是一个非模板类型'
 # 'explicit instantiation of typedef %0'
-H2C42F0D827C6: '%0类型的显式实例化是一个typedef'
+H2C42F0D827C6: '%0 类型的显式实例化是一个typedef'
 # 'explicit instantiation of undefined %select{member class|member function|static data member}0 %1 of class template %2'
-HCF3C5A632D34: '类模板%2中未定义的%select{成员类|成员函数|静态数据成员}0 %1的显式实例化'
+HCF3C5A632D34: '类模板 %2 中未定义的%select{成员类|成员函数|静态数据成员}0 %1 的显式实例化'
 # 'explicit instantiation of undefined function template %0'
-H5300C0092131: '未定义的函数模板%0的显式实例化'
+H5300C0092131: '未定义的函数模板 %0 的显式实例化'
 # 'explicit instantiation of undefined variable template %q0'
 H38D285C06249: '未定义的变量模板%q0的显式实例化'
 # 'explicit instantiation refers here'
@@ -21491,21 +21491,21 @@ H500C2DC642A9: '显式实例化指向非实例化的成员函数%q0'
 # 'explicit instantiation refers to static data member %q0 that is not an instantiation'
 H07ED3DC3915D: '显式实例化引用了非实例化的静态数据成员%q0'
 # "explicit object parameter cannot have 'void' type"
-H5DECA4F1B2FA: "显式对象参数不能具有'void'类型"
+H5DECA4F1B2FA: "显式对象参数不能具有 'void' 类型"
 # 'explicit object parameters are incompatible with C++ standards before C++2b'
 H32F147DF3434: '显式对象参数与C++2b之前的C++标准不兼容'
 # 'explicit ownership qualifier on cast result has no effect'
 H3D013C01B086: '显式拥有权限定符对转换结果没有影响'
 # 'explicit qualification required to use member %0 from dependent base class'
-H469187ADD22A: '使用来自依赖基类的成员%0需要显式限定符'
+H469187ADD22A: '使用来自依赖基类的成员 %0 需要显式限定符'
 # 'explicit specialization cannot have a storage class'
 HADDD65B5ED76: '显式特例化不能有存储类'
 # 'explicit specialization of %0 after instantiation'
-HDBBF37665EBE: '在实例化之后对%0的显式特例化'
+HDBBF37665EBE: '在实例化之后对 %0 的显式特例化'
 # 'explicit specialization of %0 in function scope'
-H4AB8E368275F: '在函数作用域内对%0的显式特例化'
+H4AB8E368275F: '在函数作用域内对 %0 的显式特例化'
 # "explicit template instantiation cannot have a definition; if this definition is meant to be an explicit specialization, add '<>' after the 'template' keyword"
-H88A1F449C08B: "显式模板实例化不能有定义；如果此定义本意是显式特例化，请在'template'关键字后添加'<>'"
+H88A1F449C08B: "显式模板实例化不能有定义；如果此定义本意是显式特例化，请在 'template' 关键字后添加'<>'"
 # 'explicit template parameter list for lambdas is a C++20 extension'
 HF9AE6F1B9252: 'lambda表达式中的显式模板参数列表是C++20扩展'
 # 'explicit template parameter list for lambdas is incompatible with C++ standards before C++20'
@@ -21515,15 +21515,15 @@ H07C70F747BCD: 'explicit(bool)是C++20扩展'
 # 'explicit(bool) is incompatible with C++ standards before C++20'
 H2A0E673F4AE0: 'explicit(bool)与C++20之前的C++标准不兼容'
 # 'explicitly assigning value of variable of type %0 to itself%select{|; did you mean to assign to member %2?}1'
-HB1C6DD04C662: '显式地将类型%0变量的值赋给自己%select{|; 是否应将成员%2赋值？}1'
+HB1C6DD04C662: '显式地将类型 %0 变量的值赋给自己%select{|; 是否应将成员 %2 赋值？}1'
 # "explicitly capture 'this'"
-HCF140BF35536: "显式捕获'this'"
+HCF140BF35536: "显式捕获 'this'"
 # 'explicitly cast the argument to size_t to silence this warning'
 HBB0D273571B1: '将参数显式转换为size_t以消除此警告'
 # 'explicitly cast the pointer to silence this warning'
 H8E24FB4D1062: '将指针显式转换以消除此警告'
 # "explicitly declare getter %objcinstance0 with '%1' to return an 'unowned' object"
-H4E2F7B8127D2: "使用'%1'显式声明返回'unowned'对象的getter %objcinstance0"
+H4E2F7B8127D2: "使用 '%1' 显式声明返回 'unowned' 对象的getter %objcinstance0"
 # 'explicitly defaulted %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator is implicitly deleted'
 H811330B8F313: '显式默认的%select{<ERROR>|相等|三向|相等|关系}0比较运算符被隐式删除'
 # 'explicitly defaulted %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}0 is implicitly deleted'
@@ -21533,11 +21533,11 @@ HF8EF8D3E0A6F: '显式默认的函数在此处被隐式删除'
 # 'explicitly defaulting this %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}0 with a type different from the implicit type is incompatible with C++ standards before C++20'
 H5E5EF3FDD4E3: '使用与隐式类型不同的类型显式默认%select{默认构造函数|拷贝构造函数|移动构造函数|拷贝赋值运算符|移动赋值运算符|析构函数}0与C++20之前的C++标准不兼容'
 # 'explicitly moving variable of type %0 to itself%select{|; did you mean to move to member %2?}1'
-H35CC5A2B002D: '显式将类型%0的变量移动到自身%select{|; 是否应移动到成员%2？}1'
+H35CC5A2B002D: '显式将类型 %0 的变量移动到自身%select{|; 是否应移动到成员 %2？}1'
 # 'explicitly specialized declaration is here'
 H0E01C428C014: '显式特化声明在此处'
 # 'explicitly-defaulted %select{copy|move}0 assignment operator must return %1'
-H36FB5B74F68A: '显式默认的%select{拷贝|移动}0赋值运算符必须返回%1'
+H36FB5B74F68A: '显式默认的%select{拷贝|移动}0赋值运算符必须返回 %1'
 # 'exponent has no digits'
 H17C521E1F810: '指数没有数字'
 # 'export block begins here'
@@ -21559,59 +21559,59 @@ H6166D4F14CA1: '导出模板不受支持'
 # 'expose the ANDI glue bug on PPC'
 HC579FD8E0F1D: '在PPC上暴露ANDI胶水漏洞'
 # 'expression cannot be followed by a postfix %0 operator; add parentheses'
-HBEECC801546A: '表达式不能后跟后缀%0操作符；请添加括号'
+HBEECC801546A: '表达式不能后跟后缀 %0 操作符；请添加括号'
 # 'expression does not compute the number of elements in this array; element type is %0, not %1'
-H23C233069DBB: '表达式未计算该数组的元素数量；元素类型为%0而非%1'
+H23C233069DBB: '表达式未计算该数组的元素数量；元素类型为 %0 而非 %1'
 # "expression evaluates to '%0 %1 %2'"
 H64BCD859D7BF: "表达式计算为'%0 %1 %2'"
 # 'expression has incomplete class type %0'
-H58E1F9927C3B: '表达式具有不完整的类类型%0'
+H58E1F9927C3B: '表达式具有不完整的类类型 %0'
 # 'expression is not a string literal'
 H3935D8B321FF: '表达式不是字符串字面量'
 # 'expression is not an %select{integer|integral}0 constant expression'
 H03AFF9CF4CF8: '表达式不是%select{整数|整型}0常量表达式'
 # 'expression is not an %select{integer|integral}0 constant expression; folding it to a constant is a GNU extension'
-H5CBB867EA1E8: '表达式不是一个%select{integer|integral}0常量表达式；将其折叠为常量是GNU扩展'
+H5CBB867EA1E8: '表达式不是一个 %select{integer|integral}0 常量表达式；将其折叠为常量是GNU扩展'
 # 'expression is not assignable'
 H5F8670A31719: '表达式不可赋值'
 # 'expression must have integral or unscoped enumeration type, not %0'
-H17B3769F086B: '表达式必须具有整型或未命名的枚举类型，而不是%0'
+H17B3769F086B: '表达式必须具有整型或未命名的枚举类型，而不是 %0'
 # 'expression not permitted as operand of fold expression'
 H291A77DD522F: '不允许在折叠表达式中使用该表达式作为操作数'
 # 'expression requires explicit conversion from %0 to %1'
-HB376E0297A16: '表达式需要显式地将%0转换为%1'
+HB376E0297A16: '表达式需要显式地将 %0 转换为 %1'
 # 'expression result unused'
 HC432FEDE1001: '表达式结果未被使用'
 # 'expression result unused; assign into a variable to force a volatile load'
 HB7AF8EB968E8: '表达式结果未被使用；将其赋给一个变量以强制加载volatile变量'
 # "expression result unused; should this cast be to 'void'?"
-HBBF825FCCB8B: "表达式结果未被使用；是否应将此强制转换为'void'类型？"
+HBBF825FCCB8B: "表达式结果未被使用；是否应将此强制转换为 'void' 类型？"
 # 'expression which evaluates to zero treated as a null pointer constant of type %0'
-H0240527F1E90: '求值为零的表达式被当作类型%0的空指针常量处理'
+H0240527F1E90: '求值为零的表达式被当作类型 %0 的空指针常量处理'
 # 'expression with side effects has no effect in an unevaluated context'
 H186C82044D81: '具有副作用的表达式在未求值的上下文中没有效果'
 # "expression with side effects will be evaluated despite being used as an operand to 'typeid'"
-H9C60337CD3B8: "用于'typeid'操作数的具有副作用的表达式仍会被求值"
+H9C60337CD3B8: "用于 'typeid' 操作数的具有副作用的表达式仍会被求值"
 # 'extension used'
 HD363255C0A95: '使用了扩展功能'
 # 'extern "C" language linkage specification begins here'
 H7A156727F19D: 'extern "C"语言链接规范从此处开始'
 # 'extern declaration of %0 follows non-extern declaration'
-HD31A31C8A91F: '%0的extern声明在非extern声明之后'
+HD31A31C8A91F: '%0 的extern声明在非extern声明之后'
 # 'extern templates are a C++11 extension'
 H1884BE10DDD8: 'extern模板是C++11的扩展'
 # 'extern templates are incompatible with C++98'
 H1796556A5B60: 'extern模板与C++98不兼容'
 # 'external function %0 declared with incompatible types in different translation units (%1 vs. %2)'
-HE651F889FA02: '外部函数%0在不同翻译单元中声明的类型不兼容（%1与%2）'
+HE651F889FA02: '外部函数 %0 在不同翻译单元中声明的类型不兼容（%1 与 %2）'
 # 'external variable %0 declared with incompatible types in different translation units (%1 vs. %2)'
-H15B2E1B8C6FC: '外部变量%0在不同翻译单元中声明的类型不兼容（%1与%2）'
+H15B2E1B8C6FC: '外部变量 %0 在不同翻译单元中声明的类型不兼容（%1 与 %2）'
 # 'external variable %0 defined in multiple translation units'
-H1F8D107DE885: '外部变量%0在多个翻译单元中定义'
+H1F8D107DE885: '外部变量 %0 在多个翻译单元中定义'
 # "extra '&' taking address of overloaded function"
 H9A83B3B4D92C: "额外的'&'操作符用于取重载函数的地址"
 # "extra ';' %select{outside of a function|inside a %1|inside instance variable list|after member function definition}0"
-HE280E1BDB8CF: "多余的 ';' %select{函数外|在%1内|在实例变量列表内|成员函数定义后}0"
+HE280E1BDB8CF: "多余的 ';' %select{函数外|在 %1 内|在实例变量列表内|成员函数定义后}0"
 # "extra ';' after member function definition"
 H3CA5397D9B51: "在成员函数定义后多余的 ';'"
 # "extra ';' outside of a function is a C++11 extension"
@@ -21733,31 +21733,31 @@ H1D2827B95FDF: '字段对 %select{copy|default-initialize}0 操作是非平凡�
 # 'field may not be qualified with an address space'
 H8FECB3E29FF3: '字段不能用地址空间进行限定'
 # 'field of illegal %select{type|pointer type}0 %1 declared here'
-H7B96A2670B39: '非法的%select{类型|指针类型}0 %1在此处声明'
+H7B96A2670B39: '非法的%select{类型|指针类型}0 %1 在此处声明'
 # 'field of type %0 has %select{private|protected}2 %select{default |copy |move |*ERROR* |*ERROR* |*ERROR* |}1constructor'
-H3E9701CFFDEE: '类型%0的字段具有%select{私有|保护}2 %select{默认|拷贝|移动|*ERROR*|*ERROR*|*ERROR*|}1构造函数'
+H3E9701CFFDEE: '类型 %0 的字段具有%select{私有|保护}2 %select{默认|拷贝|移动|*ERROR*|*ERROR*|*ERROR*|}1构造函数'
 # 'field of type %1 has %select{private|protected}2 destructor'
-H40B677C32C44: '类型%1的字段具有%select{私有|保护}2 析构函数'
+H40B677C32C44: '类型 %1 的字段具有%select{私有|保护}2 析构函数'
 # "fields must have a constant size: 'variable length array in structure' extension will never be supported"
 H4D0FA4262CAB: '字段必须具有固定大小：结构体中的"可变长度数组"扩展将永远不会被支持'
 # "file '%0' could not be located in expected %1"
-H3AFCF68EDB4D: "在期望的%1中无法找到文件'%0'"
+H3AFCF68EDB4D: "在期望的 %1 中无法找到文件 '%0'"
 # "file '%0' from the precompiled header has been overridden"
-H0CD8B8C2C117: '来自预编译头的文件"%0"已被覆盖'
+H0CD8B8C2C117: '来自预编译头的文件 "%0" 已被覆盖'
 # "file '%0' has been modified since the %select{precompiled header|module file|AST file}1 '%2' was built: %select{size|mtime|content}3 changed%select{| (was %5, now %6)}4"
-H031EEE30BF07: '自%select{预编译头|模块文件|AST文件}1 "%2"构建以来，文件"%0"已被修改：%select{大小|修改时间|内容}3发生更改%select{|（原为%5，现为%6）}4'
+H031EEE30BF07: '自%select{预编译头|模块文件|AST文件}1 "%2" 构建以来，文件 "%0" 已被修改：%select{大小|修改时间|内容}3发生更改%select{|（原为 %5，现为 %6）}4'
 # "file '%0' is not a module file"
-H5DD90DFEF976: '文件"%0"不是模块文件'
+H5DD90DFEF976: '文件 "%0" 不是模块文件'
 # "file '%0' is too large for Clang to process"
-H9AA7CD92D17E: '文件"%0"过大，Clang无法处理'
+H9AA7CD92D17E: '文件 "%0" 过大，Clang无法处理'
 # "file '%0' modified since it was first processed"
-H1DA05AEA2D52: '文件"%0"自首次处理后已被修改'
+H1DA05AEA2D52: '文件 "%0" 自首次处理后已被修改'
 # "file '%0' specified by '--extract-api-ignores=' not found"
-HC79263152CF4: '通过"--extract-api-ignores="指定的文件"%0"未找到'
+HC79263152CF4: '通过"--extract-api-ignores="指定的文件 "%0" 未找到'
 # "file '%0' specified by '-fmodules-embed-file=' not found"
-HE609B0415A4D: '通过"-fmodules-embed-file="指定的文件"%0"未找到'
+HE609B0415A4D: '通过"-fmodules-embed-file="指定的文件 "%0" 未找到'
 # "file '%1' is not a valid precompiled %select{PCH|module|AST}0 file: %2"
-H208E3D0A2BB0: '文件"%1"不是有效的预编译%select{PCH|模块|AST}0文件：%2'
+H208E3D0A2BB0: '文件 "%1" 不是有效的预编译 %select{PCH|模块|AST}0 文件：%2'
 # 'file containing an ordered list of functions to use for function reordering'
 HAA6E189FC7DA: '包含用于函数重排的有序函数列表的文件'
 # 'file entered %0 time%s0 using %1B (%human1B) of space%plural{0:|: plus %2B (%human2B) for macro expansions}2'
@@ -21777,19 +21777,19 @@ H03B4E7AB601D: '包含需要优化函数列表的文件（非正则表达式）'
 # 'file with list of functions to skip'
 HCF75D26C4EAE: '包含需要跳过函数列表的文件'
 # 'filter expression has non-integral type %0'
-H8F952076C959: '过滤表达式具有非整数类型%0'
+H8F952076C959: '过滤表达式具有非整数类型 %0'
 # 'final overrider of %q0 in %1'
-H0C345A3BEA34: '%1中的%q0最终重写者'
+H0C345A3BEA34: '%1 中的%q0最终重写者'
 # 'find_all_symbols options'
 H390ECCC2C1D8: '查找所有符号选项'
 # "finished building module '%0'"
-H243A4EC2890E: '已完成模块"%0"的构建'
+H243A4EC2890E: '已完成模块 "%0" 的构建'
 # 'first argument in call to %0 is a pointer to non-trivially copyable type %1'
-HD27C5E590173: '对%0的调用中的第一个参数是指向非平凡可拷贝类型%1的指针'
+HD27C5E590173: '对 %0 的调用中的第一个参数是指向非平凡可拷贝类型 %1 的指针'
 # 'first argument to %0 must be a pipe type'
-H3249D08A7B4F: '对%0的调用中的第一个参数必须是管道类型'
+H3249D08A7B4F: '对 %0 的调用中的第一个参数必须是管道类型'
 # "first argument to 'swift_async' must be either 'none', 'swift_private', or 'not_swift_private'"
-HF444E5B58050: "对'swift_async'的调用中的第一个参数必须是'none'、'swift_private'或'not_swift_private'"
+HF444E5B58050: "对 'swift_async' 的调用中的第一个参数必须是 'none'、'swift_private' 或 'not_swift_private'"
 # "first argument to 'va_arg' is of type %0 and not 'va_list'"
 H18598D04D35B: "'va_arg' 的第一个参数类型为 %0，而不是 'va_list'"
 # 'first argument to __builtin_annotation must be an integer'
@@ -21831,25 +21831,25 @@ HADE10FBB32E9: '空的 %select{结构|接口|联合|类|枚举}1 中的灵活数
 # 'flexible array member %0 in otherwise empty %select{struct|interface|union|class|enum}1 is a Microsoft extension'
 H9C2765356C50: '空的 %select{结构|接口|联合|类|枚举}1 中的灵活数组成员 %0 是 Microsoft 扩展'
 # 'flexible array member %0 not allowed in %select{struct|interface|union|class|enum}1 which has a virtual base class'
-HEF0666641494: '柔性数组成员%0不允许在具有虚基类的%select{struct|interface|union|class|enum}1中'
+HEF0666641494: '柔性数组成员 %0 不允许在具有虚基类的 %select{struct|interface|union|class|enum}1 中'
 # 'flexible array member %0 of type %1 with non-trivial destruction'
-H07E92B7CB701: '类型为%1且具有非平凡析构的柔性数组成员%0'
+H07E92B7CB701: '类型为 %1 且具有非平凡析构的柔性数组成员 %0'
 # 'flexible array member %0 with type %1 is not at the end of %select{struct|interface|union|class|enum}2'
-HC60DC08C387B: '类型为%1的柔性数组成员%0不在%select{struct|interface|union|class|enum}2的末尾'
+HC60DC08C387B: '类型为 %1 的柔性数组成员 %0 不在 %select{struct|interface|union|class|enum}2 的末尾'
 # 'flexible array members are a C99 feature'
 H04521DEE401E: '柔性数组成员是C99特性'
 # 'flexible array requires brace-enclosed initializer'
 H8CC54601E715: '柔性数组需要花括号包围的初始化器'
 # "float ABI '%0' is not supported by current library"
-H4A77B1741C96: "浮点ABI '%0'不受当前库支持"
+H4A77B1741C96: "浮点ABI '%0' 不受当前库支持"
 # 'floating point arithmetic produces %select{an infinity|a NaN}0'
 HE17E4C75C5CF: '浮点运算产生%select{无穷大|NaN}0'
 # 'floating point classification requires argument of floating point type (passed in %0)'
-HD0C7777CBCB2: '浮点分类需要浮点类型的参数（传递了%0）'
+HD0C7777CBCB2: '浮点分类需要浮点类型的参数（传递了 %0）'
 # 'floating point literal in preprocessor expression'
 HB66AC9BD4411: '预处理表达式中的浮点字面量'
 # 'floating-point comparison is always %select{true|false}0; constant cannot be represented exactly in type %1'
-HCE8BE2CDB468: '浮点比较始终为%select{true|false}0；常量无法在类型%1中精确表示'
+HCE8BE2CDB468: '浮点比较始终为 %select{true|false}0；常量无法在类型 %1 中精确表示'
 # 'fold functions with identical code'
 H57C9420813A5: '合并具有相同代码的函数'
 # 'fold jcc+mov into cmov'
@@ -21865,7 +21865,7 @@ HCCF9CE851541: '范围for声明必须声明一个变量'
 # 'for training'
 H23FBBEB90B89: '用于训练'
 # 'for type %0'
-HE30274CCC76F: '对于类型%0'
+HE30274CCC76F: '对于类型 %0'
 # 'force openmp unified shared memory mode'
 H98550220A417: '强制使用OpenMP统一共享内存模式'
 # 'force patching of original entry points to ensure execution follows only the new/optimized code.'
@@ -21879,15 +21879,15 @@ H8F7AF4F2F3B0: '缺少对应的force_cuda_host_device begin，使用了force_cud
 # 'format argument is %select{a value|an indirect field width|an indirect precision|an auxiliary value}0, but it should be %select{a value|an indirect field width|an indirect precision|an auxiliary value}1'
 H26324CE63C64: '格式参数是%select{一个值|一个间接字段宽度|一个间接精度|一个辅助值}0，但它应该是%select{一个值|一个间接字段宽度|一个间接精度|一个辅助值}1'
 # 'format argument modifies specifier at position %0, but it should modify specifier at position %1'
-HE2EBF92B2A88: '格式参数修改了位置%0的说明符，但它应该修改位置%1的说明符'
+HE2EBF92B2A88: '格式参数修改了位置 %0 的说明符，但它应该修改位置 %1 的说明符'
 # 'format argument not a string type'
 H84E99A867F54: '格式参数不是字符串类型'
 # 'format attribute cannot specify the implicit this argument as the format string'
 H6DFBB5CF7F53: '格式属性不能将隐式this参数指定为格式字符串'
 # "format specifier '%0' is incompatible with '%1'"
-H4D29848904BC: "格式说明符'%0'与'%1'不兼容"
+H4D29848904BC: "格式说明符 '%0' 与 '%1' 不兼容"
 # 'format specifies type %0 but the argument has %select{type|underlying type}2 %1'
-H2B1918042742: '格式指定类型%0，但参数具有%select{类型|底层类型}2 %1'
+H2B1918042742: '格式指定类型 %0，但参数具有%select{类型|底层类型}2 %1'
 # "format string contains '\\0' within the string body"
 H262604652293: "格式字符串在字符串正文中包含'\\0'"
 # 'format string is defined here'
@@ -21907,13 +21907,13 @@ H5D46A69914C2: '格式字符串不应是宽字符串'
 # 'format to dump profile output in aggregation mode, default is fdata'
 H4B4189014528: '以聚合模式导出分析数据的格式，默认为fdata'
 # 'forward declaration of %0'
-H9E3BA9144F24: '%0的前向声明'
+H9E3BA9144F24: '%0 的前向声明'
 # 'forward declaration of %0 cannot have a nested name specifier'
-HED9D019594EF: '%0的前向声明不能带有嵌套名称限定符'
+HED9D019594EF: '%0 的前向声明不能带有嵌套名称限定符'
 # 'forward declaration of class here'
 H169D8B5BC4E6: '类的前向声明在此处'
 # 'forward declaration of non-parameterized class %0 cannot have type parameters'
-H5EA8F1567F5D: '非参数化类%0的前向声明不能带有类型参数'
+H5EA8F1567F5D: '非参数化类 %0 的前向声明不能带有类型参数'
 # 'forward declaration of template entity is here'
 H61734FDBAB98: '模板实体的前向声明在此处'
 # "forward references to 'enum' types are a Microsoft extension"
@@ -21921,11 +21921,11 @@ H747D15D3C5A0: '枚举类型的前向引用是Microsoft扩展'
 # "found '<::' after a %select{template name|addrspace_cast|const_cast|dynamic_cast|reinterpret_cast|static_cast}0 which forms the digraph '<:' (aka '[') and a ':', did you mean '< ::'?"
 HFDE68D3C1582: "在%select{模板名称|addrspace_cast|const_cast|dynamic_cast|reinterpret_cast|static_cast}0之后发现了'<::'，这形成了双字符符号'<:'（即'['）和一个':'，是否应为'<::'？"
 # "found near match '%0'"
-HE96C9DD0F351: "找到近似匹配项'%0'"
+HE96C9DD0F351: "找到近似匹配项 '%0'"
 # 'fp convert instructions on integers with more than <N> bits are expanded.'
-HBF7A8F526E5F: '对超过<N>位的整数进行浮点转换指令展开'
+HBF7A8F526E5F: '对超过 <N> 位的整数进行浮点转换指令展开'
 # "friend cannot be declared in an explicit instantiation; if this declaration is meant to be a friend declaration, remove the 'template' keyword"
-H2CA4FF8AC2DD: "friend声明不能出现在显式实例化中；如果此声明本意是friend声明，请移除'template'关键字"
+H2CA4FF8AC2DD: "friend声明不能出现在显式实例化中；如果此声明本意是friend声明，请移除 'template' 关键字"
 # 'friend declaration cannot be a concept'
 HB24446765643: 'friend声明不能是一个概念'
 # 'friend declaration cannot have a pure-specifier'
@@ -21935,7 +21935,7 @@ H7F18F2309FFC: '友元声明展开包 %0，该包在其自身的模板参数列�
 # 'friend declaration naming a member of the declaring class is incompatible with C++98'
 H785F5E24B496: '命名声明类成员的友元声明与C++98不兼容'
 # 'friend declaration of %0 does not match any declaration in %1'
-H31DFE021DF93: '%0的友元声明与%1中的任何声明不匹配'
+H31DFE021DF93: '%0 的友元声明与 %1 中的任何声明不匹配'
 # 'friend declaration specifying a default argument must be a definition'
 H55D4B490E76D: '指定默认参数的友元声明必须是一个定义'
 # 'friend declaration specifying a default argument must be the only declaration'
@@ -21945,13 +21945,13 @@ HC3DC9462CF4B: '依赖于包含模板参数的约束的友元声明必须是一�
 # 'friend declared here'
 H4C2593C39E2F: '此处声明的友元'
 # 'friend function %0 retaining previous language linkage is an extension'
-H45895F884047: '保留先前语言链接的友元函数%0是扩展'
+H45895F884047: '保留先前语言链接的友元函数 %0 是扩展'
 # 'friend function %1 is a %select{private|protected}0 member of %3'
-H559C2702128F: '友元函数%1是%3的%select{私有|受保护}0成员'
+H559C2702128F: '友元函数 %1 是 %3 的%select{私有|受保护}0成员'
 # 'friend function cannot be defined in a local class'
 H01D22F1D90F1: '不能在局部类中定义友元函数'
 # 'friend function definition cannot be qualified with %0'
-H87D42EF13E75: '友元函数定义不能用%0限定'
+H87D42EF13E75: '友元函数定义不能用 %0 限定'
 # 'friend function specialization cannot be defined'
 HE48A55696A0C: '不能定义友元函数特化'
 # 'friend type templates must use an elaborated type'
@@ -21961,47 +21961,47 @@ HABE505726BE2: '友元只能是类或函数'
 # 'friends cannot be members of the declaring class'
 H0C1CF26733ED: '友元不能是声明类的成员'
 # "from 'diagnose_if' attribute on %0:"
-HB7602983E09F: '来自%0上的"diagnose_if"属性：'
+HB7602983E09F: '来自 %0 上的"diagnose_if"属性：'
 # 'func1,func2,func3,...'
 H6E12F3399F53: 'func1,func2,func3,...'
 # "function %0 declared 'noreturn' should not return"
-H05EC2FA28594: '声明为noreturn的函数%0不应返回'
+H05EC2FA28594: '声明为noreturn的函数 %0 不应返回'
 # 'function %0 is unsafe'
-H16AE74CB24AD: '函数%0不安全'
+H16AE74CB24AD: '函数 %0 不安全'
 # 'function %0 with deduced return type cannot be used before it is defined'
-H55B75567CEBA: '具有推导返回类型的函数%0在定义前不能使用'
+H55B75567CEBA: '具有推导返回类型的函数 %0 在定义前不能使用'
 # 'function %0 with unknown type must be given a function type'
-H5580EE2709E6: '类型未知的函数%0必须指定函数类型'
+H5580EE2709E6: '类型未知的函数 %0 必须指定函数类型'
 # 'function by that name is mangled as "%0"'
-HD8E36422062F: '该名称的函数被编码为"%0"'
+HD8E36422062F: '该名称的函数被编码为 "%0"'
 # 'function call counts'
 HC411DF133023: '函数调用次数'
 # 'function cannot return %select{array|function}0 type %1'
-H00D7FE6EC486: '函数不能返回%select{数组|函数}0类型%1'
+H00D7FE6EC486: '函数不能返回%select{数组|函数}0类型 %1'
 # 'function cannot return qualified void type %0'
-H6C0F9155F7F7: '函数不能返回修饰的void类型%0'
+H6C0F9155F7F7: '函数不能返回修饰的void类型 %0'
 # 'function declaration cannot become a multiversioned function after first usage'
 HC4FCD39E4392: '函数声明在首次使用后不能成为多版本函数'
 # 'function declaration cannot have variably modified type'
 HC763DB755E39: '函数声明不能具有可变修改后的类型'
 # "function declaration is expected after 'declare %select{simd|variant}0' directive"
-HCE4F7AEAC2D0: '在声明%select{simd|variant}0指令后应有函数声明'
+HCE4F7AEAC2D0: '在声明 %select{simd|variant}0 指令后应有函数声明'
 # "function declaration is missing %select{'target'|'cpu_specific' or 'cpu_dispatch'|'target_version'}0 attribute in a multiversioned function"
 H3FE487F1B347: "在多版本函数中，函数声明缺少%select{'target'|'cpu_specific' 或 'cpu_dispatch'|'target_version'}0属性"
 # 'function declared %0 was previously declared %1, which has different SME function attributes'
-HF900531E932D: '函数声明%0之前被声明为%1，其具有不同的SME函数属性'
+HF900531E932D: '函数声明 %0 之前被声明为 %1，其具有不同的SME函数属性'
 # "function declared '%0' here was previously declared %select{'%2'|without calling convention}1"
-H2073EFB350A2: "在此处声明的函数'%0'之前被声明为%select{'%2'|无调用约定}1"
+H2073EFB350A2: "在此处声明的函数 '%0' 之前被声明为%select{'%2'|无调用约定}1"
 # "function declared in block scope cannot have 'static' storage class"
-H60B5EC75E0B8: "块作用域内的函数声明不能具有'static'存储类"
+H60B5EC75E0B8: "块作用域内的函数声明不能具有 'static' 存储类"
 # 'function declared non-throwing here'
 H03F3D9700027: '函数在此处声明为不抛出异常'
 # 'function declared with %0 attribute was previously declared without the %0 attribute'
-H5B84619C2423: '带有%0属性的函数声明之前被声明为没有该%0属性'
+H5B84619C2423: '带有 %0 属性的函数声明之前被声明为没有该 %0 属性'
 # 'function declared with regparm(%0) attribute was previously declared %plural{0:without the regparm|:with the regparm(%1)}1 attribute'
 HF6A7160FBDE6: '声明带有regparm(%0)属性的函数之前被声明为%plural{0:无regparm|:带有regparm(%1)}1属性'
 # "function definition declared 'typedef'"
-H4E2B82F177E3: "此处的函数定义声明了'typedef'"
+H4E2B82F177E3: "此处的函数定义声明了 'typedef'"
 # 'function definition does not declare parameters'
 HD54A2FF99A28: '函数定义未声明参数'
 # 'function definition inside an Objective-C container is deprecated'
@@ -22011,9 +22011,9 @@ HE3336279F815: '此处不允许函数定义'
 # 'function definition with pure-specifier is a Microsoft extension'
 HDD1E7812B50D: '带有pure-specifier的函数定义是Microsoft扩展'
 # 'function does not return %0'
-H7977746969A8: '函数未返回%0'
+H7977746969A8: '函数未返回 %0'
 # "function executed in streaming-SVE mode requires 'sme'"
-H6F533435BD63: "在流式SVE模式下执行的函数需要'sme'"
+H6F533435BD63: "在流式SVE模式下执行的函数需要 'sme'"
 # 'function id'
 H68D2D6A5A6D7: '函数ID'
 # "function is a coroutine due to use of '%0' here"
@@ -22033,21 +22033,21 @@ H0E47E3134914: '函数名不允许出现在"link"子句中'
 # 'function names'
 HDC0A95620EA5: '函数名称'
 # 'function parameter %0 with unknown value cannot be used in a constant expression'
-H01EB1CAEE1FB: '具有未知值的函数参数%0不能用于常量表达式'
+H01EB1CAEE1FB: '具有未知值的函数参数 %0 不能用于常量表达式'
 # 'function previously declared with an %select{explicit|implicit}0 exception specification redeclared with an %select{implicit|explicit}0 exception specification'
 H74E61DFB1137: '函数先前使用%select{显式|隐式}0异常规范声明，但现使用%select{隐式|显式}0异常规范重新声明'
 # 'function returns a type %0 marked with [[clang::coro_return_type]] but is neither a coroutine nor a coroutine wrapper; non-coroutines should be marked with [[clang::coro_wrapper]] to allow returning coroutine return type'
-H6390B743719E: '函数返回带有[[clang::coro_return_type]]标记的类型%0，但它既不是协程也不是协程包装器；非协程应使用[[clang::coro_wrapper]]标记以允许返回协程返回类型'
+H6390B743719E: '函数返回带有[[clang::coro_return_type]]标记的类型 %0，但它既不是协程也不是协程包装器；非协程应使用[[clang::coro_wrapper]]标记以允许返回协程返回类型'
 # 'function scope depth exceeded maximum of %0'
-H7DB5DD972DEA: '函数作用域深度超过最大值%0'
+H7DB5DD972DEA: '函数作用域深度超过最大值 %0'
 # "function static variables are not permitted in functions to which an OpenACC 'routine' directive applies"
 HE3AED765A103: '应用OpenACC "routine"指令的函数中不允许使用静态变量'
 # 'function template %q0 matches specialization %1'
-HA3A32C570475: '函数模板%q0与特化模板%1匹配'
+HA3A32C570475: '函数模板%q0与特化模板 %1 匹配'
 # 'function template partial specialization is not allowed'
 HA3F0ADD5EDBB: '不允许函数模板的部分特化'
 # 'function template specialization %0 ambiguously refers to more than one function template; explicitly specify%select{| additional}1 template arguments to identify a particular function template'
-H64BC13156614: '函数模板特化%0模棱两可地指向多个函数模板；请显式指定%select{|附加}1模板参数以指定特定的函数模板'
+H64BC13156614: '函数模板特化 %0 模棱两可地指向多个函数模板；请显式指定%select{|附加}1模板参数以指定特定的函数模板'
 # "function template with 'sycl_kernel' attribute must have a 'void' return type"
 HE8E9EA85C4E9: '带有"sycl_kernel"属性的函数模板必须具有"void"返回类型'
 # "function template with 'sycl_kernel' attribute must have a single parameter"
@@ -22059,7 +22059,7 @@ HACF74D9C1B64: '函数constexpr %select{函数|构造函数}0中的try块与C++2
 # 'function type may not be qualified with an address space'
 H193B814022E3: '函数类型不能用地址空间进行限定'
 # 'function type with %0 attribute must have C linkage'
-H39A9B5046A90: '带有%0属性的函数类型必须具有C语言链接性'
+H39A9B5046A90: '带有 %0 属性的函数类型必须具有C语言链接性'
 # "function using ZA state requires 'sme'"
 H355762BCE254: "使用 ZA 状态的函数需要 'sme'"
 # "function using ZT0 state requires 'sme2'"
@@ -22099,7 +22099,7 @@ H0E649CF6B515: '生成包含输入文件模式的C++源文件'
 # 'generate a list of function sections in a format suitable for inclusion in a linker script'
 H26853D1AF334: '生成一个函数段列表，格式适合包含在链接器脚本中'
 # 'generate code for binaries <128MB on AArch64'
-H5478C82F0746: '生成适用于AArch64架构下小于128MB二进制文件的代码'
+H5478C82F0746: '生成适用于AArch64架构下小于 128MB二进制文件的代码'
 # 'generate loops for copy-in/copy-out of objects with descriptors'
 HEE6A80E60F2B: '为带有描述符的对象生成复制输入/输出的循环'
 # 'generate new tags with runtime library calls'
@@ -22119,7 +22119,7 @@ H0E2372801126: '通用 lambdas 与 C++11 不兼容'
 # 'getter name mismatch between property redeclaration (%1) and its original declaration (%0)'
 HCB66D133764C: '属性重声明（%1）和其原始声明（%0）的getter名称不匹配'
 # 'given <sectname>,<filename>[@<sym>=<offset>,...]  add the content of <filename> to <sectname>'
-HB3C96722F67D: '给定<sectname>,<filename>[@<sym>=<offset>,...] 将<filename>的内容添加到<sectname>段'
+HB3C96722F67D: '给定 <sectname>,<filename>[@<sym>=<offset>,...] 将 <filename> 的内容添加到 <sectname> 段'
 # "glob '%0' did not match any header file"
 H7F85F549D444: "glob '%0' 未匹配到任何头文件"
 # 'global sampler requires a const or constant address space qualifier'
@@ -22157,7 +22157,7 @@ HDD6000DF6583: '十六进制浮点字面量与C++17之前的C++标准不兼容'
 # 'hidden overloaded virtual function %q0 declared here%select{|: different classes%diff{ ($ vs $)|}2,3|: different number of parameters (%2 vs %3)|: type mismatch at %ordinal2 parameter%diff{ ($ vs $)|}3,4|: different return type%diff{ ($ vs $)|}2,3|: different qualifiers (%2 vs %3)|: different exception specifications}1'
 HAF71C2F007E8: '被隐藏的重载虚函数 %q0 声明于此处%select{|: 不同的类%diff{ ($ vs $)|}2,3|: 参数数量不同（%2 vs %3）|: 第%ordinal2参数类型不匹配%diff{ ($ vs $)|}3,4|: 返回类型不同%diff{ ($ vs $)|}2,3|: 限定符不同（%2 vs %3）|: 异常规格不同}1'
 # "hidden visibility cannot be applied to 'dllexport' declaration"
-HF663B246106D: "隐藏可见性不能应用于'dllexport'声明"
+HF663B246106D: "隐藏可见性不能应用于 'dllexport' 声明"
 # 'higher order bits are zeroes after implicit conversion'
 H69351DA797D5: '隐式转换后高位为零'
 # 'hoist common instructions (default = false)'
@@ -22237,55 +22237,55 @@ H14E6B917A2E6: "忽略 '%0' 选项，因为它当前不支持处理器 '%1'"
 # "ignoring '%0' option as it is not currently supported for target '%1'"
 H4AA39F54EF26: "忽略 '%0' 选项，因为它当前不支持目标 '%1'"
 # "ignoring '%0' option for offload arch '%1' as it is not currently supported there. Use it with an offload arch containing '%2' instead"
-H788152E08844: "忽略为offload架构'%1'指定的'%0'选项，因为当前不支持该选项。请改用包含'%2'的offload架构"
+H788152E08844: "忽略为offload架构 '%1' 指定的 '%0' 选项，因为当前不支持该选项。请改用包含 '%2' 的offload架构"
 # "ignoring '%select{static|inline}0' keyword on explicit template instantiation"
 H8A80FA7727CA: "忽略显式模板实例化中的'%select{static|inline}0'关键字"
 # "ignoring '-f%select{no-|}0raw-string-literals', which is only valid for C and C++ standards before C++11"
 H135D75731B01: "忽略'-f%select{no-|}0raw-string-literals'选项，该选项仅适用于C和C++11之前的版本"
 # "ignoring '-mabs=2008' option because the '%0' architecture does not support it"
-H5F88EE5F0A3D: "忽略'-mabs=2008'选项，因为'%0'架构不支持该选项"
+H5F88EE5F0A3D: "忽略'-mabs=2008'选项，因为 '%0' 架构不支持该选项"
 # "ignoring '-mabs=legacy' option because the '%0' architecture does not support it"
-HE0FE9F3B46CA: "忽略'-mabs=legacy'选项，因为'%0'架构不支持该选项"
+HE0FE9F3B46CA: "忽略'-mabs=legacy'选项，因为 '%0' 架构不支持该选项"
 # "ignoring '-mcompact-branches=' option because the '%0' architecture does not support it"
-H60C9F0D89DB6: "忽略'-mcompact-branches='选项，因为'%0'架构不支持该选项"
+H60C9F0D89DB6: "忽略'-mcompact-branches='选项，因为 '%0' 架构不支持该选项"
 # "ignoring '-mgpopt' option as it cannot be used with %select{|the implicit usage of }0-mabicalls"
 H2A6F793FDFBC: "忽略'-mgpopt'选项，因为其不能与%select{|the implicit usage of }0-mabicalls同时使用"
 # "ignoring '-mlong-calls' option as it is not currently supported with %select{|the implicit usage of }0-mabicalls"
 HD076A9DC69A3: "忽略'-mlong-calls'选项，因为当前不支持与%select{|the implicit usage of }0-mabicalls同时使用"
 # "ignoring '-mnan=2008' option because the '%0' architecture does not support it"
-H29C27F0049E3: "忽略'-mnan=2008'选项，因为'%0'架构不支持该选项"
+H29C27F0049E3: "忽略'-mnan=2008'选项，因为 '%0' 架构不支持该选项"
 # "ignoring '-mnan=legacy' option because the '%0' architecture does not support it"
-HADAF322768AC: "忽略'-mnan=legacy'选项，因为'%0'架构不支持该选项"
+HADAF322768AC: "忽略'-mnan=legacy'选项，因为 '%0' 架构不支持该选项"
 # 'ignoring -fapple-kext which is valid for C++ and Objective-C++ only'
 H88A745D4B73F: '忽略仅适用于C++和Objective-C++的-fapple-kext选项'
 # 'ignoring -fdiscard-value-names for LLVM Bitcode'
 HC86237F887FA: '忽略LLVM比特码中的-fdiscard-value-names选项'
 # "ignoring -fverify-debuginfo-preserve-export=%0 because -fverify-debuginfo-preserve wasn't enabled"
-H36FCA7FF86DB: '忽略-fverify-debuginfo-preserve-export=%0选项，因为未启用-fverify-debuginfo-preserve'
+H36FCA7FF86DB: '忽略-fverify-debuginfo-preserve-export=%0 选项，因为未启用-fverify-debuginfo-preserve'
 # 'ignoring __declspec(allocator) because the function return type %0 is not a pointer or reference type'
-H6AAEF2701683: '忽略__declspec(allocator)，因为函数返回类型%0不是指针或引用类型'
+H6AAEF2701683: '忽略__declspec(allocator)，因为函数返回类型 %0 不是指针或引用类型'
 # "ignoring availability attribute %select{on '+load' method|with constructor attribute|with destructor attribute}0"
 H24871179ED63: "忽略%select{在'+load'方法上的|带有构造函数属性的|带有析构函数属性的}0可用性属性"
 # "ignoring extension '%0' because the '%1' architecture does not support it"
-HD131D7C5772F: "忽略扩展'%0'，因为'%1'架构不支持该扩展"
+HD131D7C5772F: "忽略扩展 '%0'，因为 '%1' 架构不支持该扩展"
 # "ignoring invalid -ftabstop value '%0', using default value %1"
-H55F6E19B595A: "忽略无效的-ftabstop值'%0'，使用默认值%1"
+H55F6E19B595A: "忽略无效的-ftabstop值 '%0'，使用默认值 %1"
 # "ignoring invalid /arch: argument '%0'; for %select{64|32}1-bit expected one of %2"
-HF5AE60D7E4BF: "忽略无效的/arch:参数'%0'；在%select{64|32}1位模式下应指定%2中的一个"
+HF5AE60D7E4BF: "忽略无效的/arch:参数 '%0'；在 %select{64|32}1 位模式下应指定 %2 中的一个"
 # 'ignoring redefinition of Objective-C qualifier macro'
 HE01ADCD1C19E: '忽略Objective-C限定符宏的重复定义'
 # 'ignoring return value of function declared with %0 attribute'
-H0B36C4D66510: '忽略使用%0属性声明的函数的返回值'
+H0B36C4D66510: '忽略使用 %0 属性声明的函数的返回值'
 # 'ignoring return value of function declared with %0 attribute%select{|: %2}1'
-H9DECD2C6A7A4: '忽略声明带有%0属性的函数的返回值%select{|: %2}1'
+H9DECD2C6A7A4: '忽略声明带有 %0 属性的函数的返回值%select{|: %2}1'
 # 'ignoring temporary created by a constructor declared with %0 attribute%select{|: %2}1'
-H0FFFAF84F31C: '忽略由声明带有%0属性的构造函数创建的临时对象%select{|: %2}1'
+H0FFFAF84F31C: '忽略由声明带有 %0 属性的构造函数创建的临时对象%select{|: %2}1'
 # "ignoring the 'branch-protection' attribute because the '%0' architecture does not support it"
-HF5FC687425B2: "由于'%0'架构不支持该属性，忽略'branch-protection'属性"
+HF5FC687425B2: "由于 '%0' 架构不支持该属性，忽略'branch-protection'属性"
 # 'illegal OpenMP user-defined mapper identifier'
 H4FE25A4B348F: '非法的OpenMP用户定义映射器标识符'
 # 'illegal call to %0, expected %1 argument type'
-H4DEE4185FC7F: '对%0的非法调用，期望%1参数类型'
+H4DEE4185FC7F: '对 %0 的非法调用，期望 %1 参数类型'
 # 'illegal call to enqueue_kernel, incorrect argument types'
 H96AA6DCB3DCC: '对enqueue_kernel的非法调用，参数类型不正确'
 # 'illegal call to enqueue_kernel, parameter needs to be specified as integer type'
@@ -22295,13 +22295,13 @@ H44B6CA76305B: '字符字面量中的非法字符编码'
 # 'illegal character encoding in string literal'
 H2EE26865FBAD: '字符串字面量中的非法字符编码'
 # 'illegal device builtin %select{surface|texture}0 reference class template %1 declared here'
-H7BB2FD0ACCED: '非法的设备内建%select{surface|texture}0引用类模板%1在此处声明'
+H7BB2FD0ACCED: '非法的设备内建 %select{surface|texture}0 引用类模板 %1 在此处声明'
 # 'illegal device builtin %select{surface|texture}0 reference type %1 declared here'
-H1DEC140E0334: '非法的设备内建%select{surface|texture}0引用类型%1在此处声明'
+H1DEC140E0334: '非法的设备内建 %select{surface|texture}0 引用类型 %1 在此处声明'
 # 'illegal initializer (only variables can be initialized)'
 H371A1BFF13F4: '非法的初始化器（仅变量可以被初始化）'
 # 'illegal initializer type %0'
-H000E8C02D9A4: '非法的初始化器类型%0'
+H000E8C02D9A4: '非法的初始化器类型 %0'
 # 'illegal interface qualifier'
 H247C18DEFCA4: '非法的接口限定符'
 # 'illegal operation on Objective-C container subscripting'
@@ -22309,19 +22309,19 @@ H1CDC7C944B48: 'Objective-C容器下标操作的非法操作'
 # 'illegal qualifiers on @catch parameter'
 H2C6EDFE337AA: '@catch参数上的非法限定符'
 # "illegal redeclaration of 'readwrite' property in class extension %0 (perhaps you intended this to be a 'readwrite' redeclaration of a 'readonly' public property?)"
-H77F956612F13: "在类扩展%0中非法重新声明'readwrite'属性（也许您本意是重新声明一个公开的'readonly'属性为'readwrite'？）"
+H77F956612F13: "在类扩展 %0 中非法重新声明 'readwrite' 属性（也许您本意是重新声明一个公开的 'readonly' 属性为 'readwrite'？）"
 # "illegal redeclaration of property in class extension %0 (attribute must be 'readwrite', while its primary must be 'readonly')"
-HA09E774D29B3: "在类扩展%0中非法重新声明属性（属性必须为'readwrite'，而其主属性必须为'readonly'）"
+HA09E774D29B3: "在类扩展 %0 中非法重新声明属性（属性必须为 'readwrite'，而其主属性必须为 'readonly'）"
 # 'illegal scalar extension cast on argument %0 to %select{|in}1out paramemter'
-HF91E5CAEA96B: '参数%0到%select{|in}1out参数的非法标量扩展转换'
+HF91E5CAEA96B: '参数 %0 到%select{|in}1out参数的非法标量扩展转换'
 # 'illegal storage class on file-scoped variable'
 H601564466459: '文件作用域变量上的非法存储类'
 # 'illegal storage class on function'
 H930E494BEBBE: '函数上使用了非法的存储类'
 # 'illegal type %0 used in a boxed expression'
-H5782BEFABE5B: '在打包表达式中使用了非法类型%0'
+H5782BEFABE5B: '在打包表达式中使用了非法类型 %0'
 # 'illegal vector component name %0'
-H6F3BE393AEDE: '非法的向量组件名称%0'
+H6F3BE393AEDE: '非法的向量组件名称 %0'
 # 'illegal visibility specification'
 H39F781806C46: '非法的可见性说明'
 # 'imaginary constants are a C2y extension'
@@ -22333,7 +22333,7 @@ H8F7EDEA31FE9: '虚数常量与C2y之前的C标准不兼容'
 # 'imaginary types are not supported'
 H8AEF701858F7: '不支持虚数类型'
 # 'immediate function %0 used before it is defined'
-H1A240E8F6E49: '立即函数%0在其定义之前被使用'
+H1A240E8F6E49: '立即函数 %0 在其定义之前被使用'
 # 'implementing deprecated %select{method|class|category}0'
 H9AA979884A67: '实现已弃用的%select{方法|类|分类}0'
 # 'implementing unavailable method'
@@ -22347,15 +22347,15 @@ H7D01BFC1D4A1: '使用默认捕获方式"="隐式捕获"this"已弃用'
 # 'implicit capture of lambda object due to conversion to block pointer here'
 H9CBFA98934C5: '由于此处转换为块指针，隐式捕获了lambda对象'
 # 'implicit cast from type %0 to type %1 drops __unaligned qualifier'
-HBCE299280FC0: '从类型%0到类型%1的隐式转换会丢失__unaligned限定符'
+HBCE299280FC0: '从类型 %0 到类型 %1 的隐式转换会丢失__unaligned限定符'
 # 'implicit conversion between pointer-to-function and pointer-to-object is a Microsoft extension'
 HE1B9297E3DCF: '函数指针与对象指针之间的隐式转换是Microsoft扩展'
 # "implicit conversion between vector types ('%0' and '%1') is deprecated; in the future, the behavior implied by '-fno-lax-vector-conversions' will be the default"
-HD9008DAA3AF0: '向量类型（"%0"和"%1"）之间的隐式转换已弃用；未来，"-fno-lax-vector-conversions"选项指定的行为将成为默认'
+HD9008DAA3AF0: '向量类型（"%0" 和 "%1"）之间的隐式转换已弃用；未来，"-fno-lax-vector-conversions"选项指定的行为将成为默认'
 # 'implicit conversion changes signedness: %0 to %1'
-H2AEC008E19C8: '隐式转换改变了符号性：%0到%1'
+H2AEC008E19C8: '隐式转换改变了符号性：%0 到 %1'
 # 'implicit conversion discards imaginary component: %0 to %1'
-H5E6175D2FC4A: '隐式转换丢弃了虚数部分：%0到%1'
+H5E6175D2FC4A: '隐式转换丢弃了虚数部分：%0 到 %1'
 # 'implicit conversion from %0 cannot fit within the range of values for %1'
 HC3B95ADC5255: '来自 %0 的隐式转换无法适应 %1 的取值范围'
 # 'implicit conversion from %0 to %1 changes non-zero value from %2 to %3'
@@ -22447,23 +22447,23 @@ HECE190C4501D: "导入被遮蔽的模块 '%0'"
 # "imported AST from '%0' had been generated for a different target, current: %1, imported: %2"
 H30A99270FD50: "从 '%0' 导入的 AST 是为不同目标生成的，当前目标: %1，导入目标: %2"
 # "imported by %select{|module '%2' in }1'%0'"
-HBA6CF98B38A4: "通过%select{ |模块'%2'在}1'%0'导入"
+HBA6CF98B38A4: "通过%select{ |模块 '%2' 在}1'%0' 导入"
 # 'importing an implementation partition unit in a module interface is not recommended. Names from %0 may not be reachable'
-H4BCD18B5E018: '在模块接口中导入实现分区单元不被推荐。%0中的名称可能无法访问'
+H4BCD18B5E018: '在模块接口中导入实现分区单元不被推荐。%0 中的名称可能无法访问'
 # "importing module '%0'%select{| into '%3'}2 from '%1'"
-HD074A7D9BA2D: "从'%1'%select{ |到'%3'}2导入模块'%0'"
+HD074A7D9BA2D: "从 '%1'%select{ |到 '%3'}2导入模块 '%0'"
 # 'imports must immediately follow the module declaration'
 H25C0CF982742: '导入必须紧跟模块声明之后'
 # 'impossible constraint in asm: cannot store value into a register'
 HEC9C616BA3F9: 'asm中不可能的约束：无法将值存储到寄存器'
 # 'in %select{implicit|defaulted}0 %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}1 for %2 first required here'
-H7F88B1ED021A: '在%select{隐式|默认}0 %select{默认构造函数|拷贝构造函数|移动构造函数|拷贝赋值运算符|移动赋值运算符|析构函数}1为%2首次需要此处'
+H7F88B1ED021A: '在%select{隐式|默认}0 %select{默认构造函数|拷贝构造函数|移动构造函数|拷贝赋值运算符|移动赋值运算符|析构函数}1为 %2 首次需要此处'
 # "in call to '%0'"
 H5F44B6591F5A: "在转储结构体时，调用带有参数 '(%0)' 的打印函数"
 # "in call to printing function with arguments '(%0)' while dumping struct"
 H5B10BE57CF69: "在转储结构时调用参数为'(%0)'的打印函数"
 # 'in defaulted %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator for %1 first required here'
-H41C2C013E2E2: '在%1的默认%select{<ERROR>|相等|三向|相等|关系}0比较运算符中首次需要此处'
+H41C2C013E2E2: '在 %1 的默认%select{<ERROR>|相等|三向|相等|关系}0比较运算符中首次需要此处'
 # 'in evaluating default argument here'
 HA6EC671D8C49: '在此处评估默认参数'
 # 'in evaluation of exception specification for %q0 needed here'
@@ -22473,23 +22473,23 @@ HAF3474709EF4: '在首次定义中，可能的差异在此处'
 # "in implicit call to 'operator%select{!=|*|++}0' for iterator of type %1"
 HA1274A4A4765: "在类型 %1 的迭代器隐式调用 'operator%select{!=|*|++}0' 运算符时"
 # 'in implicit initialization for inherited constructor of %0'
-HE4CCA87F39AA: '在继承构造函数%0的隐式初始化中'
+HE4CCA87F39AA: '在继承构造函数 %0 的隐式初始化中'
 # 'in implicit initialization of %select{array element %1 with omitted initializer|field %1 with omitted initializer|trailing array elements in runtime-sized array new}0'
-HD4BCA75D333B: '在隐式初始化%select{省略初始值的数组元素%1|省略初始值的域%1|运行时尺寸数组new的末尾数组元素}0时'
+HD4BCA75D333B: '在隐式初始化%select{省略初始值的数组元素 %1|省略初始值的域 %1|运行时尺寸数组new的末尾数组元素}0时'
 # 'in implicit initialization of binding declaration %0'
-H6B3B1A4A0790: '在初始化此处需要的绑定声明%0时'
+H6B3B1A4A0790: '在初始化此处需要的绑定声明 %0 时'
 # 'in initialization of temporary of type %0 created to list-initialize this reference'
-H5C5815C0F326: '在初始化为此引用进行列表初始化(type %0类型)创建的临时对象时'
+H5C5815C0F326: '在初始化为此引用进行列表初始化(type %0 类型)创建的临时对象时'
 # "in instantiation of default argument for '%0' required here"
-H920C89F748D0: '在实例化%0的默认参数时需要此处'
+H920C89F748D0: '在实例化 %0 的默认参数时需要此处'
 # "in instantiation of default function argument expression for '%0' required here"
-H05CBF7F0C1EE: '在实例化%0的默认函数参数表达式时需要此处'
+H05CBF7F0C1EE: '在实例化 %0 的默认函数参数表达式时需要此处'
 # 'in instantiation of default member initializer %q0 requested here'
 HD2F44CDF38B1: '在实例化此处请求的默认成员初始化器%q0时'
 # 'in instantiation of enumeration %q0 requested here'
 H6EB646EE227A: '在实例化此处请求的枚举%q0时'
 # 'in instantiation of exception specification for %0 requested here'
-H3C01A542E6EB: '在实例化此处请求的%0异常说明时'
+H3C01A542E6EB: '在实例化此处请求的 %0 异常说明时'
 # 'in instantiation of function template specialization %q0 requested here'
 HAEB9C4D2EE7B: '在实例化此处请求的函数模板特化%q0时'
 # 'in instantiation of member class %q0 requested here'
@@ -22505,7 +22505,7 @@ H0491530140D7: '在实例化此处请求的静态数据成员%q0时'
 # 'in instantiation of template class %q0 requested here'
 H65B85839EF55: '在实例化此处请求的模板类%q0时'
 # 'in instantiation of template type alias %0 requested here'
-HAECA7764FC0E: '在实例化此处请求的模板类型别名%0时'
+HAECA7764FC0E: '在实例化此处请求的模板类型别名 %0 时'
 # 'in instantiation of variable template specialization %q0 requested here'
 H0FA1B781E861: '在实例化此处请求的变量模板特化%q0时'
 # 'in lowering create ArrayCoorOp instead of CoordinateOp'
@@ -22513,7 +22513,7 @@ H38357B1F88DE: '在降级时创建ArrayCoorOp而非CoordinateOp'
 # 'in non-LBR mode, guess edge counts using iterative technique'
 H7372BDB68057: '在非LBR模式下，使用迭代技术推测边数'
 # "in pattern '%1': %0"
-H2F43FF1537BC: "在模式'%1'中：%0"
+H2F43FF1537BC: "在模式 '%1' 中：%0"
 # 'in relocation mode trap upon entry to any function that uses AVX-512 instructions'
 H082BA4E3D29F: '在重定位模式下，进入任何使用AVX-512指令的函数时触发陷阱'
 # 'in second definition, possible difference is here'
@@ -22521,9 +22521,9 @@ HEC9D50C16660: '在第二个定义中，可能的差异在此处'
 # 'in template expansion here'
 H1E2D3625EAB4: '在模板展开时此处'
 # 'in the default initializer of %0'
-H6D9691DC0D28: '在%0的默认初始化器中'
+H6D9691DC0D28: '在 %0 的默认初始化器中'
 # 'in value-initialization of type %0 here'
-H74E349C94BB1: '在此处%0类型的值初始化中'
+H74E349C94BB1: '在此处 %0 类型的值初始化中'
 # 'in%select{| implicit}0 constructor here'
 H24F20A5C047E: '在%select{| 隐式}0构造函数中'
 # 'in-class initializer for static data member is not a constant expression'
@@ -22531,27 +22531,27 @@ H9B69A27F211E: '类内静态数据成员的初始值设定项不是常量表达�
 # 'in-class initializer for static data member is not a constant expression; folding it to a constant is a GNU extension'
 HA2848C2F37A8: '类内静态数据成员的初始值设定项不是常量表达式；将其折叠为常量是GNU扩展'
 # 'in-class initializer for static data member of type %0 is a GNU extension'
-H46A5C414A183: '类型%0的类内静态数据成员初始值设定项是GNU扩展'
+H46A5C414A183: '类型 %0 的类内静态数据成员初始值设定项是GNU扩展'
 # "in-class initializer for static data member of type %0 requires 'constexpr' specifier"
-H7E9F22B76B86: '类型%0的类内静态数据成员需要添加constexpr限定符'
+H7E9F22B76B86: '类型 %0 的类内静态数据成员需要添加constexpr限定符'
 # 'in_reduction variable must have the same reduction operation as in a task_reduction clause'
 H7647CFB2C410: '规约变量必须与任务规约条款中的规约操作一致'
 # 'include a detailed record of preprocessing actions'
 H4B25771F85AC: '包含预处理操作的详细记录'
 # "include location '%0' is unsafe for cross-compilation"
-H62F3D6400A8A: '交叉编译时，包含位置%0存在安全风险'
+H62F3D6400A8A: '交叉编译时，包含位置 %0 存在安全风险'
 # 'include module search paths'
 HFFA588262B00: '包含模块搜索路径'
 # "include of non-modular header inside framework module '%0': '%1'"
-H82B29FF5B7DD: '在框架模块%0内包含非模块化头文件：%1'
+H82B29FF5B7DD: '在框架模块 %0 内包含非模块化头文件：%1'
 # "include of non-modular header inside module '%0': '%1'"
-H747C5EDF3216: '在模块%0内包含非模块化头文件：%1'
+H747C5EDF3216: '在模块 %0 内包含非模块化头文件：%1'
 # "include path for libstdc++ headers not found; pass '-stdlib=libc++' on the command line to use the libc++ standard library instead"
 H45B1E0C04AB4: '未找到libstdc++头文件的包含路径；请通过命令行传递-stdlib=libc++以改用libc++标准库'
 # 'include search path'
 H43B868761DFC: '包含搜索路径'
 # "include the header <%0> or explicitly provide a declaration for '%1'"
-HBFC18315E2CB: '包含头文件<%0>或显式为%1提供声明'
+HBFC18315E2CB: '包含头文件<%0>或显式为 %1 提供声明'
 # 'incompatible block pointer types %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2'
 HA4D550DCCECE: '不兼容的块指针类型 %select{%diff{将$赋值给$|将不同类型赋值}0,1|%diff{将$传给类型$的参数|传给不同类型参数}0,1|%diff{从结果类型为$的函数返回$|从函数返回不同类型}1,0|%diff{将$转换为类型$|转换类型}0,1|%diff{用类型$的表达式初始化$|用不同类型的表达式初始化}0,1|%diff{将$发送给类型$的参数|发送给不同类型参数}0,1|%diff{将$转换为类型$|转换类型}0,1}2'
 # 'incompatible constant for this __builtin_neon function'
@@ -22561,7 +22561,7 @@ H803DA0209C00: '不兼容的函数指针类型 %select{%diff{将$赋值给$|将�
 # 'incompatible integer to pointer conversion %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &|; remove *|; remove &}3'
 H48B50F4A5A68: '不兼容的整数到指针转换 %select{%diff{将$赋值给$|将不同类型赋值}0,1|%diff{将$传给类型$的参数|传给不同类型参数}0,1|%diff{从结果类型为$的函数返回$|从函数返回不同类型}1,0|%diff{将$转换为类型$|转换类型}0,1|%diff{用类型$的表达式初始化$|用不同类型的表达式初始化}0,1|%diff{将$发送给类型$的参数|发送给不同类型参数}0,1|%diff{将$转换为类型$|转换类型}0,1}2%select{|; 使用*解引用|; 使用&取地址|; 移除*|; 移除&}3'
 # 'incompatible operand types (%0 and %1)'
-HCEE400E94353: '不兼容的操作数类型（%0和%1）'
+HCEE400E94353: '不兼容的操作数类型（%0 和 %1）'
 # 'incompatible operand types%diff{ ($ and $)|}0,1'
 H1FD3FD989888: '不兼容的操作数类型%diff{ ($和$)|}0,1'
 # 'incompatible pointer to integer conversion %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &|; remove *|; remove &}3'
@@ -22569,41 +22569,41 @@ HFD878F5F2922: '不兼容的指针到整数转换 %select{%diff{将$赋值给$|�
 # 'incompatible pointer types %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &|; remove *|; remove &}3'
 HBA7B4F7FCD76: '指针类型不兼容 %select{%diff{将$赋给$|将不同类型赋值}0,1|%diff{将$传给类型为$的参数|传给不同类型的参数}0,1|%diff{从结果类型为$的函数返回$|函数返回类型不匹配}1,0|%diff{将$转换为类型$|类型间转换}0,1|%diff{用类型$的表达式初始化$|用不同类型的表达式初始化}0,1|%diff{将$传给类型为$的参数|传给不同类型的参数}0,1|%diff{将$转换为类型$|类型间转换}0,1}2%select{|; 使用*解引用|; 取地址使用&|; 移除*|; 移除&}3'
 # 'incompatible pointer types passing retainable parameter of type %0to a CF function expecting %1 type'
-H85C3F4475A3D: '将类型%0的可保留参数传给期望类型%1的CF函数时指针类型不兼容'
+H85C3F4475A3D: '将类型 %0 的可保留参数传给期望类型 %1 的CF函数时指针类型不兼容'
 # 'incompatible redeclaration of library function %0'
-H4DCB8A7133E4: '库函数%0的不兼容重声明'
+H4DCB8A7133E4: '库函数 %0 的不兼容重声明'
 # 'incompatible types casting %0 to %1 with a %select{__bridge|__bridge_transfer|__bridge_retained}2 cast'
-HA70D951974C7: '使用%select{__bridge|__bridge_transfer|__bridge_retained}2类型转换将%0转为%1时类型不兼容'
+HA70D951974C7: '使用%select{__bridge|__bridge_transfer|__bridge_retained}2类型转换将 %0 转为 %1 时类型不兼容'
 # 'incompatible vector types %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2'
 H349444057F6C: '向量类型不兼容 %select{%diff{将$赋给$|将不同类型赋值}0,1|%diff{将$传给类型为$的参数|传给不同类型的参数}0,1|%diff{从结果类型为$的函数返回$|函数返回类型不匹配}1,0|%diff{将$转换为类型$|类型间转换}0,1|%diff{用类型$的表达式初始化$|用不同类型的表达式初始化}0,1|%diff{将$传给类型为$的参数|传给不同类型的参数}0,1|%diff{将$转换为类型$|类型间转换}0,1}2'
 # 'incomplete definition of type %0'
-H74F733EC60E9: '类型%0的定义不完整'
+H74F733EC60E9: '类型 %0 的定义不完整'
 # "incomplete delimited universal character name; treating as '\\' '%0' '{' identifier"
 H45A3D640545C: "不完整的限定通用名称; 将视为 '\\' '%0' '{' 标识符"
 # 'incomplete format specifier'
 HC2682570C017: '格式说明符不完整'
 # 'incomplete receiver type %0'
-H6C117CF6E37A: '接收者类型%0不完整'
+H6C117CF6E37A: '接收者类型 %0 不完整'
 # 'incomplete result type %0 in function definition'
-HA8E1F3068B20: '函数定义中结果类型%0不完整'
+HA8E1F3068B20: '函数定义中结果类型 %0 不完整'
 # 'incomplete result type %0 in lambda expression'
-H69E2641DED85: 'lambda表达式中结果类型%0不完整'
+H69E2641DED85: 'lambda表达式中结果类型 %0 不完整'
 # "incomplete type %0 in a '_Generic' association is a C2y extension"
-H7D3852AE4A16: "'_Generic' 关联中的不完整类型%0是C2y扩展"
+H7D3852AE4A16: "'_Generic' 关联中的不完整类型 %0 是C2y扩展"
 # 'incomplete type %0 is not a literal type'
-H8AFDEC1F2348: '不完整类型%0不是字面类型'
+H8AFDEC1F2348: '不完整类型 %0 不是字面类型'
 # 'incomplete type %0 is not assignable'
-HF862B3215822: '不完整类型%0不可赋值'
+HF862B3215822: '不完整类型 %0 不可赋值'
 # 'incomplete type %0 named in nested name specifier'
-HCA7665DF5910: '嵌套命名限定符中指定的不完整类型%0'
+HCA7665DF5910: '嵌套命名限定符中指定的不完整类型 %0'
 # 'incomplete type %0 used in a boxed expression'
-HF426C73BD83F: '在包装表达式中使用不完整类型%0'
+HF426C73BD83F: '在包装表达式中使用不完整类型 %0'
 # 'incomplete type %0 used in type trait expression'
-H4539C0CCBFB9: '在类型特征表达式中使用不完整类型%0'
+H4539C0CCBFB9: '在类型特征表达式中使用不完整类型 %0'
 # 'incomplete type %0 where a complete type is required'
-H95C11FF1D056: '在需要完整类型的位置使用不完整类型%0'
+H95C11FF1D056: '在需要完整类型的位置使用不完整类型 %0'
 # 'incomplete type in call to object of type %0'
-HB57B0356D109: '调用类型%0的对象时使用了不完整类型'
+HB57B0356D109: '调用类型 %0 的对象时使用了不完整类型'
 # 'incomplete universal character name'
 H0184822E59BB: '通用名称不完整'
 # "incomplete universal character name; treating as '\\' followed by identifier"
@@ -22611,21 +22611,21 @@ H5B8C01DBAD90: "不完整的通用字符名；视为'\\'后跟标识符"
 # 'inconsistent number of instance variables specified'
 H7EB07F9DCA1E: '指定的实例变量数量不一致'
 # "incorrect adjust_args type, expected 'need_device_ptr' or 'nothing'"
-H34BB37A9E639: "错误的adjust_args类型，期望'need_device_ptr'或'nothing'"
+H34BB37A9E639: "错误的adjust_args类型，期望 'need_device_ptr' 或 'nothing'"
 # 'incorrect format for -preamble-bytes=N,END'
 HD764A19076F3: '-preamble-bytes=N,END 的格式不正确'
 # "incorrect map type modifier, expected one of: 'always', 'close', 'mapper'%select{|, 'present'|, 'present', 'iterator'}0%select{|, 'ompx_hold'}1%select{|, 'self'}2"
 H6BCE6C4F91C6: "错误的映射类型修饰符，期望其中一个：'always', 'close', 'mapper'%select{|, 'present'|, 'present', 'iterator'}0%select{|, 'ompx_hold'}1%select{|, 'self'}2"
 # "incorrect map type, expected one of 'to', 'from', 'tofrom', 'alloc', 'release', or 'delete'"
-HFC0556B7E292: "错误的映射类型，期望其中一个：'to', 'from', 'tofrom', 'alloc', 'release'或'delete'"
+HFC0556B7E292: "错误的映射类型，期望其中一个：'to', 'from', 'tofrom', 'alloc', 'release' 或 'delete'"
 # 'incorrect number of bits in integer (expected %0 bits, have %1)'
-H39F86512F6F1: '整数中的位数不正确（期望%0位，但实际为%1位）'
+H39F86512F6F1: '整数中的位数不正确（期望 %0 位，但实际为 %1 位）'
 # 'incorrect number of bits in vector operand (expected %select{|a multiple of}0 %1 bits, have %2)'
-HDF4134C84931: '向量操作数位数不正确（期望%select{ |的倍数}0%1位，实际%2位）'
+HDF4134C84931: '向量操作数位数不正确（期望%select{ |的倍数}0%1 位，实际 %2 位）'
 # "incorrect reduction identifier, expected one of '+', '*', '&', '|', '^', '&&', '||', 'min' or 'max' or declare reduction for type %0"
-HD90D2B65D413: "错误的规约标识符，期望其中一个：'+'、'*'、'max'、'min'、'&'、'|'、'^'、'&&'、'||'或为类型%0声明规约"
+HD90D2B65D413: "错误的规约标识符，期望其中一个：'+'、'*'、'max'、'min'、'&'、'|'、'^'、'&&'、'||'或为类型 %0 声明规约"
 # "incorrect reduction identifier, expected one of '+', '-', '*', '&', '|', '^', '&&', '||', 'min' or 'max' or declare reduction for type %0"
-HC80B58A26C84: "错误的规约标识符，期望其中一个：'+'、'-'、'*'、'&'、'|'、'^'、'&&'、'||'、'min'或'max'或为类型%0声明规约"
+HC80B58A26C84: "错误的规约标识符，期望其中一个：'+'、'-'、'*'、'&'、'|'、'^'、'&&'、'||'、'min' 或 'max' 或为类型 %0 声明规约"
 # 'incorrect use of #pragma clang force_cuda_host_device begin|end'
 HB4E983FB1A7D: '错误使用 #pragma clang force_cuda_host_device begin|end'
 # "incorrect use of '#pragma fenv_access (on|off)' - ignored"
@@ -22633,19 +22633,19 @@ HB0DD6B333D8B: '#pragma fenv_access (on|off) 的使用不正确 - 已忽略'
 # "incorrect use of '#pragma ms_struct on|off' - ignored"
 HB1C2DABF7753: '#pragma ms_struct on|off 的使用不正确 - 已忽略'
 # 'increment clause of OpenMP for loop must perform simple addition or subtraction on loop variable %0'
-H1F62FE8343E9: 'OpenMP for循环的增量子句必须对循环变量%0执行简单的加法或减法'
+H1F62FE8343E9: 'OpenMP for循环的增量子句必须对循环变量 %0 执行简单的加法或减法'
 # 'increment expression must cause %0 to %select{decrease|increase}1 on each iteration of OpenMP for loop'
-H6AE9805023F0: '增量表达式必须在每次OpenMP for循环迭代中使%0 %select{减少|增加}1'
+H6AE9805023F0: '增量表达式必须在每次OpenMP for循环迭代中使 %0 %select{减少|增加}1'
 # 'incremented enumerator value %0 is not representable in the largest integer type'
-H33F55260A9EF: '递增的枚举值%0无法用最大的整数类型表示'
+H33F55260A9EF: '递增的枚举值 %0 无法用最大的整数类型表示'
 # 'incrementing expression of type bool is deprecated and incompatible with C++17'
 HB438D9D07956: 'bool类型的递增表达式已弃用，并与C++17不兼容'
 # 'increments 8-bit counter for every edge'
-H286B107846BC: '为每条边递增8位计数器'
+H286B107846BC: '为每条边递增 8 位计数器'
 # "indeterminate value can only initialize an object of type 'unsigned char'%select{, 'char',|}1 or 'std::byte'; %0 is invalid"
-H26C79B7B3090: "不确定的值只能初始化类型为'unsigned char'%select{, 'char',|}1或'std::byte'的对象；%0无效"
+H26C79B7B3090: "不确定的值只能初始化类型为'unsigned char'%select{, 'char',|}1或'std::byte'的对象；%0 无效"
 # 'index %0 must appear exactly once in the permutation clause'
-H907BCB3D7A64: '索引%0必须在排列子句中恰好出现一次'
+H907BCB3D7A64: '索引 %0 必须在排列子句中恰好出现一次'
 # 'index for __builtin_shufflevector must be a constant integer'
 H2AA72873C8D9: '__builtin_shufflevector的索引必须是常量整数'
 # 'index for __builtin_shufflevector must be less than the total number of vector elements'
@@ -22697,13 +22697,13 @@ HE0B5DF2EAC96: 'init方法必须返回与其接收器类型相关的类型'
 # 'init methods must return a type related to the receiver type'
 H77EF2E241D1F: 'init方法必须返回与接收器类型相关的类型'
 # 'init methods must return an object pointer type, not %0'
-HA49BF476668F: 'init方法必须返回对象指针类型，而非%0'
+HA49BF476668F: 'init方法必须返回对象指针类型，而非 %0'
 # "initialization clause of OpenMP for loop is not in canonical form ('var = init' or 'T var = init')"
 H55BD0EE327C7: 'OpenMP for循环的初始化子句不在规范形式（var = init 或 T var = init）'
 # 'initialization is not supported for __shared__ variables'
 H36A01643C5A6: '__shared__变量的初始化不受支持'
 # 'initialization of %0 may run twice when built into a shared library: it has hidden visibility and external linkage'
-H8FC0CAE3AC23: '具有隐藏可见性和外部链接性的%0初始化在构建为共享库时可能执行两次'
+H8FC0CAE3AC23: '具有隐藏可见性和外部链接性的 %0 初始化在构建为共享库时可能执行两次'
 # "initialization of %select{|signed }0char array with UTF-8 string literal is not permitted by %select{'-fchar8_t'|C++20}1"
 H2A8B3176C3CF: "使用%select{'-fchar8_t'|C++20}1时不允许用UTF-8字符串字面量初始化%select{有符号 |}0char数组"
 # 'initialization of an array %diff{of type $ from a compound literal of type $|from a compound literal}0,1 is a GNU extension'
@@ -22711,23 +22711,23 @@ HA729653B7153: '从复合字面量类型$初始化数组%diff{类型$到|来自}
 # 'initialization of flexible array member is not allowed'
 H080F42BFBE3B: '不允许初始化柔性数组成员'
 # 'initialization of incomplete type %0'
-H8382A60542C7: '初始化不完整类型%0'
+H8382A60542C7: '初始化不完整类型 %0'
 # 'initialization of initializer_list object is incompatible with C++98'
 HB868A7DFE86A: 'initializer_list对象的初始化与C++98不兼容'
 # 'initialization of non-aggregate type %0 with a designated initializer list'
-HD9BEB3E28681: '使用指定初始化列表初始化非聚合类型%0'
+HD9BEB3E28681: '使用指定初始化列表初始化非聚合类型 %0'
 # 'initialization of non-aggregate type %0 with an initializer list'
-HD61976EAB0C6: '使用初始化列表初始化非聚合类型%0'
+HD61976EAB0C6: '使用初始化列表初始化非聚合类型 %0'
 # 'initialization of pointer of type %0 to null from a constant boolean expression'
-HF7B6BD10B980: '从常量布尔表达式将类型%0指针初始化为null'
+HF7B6BD10B980: '从常量布尔表达式将类型 %0 指针初始化为null'
 # 'initialization statement is not supported when iterating over Objective-C collection'
 H6990A52E0D21: '在遍历Objective-C集合时不支持初始化语句'
 # 'initialize the variable %0 to silence this warning'
-HFBFEA45EAD29: '初始化变量%0以消除此警告'
+HFBFEA45EAD29: '初始化变量 %0 以消除此警告'
 # 'initialized flexible array member %0 is here'
-H040CBD4967B6: '此处初始化了柔性数组成员%0'
+H040CBD4967B6: '此处初始化了柔性数组成员 %0'
 # 'initialized here %0'
-H6E543F660366: '此处初始化%0'
+H6E543F660366: '此处初始化 %0'
 # 'initialized lambda capture packs are incompatible with C++ standards before C++20'
 H4508A321B7A7: '已初始化的lambda捕获包与C++20之前的标准不兼容'
 # 'initialized lambda captures are a C++14 extension'
@@ -22737,7 +22737,7 @@ H4B4A5D06C778: 'C++14之前的C++标准不支持初始化的lambda捕获'
 # 'initialized lambda pack captures are a C++20 extension'
 H7BA4847E4BDF: '初始化的lambda包捕获是C++20扩展特性'
 # 'initializer %0 does not name a non-static data member or base class; did you mean the %select{base class|member}1 %2?'
-HBFA8CB0E43F8: '初始化器%0未命名非静态数据成员或基类；是否指%select{基类|成员}1%2？'
+HBFA8CB0E43F8: '初始化器 %0 未命名非静态数据成员或基类；是否指%select{基类|成员}1%2？'
 # 'initializer %select{partially |}0overrides prior initialization of this subobject'
 H5DE4CB24B2D2: '初始化器%select{部分|}0覆盖了此子对象的先前初始化'
 # 'initializer element is not a compile-time constant'
@@ -22747,31 +22747,31 @@ H6A5ECCAF1E62: '聚合类型的初始化器不是编译时常量'
 # 'initializer for aggregate with no elements requires explicit braces'
 H2820D73AEF2F: '无元素的聚合类型初始化需要显式的大括号'
 # 'initializer for functional-style cast to %0 contains multiple expressions'
-H98881129A20C: '对%0的函数式类型转换初始化器包含多个表达式'
+H98881129A20C: '对 %0 的函数式类型转换初始化器包含多个表达式'
 # 'initializer for functional-style cast to %0 is empty'
-H4EA4C8E23F55: '对%0的函数式类型转换初始化器为空'
+H4EA4C8E23F55: '对 %0 的函数式类型转换初始化器为空'
 # 'initializer for lambda capture %0 contains multiple expressions'
-H66A3A7273E8A: 'lambda捕获%0的初始化器包含多个表达式'
+H66A3A7273E8A: 'lambda捕获 %0 的初始化器包含多个表达式'
 # 'initializer for sizeless type %0 cannot be empty'
-H8FFA617F38FD: '无大小类型%0的初始化器不能为空'
+H8FFA617F38FD: '无大小类型 %0 的初始化器不能为空'
 # 'initializer for thread-local variable must be a constant expression'
 HD7C0523C87D0: '线程局部变量的初始化器必须是常量表达式'
 # 'initializer for variable %0 with type %1 contains multiple expressions'
-HA7D83169E121: '变量%0（类型%1）的初始化器包含多个表达式'
+HA7D83169E121: '变量 %0（类型 %1）的初始化器包含多个表达式'
 # 'initializer for variable %0 with type %1 is empty'
-HD6A61B62F49C: '变量%0（类型%1）的初始化器为空'
+HD6A61B62F49C: '变量 %0（类型 %1）的初始化器为空'
 # 'initializer for virtual base class %0 of abstract class %1 will never be used'
-H377D13F4BA4B: '抽象类%1的虚基类%0初始化器永远不会被使用'
+H377D13F4BA4B: '抽象类 %1 的虚基类 %0 初始化器永远不会被使用'
 # "initializer list cannot be used on the %select{left|right}0 hand side of operator '%1'"
-H08A1BB46A564: '运算符"%1"的%select{左|右}0边不能使用初始化列表'
+H08A1BB46A564: '运算符 "%1" 的%select{左|右}0边不能使用初始化列表'
 # 'initializer missing for lambda capture %0'
-H362962332DA4: 'lambda捕获%0缺少初始化器'
+H362962332DA4: 'lambda捕获 %0 缺少初始化器'
 # 'initializer of %0 is not a constant expression'
-HF34500BAECA9: '%0的初始化器不是常量表达式'
+HF34500BAECA9: '%0 的初始化器不是常量表达式'
 # 'initializer of %0 is unknown'
-H4815D272C20B: '%0的初始化器未知'
+H4815D272C20B: '%0 的初始化器未知'
 # 'initializer of weak variable %0 is not considered constant because it may be different at runtime'
-HBD6BC73EA44F: '弱符号变量%0的初始化器在运行时可能不同，因此不被视为常量'
+HBD6BC73EA44F: '弱符号变量 %0 的初始化器在运行时可能不同，因此不被视为常量'
 # 'initializer on function does not look like a pure-specifier'
 H79A85F4AF5C7: '函数上的初始化器看起来不像纯说明符'
 # 'initializer order does not match the declaration order'
@@ -22779,29 +22779,29 @@ HBA21FCA776B9: '初始化器顺序与声明顺序不匹配'
 # 'initializer priorities are not supported in HLSL'
 HFAA073E424F4: 'HLSL不支持初始化器优先级'
 # 'initializer would partially override prior initialization of object of type %1 with non-trivial destruction'
-H52C4E394B1C2: '初始化器将部分覆盖类型%1的先前初始化，该类型具有非平凡的析构函数'
+H52C4E394B1C2: '初始化器将部分覆盖类型 %1 的先前初始化，该类型具有非平凡的析构函数'
 # 'initializer-string for char array is too long'
 HF948F6263A8D: '字符数组的初始化字符串太长'
 # 'initializer-string for char array is too long, array size is %0 but initializer has size %1 (including the null terminating character)'
-H17CD335B9F9F: '字符数组的初始化字符串太长，数组大小为%0，但初始化器的大小为%1（包括空终止字符）'
+H17CD335B9F9F: '字符数组的初始化字符串太长，数组大小为 %0，但初始化器的大小为 %1（包括空终止字符）'
 # 'initializing %0 from an empty initializer list is incompatible with C++98'
-H822723DC0E42: '从空初始化列表初始化%0与C++98不兼容'
+H822723DC0E42: '从空初始化列表初始化 %0 与C++98不兼容'
 # "initializing 'char8_t' array with plain string literal"
-H1EA4AB240813: "使用普通字符串字面量初始化'char8_t'数组"
+H1EA4AB240813: "使用普通字符串字面量初始化 'char8_t' 数组"
 # "initializing an array from a '%0' predefined identifier is a Microsoft extension"
-H8573434E16CF: "使用'%0'预定义标识符初始化数组是Microsoft扩展"
+H8573434E16CF: "使用 '%0' 预定义标识符初始化数组是Microsoft扩展"
 # 'initializing char array with wide string literal'
 H698D73717CFB: '使用宽字符串字面量初始化字符数组'
 # 'initializing field %0 with default member initializer'
-HC1BC6A14F9CB: '使用默认成员初始化器初始化字段%0'
+HC1BC6A14F9CB: '使用默认成员初始化器初始化字段 %0'
 # 'initializing multiple members of union'
 HC7C97F10525A: '初始化联合的多个成员'
 # 'initializing parameter %0 with default argument'
-H20102CE039A6: '使用默认参数值初始化参数%0'
+H20102CE039A6: '使用默认参数值初始化参数 %0'
 # 'initializing pointer member %0 to point to a temporary object whose lifetime is shorter than the lifetime of the constructed object'
-H705DCA77F9DC: '指针成员%0被初始化为指向构造对象生命周期较短的临时对象'
+H705DCA77F9DC: '指针成员 %0 被初始化为指向构造对象生命周期较短的临时对象'
 # 'initializing pointer member %0 with the stack address of %select{variable|parameter}2 %1'
-HF09BD5727610: '指针成员%0被初始化为%select{变量|参数}2 %1的栈地址'
+HF09BD5727610: '指针成员 %0 被初始化为%select{变量|参数}2 %1 的栈地址'
 # 'initializing wide char array with incompatible wide string literal'
 HA0905D8F9102: '使用不兼容的宽字符串字面量初始化宽字符数组'
 # 'initializing wide char array with non-wide string literal'
@@ -22811,11 +22811,11 @@ HF0EA4880CACC: '内联所有检查'
 # 'inline all functions'
 HEE76F6E2509B: '内联所有函数'
 # 'inline assembly label %0 declared here'
-H1FAD9492270E: '此处声明了内联汇编标签%0'
+H1FAD9492270E: '此处声明了内联汇编标签 %0'
 # 'inline declaration of %0 follows non-inline definition'
-H9E262DCDBF26: '内联声明%0跟随非内联定义'
+H9E262DCDBF26: '内联声明 %0 跟随非内联定义'
 # 'inline declaration of %0 not allowed in block scope'
-H0812ED282234: '块作用域中不允许内联声明%0'
+H0812ED282234: '块作用域中不允许内联声明 %0'
 # 'inline function %q0 is not defined'
 HC9FA92373F42: '内联函数 %q0 未定义'
 # 'inline function not defined%select{| before the private module fragment}0'
@@ -22877,27 +22877,27 @@ H625478AB58CF: '在旧函数体中插入陷阱（重定位模式）'
 # "install_name does not match: '%0' (provided) vs '%1' (found)"
 H748B1AE34A35: "install_name 不匹配: '%0' (提供) vs '%1' (找到)"
 # 'instance method %0 found instead of class method %1'
-H1FCFE23050D1: '找到实例方法%0 而非类方法%1'
+H1FCFE23050D1: '找到实例方法 %0 而非类方法 %1'
 # "instance method %0 is being used on 'Class' which is not in the root class"
-H214A12BD7783: "实例方法%0 被用在 'Class' 类型上，而该类型不在根类层级中"
+H214A12BD7783: "实例方法 %0 被用在 'Class' 类型上，而该类型不在根类层级中"
 # "instance method %objcinstance0 not found (return type defaults to 'id')"
 HAFE085EFCB1C: "未找到实例方法%objcinstance0（返回类型默认为 'id'）"
 # "instance method %objcinstance0 not found (return type defaults to 'id'); did you mean %objcinstance2?"
 H44E31EFE4C27: "未找到实例方法%objcinstance0（返回类型默认为 'id'）；您是否是指 %objcinstance2？"
 # 'instance variable %0 accessed in class method'
-H3EADF48ACA9A: '在类方法中直接访问实例变量%0'
+H3EADF48ACA9A: '在类方法中直接访问实例变量 %0'
 # 'instance variable %0 declared with incompatible types in different translation units (%1 vs. %2)'
-HBFCDBA937742: '实例变量%0 在不同翻译单元中被声明为不兼容的类型（%1 与 %2）'
+HBFCDBA937742: '实例变量 %0 在不同翻译单元中被声明为不兼容的类型（%1 与 %2）'
 # 'instance variable %0 has conflicting bit-field width'
-H2B77404519CC: '实例变量%0 的位段宽度冲突'
+H2B77404519CC: '实例变量 %0 的位段宽度冲突'
 # 'instance variable %0 has conflicting type%diff{: $ vs $|}1,2'
-H9D5CF719769D: '实例变量%0 的类型冲突%diff{: $ vs $|}1,2'
+H9D5CF719769D: '实例变量 %0 的类型冲突%diff{: $ vs $|}1,2'
 # 'instance variable %0 is being directly accessed'
-H3F2D0ABA6990: '实例变量%0 正在被直接访问'
+H3F2D0ABA6990: '实例变量 %0 正在被直接访问'
 # 'instance variable %0 is private'
-HDB3564656CA2: '实例变量%0 是私有成员'
+HDB3564656CA2: '实例变量 %0 是私有成员'
 # 'instance variable %0 is protected'
-HD16F20CBE669: '实例变量%0 是受保护成员'
+HD16F20CBE669: '实例变量 %0 是受保护成员'
 # 'instance variable is already declared'
 H801D25BC5C9A: '实例变量已在此处声明'
 # 'instance variable is declared here'
@@ -22949,7 +22949,7 @@ HA31AFF85F744: '监控写入指令'
 # 'instrumentation map used to identify function ids. Currently supports elf file instrumentation maps.'
 HABD136211445: '用于标识函数ID的监控映射文件。当前支持ELF文件监控映射。'
 # 'integer constant expression evaluates to value %0 that cannot be represented in a %1-bit %select{signed|unsigned}2 integer type'
-HA689EA8A19CC: '整型常量表达式计算得到无法用%1位%select{有符号|无符号}2整型表示的值 %0'
+HA689EA8A19CC: '整型常量表达式计算得到无法用 %1 位%select{有符号|无符号}2整型表示的值 %0'
 # 'integer constant not in range of enumerated type %0'
 H38F9A13FA923: '整型常量超出枚举类型 %0 的取值范围'
 # 'integer literal is too large to be represented in a signed integer type, interpreting as unsigned'
@@ -23035,9 +23035,9 @@ H74A42ADBF419: "无效的OpenACC指令 %select{%1|'%1 %2'}0"
 # 'invalid PCS type'
 H696D824B4D2C: '无效的PCS类型'
 # "invalid RVV vector size '%0', expected size is '%1' based on LMUL of type and '-mrvv-vector-bits'"
-H96A03531A0AD: "无效的RVV向量大小'%0'，基于类型LMUL和'-mrvv-vector-bits'参数，期望的大小应为'%1'"
+H96A03531A0AD: "无效的RVV向量大小 '%0'，基于类型LMUL和'-mrvv-vector-bits'参数，期望的大小应为 '%1'"
 # "invalid SVE vector size '%0', must match value set by '-msve-vector-bits' ('%1')"
-HF993CA8A3093: "无效的SVE向量大小'%0'，必须与'-msve-vector-bits'设置的值'%1'一致"
+HF993CA8A3093: "无效的SVE向量大小 '%0'，必须与'-msve-vector-bits'设置的值 '%1' 一致"
 # 'invalid UTF-8 in comment'
 H58EB41DE8F48: '注释中的无效UTF-8编码'
 # "invalid Xarch argument: '%0', not all driver options can be forwared via Xarch argument"
@@ -23047,99 +23047,99 @@ H7917BEC4B42C: "无效的Xarch参数：'%0'，需要参数的选项不被支持"
 # 'invalid __hlsl_resource_t type attributes'
 H9A97FF7B54BE: '无效的__hlsl_resource_t类型属性'
 # 'invalid address discrimination mode %0'
-H1D217687F248: '无效的地址区分模式%0'
+H1D217687F248: '无效的地址区分模式 %0'
 # "invalid alignment option in '#pragma %select{align|options align}0' - ignored"
 H410475644E70: "在'#pragma %select{align|options align}0'中指定了无效的对齐选项 - 已忽略"
 # "invalid application of '%0' to %select{an incomplete|sizeless}1 type %2"
-H3984632B643A: "将'%0'应用于%select{不完整|无大小}1类型%2是无效的"
+H3984632B643A: "将 '%0' 应用于%select{不完整|无大小}1类型 %2 是无效的"
 # "invalid application of '%0' to WebAssembly table"
-HA443432F106F: "将'%0'应用于WebAssembly表无效"
+HA443432F106F: "将 '%0' 应用于WebAssembly表无效"
 # "invalid application of '%0' to a function type"
-HFD1A077F0D84: "将'%0'应用于函数类型无效"
+HFD1A077F0D84: "将 '%0' 应用于函数类型无效"
 # "invalid application of '%0' to a void type"
-H3290D1C688B6: "将'%0'应用于void类型无效"
+H3290D1C688B6: "将 '%0' 应用于void类型无效"
 # "invalid application of '%select{sizeof|alignof|typeof|typeof_unqual}0' to bit-field"
 H4D97635BE644: "将'%select{sizeof|alignof|typeof|typeof_unqual}0'应用于位域无效"
 # "invalid application of '__builtin_omp_required_simd_align' to an expression, only type is allowed"
 H0F35C466B34C: '__builtin_omp_required_simd_align只能用于类型，不能应用于表达式'
 # "invalid application of 'alignof' to a field of a class still being defined"
-H584C8A2541E4: "将'alignof'应用于仍在定义中的类的字段无效"
+H584C8A2541E4: "将 'alignof' 应用于仍在定义中的类的字段无效"
 # "invalid application of 'offsetof' to a field of a virtual base"
-H7E5DD90FD952: "将'offsetof'应用于虚基类的字段无效"
+H7E5DD90FD952: "将 'offsetof' 应用于虚基类的字段无效"
 # "invalid arch name '%0'"
-H053EB6DE40C8: "无效的架构名称'%0'"
+H053EB6DE40C8: "无效的架构名称 '%0'"
 # "invalid arch name '%0', %1"
-HAF3A77CFBCF8: "无效的架构名称'%0'，%1"
+HAF3A77CFBCF8: "无效的架构名称 '%0'，%1"
 # 'invalid argument %0 to function: %1, expecting a generic pointer argument'
-H45B49DB90594: '函数%1的参数%0无效：期望一个通用指针参数'
+H45B49DB90594: '函数 %1 的参数 %0 无效：期望一个通用指针参数'
 # "invalid argument '%0' not allowed with '%1'"
-H5F814EC912CC: "与'%1'不能同时使用的无效参数'%0'"
+H5F814EC912CC: "与 '%1' 不能同时使用的无效参数 '%0'"
 # "invalid argument '%0' only allowed with '%1'"
-HCD365CC8E5D4: "仅允许与'%1'一起使用的无效参数'%0'"
+HCD365CC8E5D4: "仅允许与 '%1' 一起使用的无效参数 '%0'"
 # "invalid argument '%0' to -%1"
-H8405E80D8137: "选项-%1的无效参数'%0'"
+H8405E80D8137: "选项-%1 的无效参数 '%0'"
 # "invalid argument '%0' to -malign-branch=; each element must be one of: %1"
-H20657E1CDBBF: "选项-malign-branch=的无效参数'%0'；每个元素必须是以下之一： %1"
+H20657E1CDBBF: "选项-malign-branch=的无效参数 '%0'；每个元素必须是以下之一： %1"
 # "invalid argument '%0' to -mfpu=; must be one of: 64, 32, none, 0 (alias for none)"
-HF131652C4C29: "选项-mfpu=的无效参数'%0'；必须为以下之一：64、32、none、0（等同于none）"
+HF131652C4C29: "选项-mfpu=的无效参数 '%0'；必须为以下之一：64、32、none、0（等同于none）"
 # "invalid argument '%0' to -msimd=; must be one of: none, lsx, lasx"
-H2BA112BC46B6: "选项-msimd=的无效参数'%0'；必须为以下之一：none、lsx、lasx"
+H2BA112BC46B6: "选项-msimd=的无效参数 '%0'；必须为以下之一：none、lsx、lasx"
 # "invalid argument '%0' to atomic attribute; valid options are: 'remote_memory', 'fine_grained_memory', 'ignore_denormal_mode' (optionally prefixed with 'no_')"
-H438B1A442EF4: "原子属性的无效参数'%0'；有效选项包括：'remote_memory', 'fine_grained_memory', 'ignore_denormal_mode'（可选前缀'no_'）"
+H438B1A442EF4: "原子属性的无效参数 '%0'；有效选项包括：'remote_memory', 'fine_grained_memory', 'ignore_denormal_mode'（可选前缀 'no_'）"
 # "invalid argument '-mno-amdgpu-ieee' only allowed with relaxed NaN handling"
 H507F0448DDCC: "无效选项 '-mno-amdgpu-ieee' 仅在启用宽松NaN处理时允许"
 # "invalid argument in '%0', only integer or 'auto' is supported"
-H40210717B247: "在'%0'中参数无效，仅支持整数或'auto'"
+H40210717B247: "在 '%0' 中参数无效，仅支持整数或 'auto'"
 # "invalid argument in '%0', only integers are supported"
-H7CC5EAE0927D: "在'%0'中参数无效，仅支持整数"
+H7CC5EAE0927D: "在 '%0' 中参数无效，仅支持整数"
 # 'invalid argument of type %0; expected an integer type'
-HDC97D348BCF9: '类型%0的无效参数；期望一个整数类型'
+HDC97D348BCF9: '类型 %0 的无效参数；期望一个整数类型'
 # 'invalid argument to convert to character'
 H035CE8B39D0F: '无法转换为字符类型的无效参数'
 # 'invalid argument type %0 to unary expression'
-HB7A2329B026C: '一元表达式参数类型%0无效'
+HB7A2329B026C: '一元表达式参数类型 %0 无效'
 # 'invalid argument type to function %0 (expecting %1 having %2)'
-H740D8FB32D84: '函数%0的参数类型%1无效（应为%2类型）'
+H740D8FB32D84: '函数 %0 的参数类型 %1 无效（应为 %2 类型）'
 # 'invalid argument: symbol must be a device-side function or global variable'
 HB29E0DD1BCB5: '无效参数：符号必须是设备端函数或全局变量'
 # "invalid argument; expected 'disable'"
-H14256C1A2363: "无效参数；期望'disable'"
+H14256C1A2363: "无效参数；期望 'disable'"
 # "invalid argument; expected 'enable'%select{|, 'full'}0%select{|, 'assume_safety'}1 or 'disable'"
-H369903756AB7: "无效参数；期望'enable'%select{|, 'full'}0%select{|, 'assume_safety'}1 或 'disable'"
+H369903756AB7: "无效参数；期望 'enable'%select{|, 'full'}0%select{|, 'assume_safety'}1 或 'disable'"
 # 'invalid authentication key %0'
-H1380B8ED725A: '无效的认证密钥%0'
+H1380B8ED725A: '无效的认证密钥 %0'
 # 'invalid block pointer conversion %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2'
 H1E4447440EDF: '块指针转换无效%select{%diff{将$分配给$|不同类型的赋值}0,1|%diff{将$传递给类型$的参数|传递到不同类型参数}0,1|%diff{从返回类型$的函数返回$|函数返回类型不匹配}0,1|%diff{将$转换为类型$|不同类型的转换}0,1|%diff{用类型$的表达式初始化$|表达式类型与初始化类型不匹配}0,1|%diff{将$发送到类型$的参数|发送到不同类型参数}0,1|%diff{将$强制转换为类型$|不同类型的强制转换}0,1}2'
 # 'invalid block variable declaration - must be %select{const qualified|initialized}0'
 HF892D907A5A7: '无效的块变量声明 - 必须是%select{const限定|已初始化}0'
 # "invalid block variable declaration - using 'extern' storage class is disallowed"
-H2029EAB9FA9A: "无效的块变量声明 - 不允许使用'extern'存储类"
+H2029EAB9FA9A: "无效的块变量声明 - 不允许使用 'extern' 存储类"
 # 'invalid branch into OpenACC Compute/Combined Construct'
 HC49FDF0B5C89: '无效的进入OpenACC Compute/Combined Construct的分支'
 # 'invalid branch out of OpenACC Compute/Combined Construct'
 H921800904C81: '无效的退出OpenACC Compute/Combined Construct的分支'
 # "invalid branch protection option '%0' in '%1'"
-H69A222420F22: "在'%1'中的分支保护选项'%0'无效"
+H69A222420F22: "在 '%1' 中的分支保护选项 '%0' 无效"
 # "invalid character '%0' in raw string delimiter; use PREFIX( )PREFIX to delimit raw string"
-H82170E32D0E4: "原始字符串分隔符中的无效字符'%0'；使用PREFIX( )PREFIX来分隔原始字符串"
+H82170E32D0E4: "原始字符串分隔符中的无效字符 '%0'；使用PREFIX( )PREFIX来分隔原始字符串"
 # "invalid comparison flag %0; use 'layout_compatible' or 'must_be_null'"
-H677EA1A68EB0: "无效的比较标志%0；使用'layout_compatible'或'must_be_null'"
+H677EA1A68EB0: "无效的比较标志 %0；使用 'layout_compatible' 或 'must_be_null'"
 # "invalid component '%0' used; expected 'x', 'y', 'z', or 'w'"
-H32632D0CDE2F: "无效的组件'%0'；应使用'x'、'y'、'z'或'w'"
+H32632D0CDE2F: "无效的组件 '%0'；应使用 'x'、'y'、'z' 或 'w'"
 # 'invalid constructor from class in system header, should not be explicit'
 HEFC602372E3E: '来自系统头文件的类的无效构造函数，不应显式声明'
 # 'invalid conversion between ext-vector type %0 and %1'
-H4E43BF77A891: '不同类型大小的向量类型%0和%1之间的无效转换'
+H4E43BF77A891: '不同类型大小的向量类型 %0 和 %1 之间的无效转换'
 # 'invalid conversion between vector type %0 and integer type %1 of different size'
-HAD5A2EB8C76E: '不同类型大小的向量类型%0和整型类型%1之间的无效转换'
+HAD5A2EB8C76E: '不同类型大小的向量类型 %0 和整型类型 %1 之间的无效转换'
 # 'invalid conversion between vector type %0 and scalar type %1'
-H0E21BE8324C1: '向量类型%0和标量类型%1之间的无效转换'
+H0E21BE8324C1: '向量类型 %0 和标量类型 %1 之间的无效转换'
 # 'invalid conversion between vector type%diff{ $ and $|}0,1 of different size'
 H62FB40425AFD: '不同大小的向量类型%diff{ $和$|}0,1之间的无效转换'
 # "invalid conversion specifier '%0'"
-H36DE3CE25255: "无效的格式说明符'%0'"
+H36DE3CE25255: "无效的格式说明符 '%0'"
 # 'invalid covariant return for virtual function: %1 is a %select{private|protected}2 base class of %0'
-HB307942D226E: '虚函数的协变返回类型无效：%1是%0的%select{私有|保护}2基类'
+HB307942D226E: '虚函数的协变返回类型无效：%1 是 %0 的%select{私有|保护}2基类'
 # 'invalid cpu feature string for builtin'
 H63D2023D3150: '内建函数的无效CPU特性字符串'
 # 'invalid cpu name for builtin'
@@ -23147,27 +23147,27 @@ HD2B5E0F427CF: '内建函数的无效CPU名称'
 # 'invalid custom discrimination'
 HBF55CC3D0D6C: '无效的自定义判别式'
 # 'invalid declaration inside %select{tbuffer|cbuffer}0'
-H75299BE36932: '在%select{tbuffer|cbuffer}0内部的无效声明'
+H75299BE36932: '在 %select{tbuffer|cbuffer}0 内部的无效声明'
 # 'invalid declaration specifier in template non-type parameter'
 HE0A0675789D7: '模板非类型参数中的无效声明说明符'
 # 'invalid diagnostic type for \'diagnose_if\'; use "error" or "warning" instead'
 HD2E5D476D869: '无效的诊断类型用于\'diagnose_if\'; 使用"error"或"warning"代替'
 # "invalid digit '%0' in %select{decimal|octal|binary}1 constant"
-H6F9BD80EC0BE: "无效的数字'%0'在%select{十进制|八进制|二进制}1常量中"
+H6F9BD80EC0BE: "无效的数字 '%0' 在%select{十进制|八进制|二进制}1常量中"
 # "invalid digit '%0' in escape sequence"
-HF729B18CD0D2: "无效的数字'%0'在转义序列中"
+HF729B18CD0D2: "无效的数字 '%0' 在转义序列中"
 # "invalid escape sequence '%0' in an unevaluated string literal"
-HF58F976119B7: "无效的转义序列'%0'在未求值的字符串字面量中"
+HF58F976119B7: "无效的转义序列 '%0' 在未求值的字符串字面量中"
 # "invalid exception model '%select{none|sjlj|seh|dwarf|wasm}0' for target '%1'"
-H00FCEE8853CC: "目标'%1'的无效异常模型'%select{none|sjlj|seh|dwarf|wasm}0'"
+H00FCEE8853CC: "目标 '%1' 的无效异常模型'%select{none|sjlj|seh|dwarf|wasm}0'"
 # 'invalid expected %0: %1'
-HE0DC8B702320: '无效的期望%0：%1'
+HE0DC8B702320: '无效的期望 %0：%1'
 # 'invalid explicit object parameter type %0 in lambda with capture; the type must be the same as, or derived from, the lambda'
-H98E01B807F8E: '具有捕获的lambda的显式对象参数类型%0无效; 类型必须与lambda相同或派生自lambda'
+H98E01B807F8E: '具有捕获的lambda的显式对象参数类型 %0 无效; 类型必须与lambda相同或派生自lambda'
 # 'invalid explicit object parameter type %0 in lambda with capture; the type must derive publicly from the lambda'
-H607716F86E02: '具有捕获的lambda的显式对象参数类型%0无效; 类型必须公开派生自lambda'
+H607716F86E02: '具有捕获的lambda的显式对象参数类型 %0 无效; 类型必须公开派生自lambda'
 # 'invalid extra discrimination selection %0'
-HAC5AAEAB2B1D: '无效的额外判别选择%0'
+HAC5AAEAB2B1D: '无效的额外判别选择 %0'
 # 'invalid feature combination: %0'
 H53E34DDB7754: '无效的特性组合: %0'
 # 'invalid field is here'
@@ -23181,15 +23181,15 @@ H5CC65A10A5E0: '无效的标志行标记指令'
 # "invalid float ABI '%0'"
 H606FAE3A11E2: "无效的浮点ABI '%0'"
 # "invalid iOS deployment version '%0', iOS 10 is the maximum deployment target for 32-bit targets"
-HD422F25540A2: "无效的iOS部署版本'%0', iOS 10是32位目标的最大部署目标"
+HD422F25540A2: "无效的iOS部署版本 '%0', iOS 10是 32 位目标的最大部署目标"
 # 'invalid index %0 for pack %1 of size %2'
-H1627FB393F43: '大小为%2的参数包%1的无效索引%0'
+H1627FB393F43: '大小为 %2 的参数包 %1 的无效索引 %0'
 # "invalid input constraint '%0' in asm"
-H09D927559067: "asm中无效的输入约束'%0'"
+H09D927559067: "asm中无效的输入约束 '%0'"
 # "invalid input for analyzer-config option '%0', that expects %1 value"
-HB14EB9C7A93F: "分析器配置选项'%0'的无效输入，该选项需要%1值"
+HB14EB9C7A93F: "分析器配置选项 '%0' 的无效输入，该选项需要 %1 值"
 # "invalid input for checker option '%0', that expects %1"
-H784B521FDFA9: "检查器选项'%0'的无效输入，该选项需要%1"
+H784B521FDFA9: "检查器选项 '%0' 的无效输入，该选项需要 %1"
 # "invalid input size for constraint '%0'"
 H8F6CDB6F0449: "约束 '%0' 的输入大小无效"
 # "invalid integral value '%1' in '%0'"
@@ -23249,11 +23249,11 @@ H1AE0ECD8B562: "与gcc工具一起使用时无效的输出类型 '%0'"
 # "invalid parameter name: '%0' is a keyword"
 HBA4C66D8A8AA: "无效的参数名称：'%0' 是一个关键字"
 # 'invalid parameter type for defaulted %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator; found %1, expected %2%select{| or %4}3'
-H1333988BA8FC: '默认的%select{<ERROR>|相等|三向|相等|关系}0比较运算符的参数类型无效；找到%1，期望%2%select{|或 %4}3'
+H1333988BA8FC: '默认的%select{<ERROR>|相等|三向|相等|关系}0比较运算符的参数类型无效；找到 %1，期望 %2%select{|或 %4}3'
 # 'invalid parameter type for non-member defaulted %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator; found %1, expected class or reference to a constant class'
-HEB967961C960: '非成员默认的%select{<ERROR>|相等|三向|相等|关系}0比较运算符的参数类型无效；找到%1，期望类或常量类的引用'
+HEB967961C960: '非成员默认的%select{<ERROR>|相等|三向|相等|关系}0比较运算符的参数类型无效；找到 %1，期望类或常量类的引用'
 # 'invalid pipe access modifier (expecting %0)'
-HA4FFF117B821: '无效的管道访问修饰符（期望%0）'
+HA4FFF117B821: '无效的管道访问修饰符（期望 %0）'
 # 'invalid position specified for %select{field width|field precision}0'
 H5DF564C1B18C: '为%select{字段宽度|字段精度}0指定的无效位置'
 # "invalid preprocessing directive%select{|, did you mean '#%1'?}0"
@@ -23265,27 +23265,27 @@ H3723A726B37F: '非ObjC类型上的无效协议限定符'
 # 'invalid prototype, variadic arguments are not allowed in OpenCL'
 H5E1888FFA26E: '无效的原型，在OpenCL中不允许使用可变参数'
 # "invalid range expression of type %0; did you mean to dereference it with '*'?"
-H1FCBEB4D2213: '类型为%0的无效区间表达式；您是否打算用"*"进行解引用？'
+H1FCBEB4D2213: '类型为 %0 的无效区间表达式；您是否打算用"*"进行解引用？'
 # "invalid range expression of type %0; no viable '%select{begin|end}1' function available"
-H76B630AFA57F: '类型为%0的无效区间表达式；没有可用的"%select{begin|end}1"函数'
+H76B630AFA57F: '类型为 %0 的无效区间表达式；没有可用的"%select{begin|end}1"函数'
 # "invalid range following '-' in expected %0"
-H99FD9B7E0352: "在期望的%0中'-'后的范围无效"
+H99FD9B7E0352: "在期望的 %0 中'-'后的范围无效"
 # "invalid reduction operator,  expected '+', '*', 'max', 'min', '&', '|', '^', '&&', or '||'"
 H3407BE2F5E5D: "无效的规约运算符，期望的运算符之一为 '+'、'*'、'max'、'min'、'&'、'|'、'^'、'&&' 或 '||'"
 # 'invalid reference to function %0: constraints not satisfied'
-H9E6FAF3D6010: '对函数%0的无效引用：约束条件未满足'
+H9E6FAF3D6010: '对函数 %0 的无效引用：约束条件未满足'
 # 'invalid reinterpretation: sizes of %0 and %1 must match'
-HC6E0606A101D: '无效的重新解释：%0和%1的大小必须匹配'
+HC6E0606A101D: '无效的重新解释：%0 和 %1 的大小必须匹配'
 # "invalid resource class specifier '%0' for packoffset, expected 'c'"
-H2B96C40BB1F0: "packoffset的无效资源类指定符'%0'，期望为'c'"
+H2B96C40BB1F0: "packoffset的无效资源类指定符 '%0'，期望为 'c'"
 # 'invalid rounding argument'
 HD77BD554C068: '无效的舍入参数'
 # "invalid runtime library name in argument '%0'"
-HCC4F20591ADF: "参数'%0'中无效的运行时库名称"
+HCC4F20591ADF: "参数 '%0' 中无效的运行时库名称"
 # 'invalid size value'
 H41C03C7DB477: '无效的大小值'
 # "invalid space specifier '%0' used; expected 'space' followed by an integer, like space1"
-HB8CFB0AAB2CD: "无效的空格指定符'%0'，期望类似'space1'的'space'后跟整数形式"
+HB8CFB0AAB2CD: "无效的空格指定符 '%0'，期望类似 'space1' 的 'space' 后跟整数形式"
 # 'invalid special register for builtin'
 H26E533E2D360: '内建函数的无效特殊寄存器'
 # 'invalid storage class specifier in function declarator'
@@ -23293,19 +23293,19 @@ HF2FD2E42B318: '函数说明符中的无效存储类说明符'
 # "invalid string literal, ignoring final '\\'"
 H550F921F116D: "无效的字符串文字，忽略末尾的'\\'"
 # "invalid suffix '%0' on %select{integer|floating|fixed-point}1 constant"
-HFE61994BB7A3: "在%select{整型|浮点型|定点型}1常量上的无效后缀'%0'"
+HFE61994BB7A3: "在%select{整型|浮点型|定点型}1常量上的无效后缀 '%0'"
 # 'invalid suffix on literal; C++11 requires a space between literal and identifier'
 H3AC3DC712C63: '文字的无效后缀；C++11要求文字和标识符之间有一个空格'
 # "invalid tag %0 on '%1' %select{directive|clause}2"
-HB6EF4B837656: "在'%1'的%select{指令|子句}2上的无效标签%0"
+HB6EF4B837656: "在 '%1' 的%select{指令|子句}2上的无效标签 %0"
 # "invalid target ID '%0'; format is a processor name followed by an optional colon-delimited list of features followed by an enable/disable sign (e.g., 'gfx908:sramecc+:xnack-')"
 HF2F065F66FFD: "无效的目标ID'%0'；格式为处理器名称后可接用冒号分隔的功能列表，再接启用/禁用符号（例如'gfx908:sramecc+:xnack-'）"
 # 'invalid target type %0 for dynamic_cast; target type must be a reference or pointer type to a defined class'
-HFE4D2B7D8E06: 'dynamic_cast的无效目标类型%0；目标类型必须是对已定义类的引用或指针类型'
+HFE4D2B7D8E06: 'dynamic_cast的无效目标类型 %0；目标类型必须是对已定义类的引用或指针类型'
 # "invalid thread model '%0' in '%1' for this target"
-HE75965380195: "在此目标的'%1'中的无效线程模型'%0'"
+HE75965380195: "在此目标的 '%1' 中的无效线程模型 '%0'"
 # "invalid thread pointer reading mode '%0'"
-H602D0823E0FB: "无效的线程指针读取模式'%0'"
+H602D0823E0FB: "无效的线程指针读取模式 '%0'"
 # 'invalid token at start of a preprocessor expression'
 HAAFAB4DB043C: '预处理器表达式开头的无效标记'
 # 'invalid token in macro parameter list'
@@ -23313,61 +23313,61 @@ HA6A8BDC08D89: '宏参数列表中的无效标记'
 # 'invalid transaction abort code'
 H75E4D8742736: '无效的事务中止代码'
 # 'invalid type %0 as argument of iboutletcollection attribute'
-HE41F37E3851B: 'iboutletcollection属性的参数类型%0无效'
+HE41F37E3851B: 'iboutletcollection属性的参数类型 %0 无效'
 # 'invalid type %0 in asm %select{input|output}1'
-H2A71CC82E6A7: '汇编%select{输入|输出}1中的类型%0无效'
+H2A71CC82E6A7: '汇编%select{输入|输出}1中的类型 %0 无效'
 # "invalid type %0 in asm input for constraint '%1'"
-H1E6A37C4D619: "汇编输入的约束'%1'中类型%0无效"
+H1E6A37C4D619: "汇编输入的约束 '%1' 中类型 %0 无效"
 # 'invalid type %0 is a %select{member|base}1 of %2'
-HB6D9D0DC110A: '无效类型%0是%select{成员|基类}1的%2'
+HB6D9D0DC110A: '无效类型 %0 是%select{成员|基类}1的 %2'
 # 'invalid type %0 to %1 operator'
-H4C8C1A65C2A4: '无效类型%0到%1运算符'
+H4C8C1A65C2A4: '无效类型 %0 到 %1 运算符'
 # 'invalid universal character'
 H73C6676CA247: '无效通用字符'
 # "invalid unwind library name in argument '%0'"
-HD675186A50F6: "参数'%0'中的解扰库名称无效"
+HD675186A50F6: "参数 '%0' 中的解扰库名称无效"
 # "invalid use of '__funcref' keyword outside the WebAssembly triple"
-H5B018C340841: "在WebAssembly架构外使用'__funcref'关键字的无效用法"
+H5B018C340841: "在WebAssembly架构外使用 '__funcref' 关键字的无效用法"
 # "invalid use of '__super', %0 has no base classes"
-HC8BFC8F3D816: '无效的__super用法，%0没有基类'
+HC8BFC8F3D816: '无效的__super用法，%0 没有基类'
 # "invalid use of '__super', this keyword can only be used inside class or member function scope"
 H02BB07D5882C: '无效的__super用法，此关键字只能在类或成员函数作用域内使用'
 # "invalid use of 'this' %select{outside of a non-static member function|in a function with an explicit object parameter}0"
-H9633100217CB: "在%select{非静态成员函数外部|带有显式对象参数的函数中}0使用'this'无效"
+H9633100217CB: "在%select{非静态成员函数外部|带有显式对象参数的函数中}0使用 'this' 无效"
 # 'invalid use of PPC MMA type'
 H23BD562DB2DF: '在PPC上对MMA类型的无效使用'
 # 'invalid use of a cast in an inline asm context requiring an lvalue'
 H5D073F64410B: '在需要左值的内联汇编上下文中对强制类型转换的无效使用'
 # 'invalid use of incomplete type %0'
-H7FE8554F5009: '无效的不完全类型%0的用法'
+H7FE8554F5009: '无效的不完全类型 %0 的用法'
 # 'invalid use of member %0 in %select{static|explicit object}1 member function'
-H50EBCD910232: '在%select{静态|显式对象}1成员函数中对成员%0的无效使用'
+H50EBCD910232: '在%select{静态|显式对象}1成员函数中对成员 %0 的无效使用'
 # 'invalid use of non-static data member %0'
-H59D616D352F1: '非静态数据成员%0的无效使用'
+H59D616D352F1: '非静态数据成员 %0 的无效使用'
 # 'invalid use of pointer to member type after %select{.*|->*}0'
 H48A2AD1643D5: '%select{.*|->*}0之后的成员指针类型无效'
 # 'invalid validator version : %0; format of validator version is "<major>.<minor>" (ex:"1.4")'
 H4B1AA82F67A0: '无效的验证程序版本：%0；验证程序版本格式应为"<主版本>.<次版本>"（例如："1.4"）'
 # 'invalid validator version : %0; if validator major version is 0, minor version must also be 0'
-HD365448B0579: '无效的验证程序版本：%0；如果验证程序主版本号为0，则次版本号也必须为0'
+HD365448B0579: '无效的验证程序版本：%0；如果验证程序主版本号为 0，则次版本号也必须为 0'
 # 'invalid validator version : %0; validator version must be less than or equal to current internal version'
 HED613B352B91: '无效的验证器版本：%0；验证器版本必须小于或等于当前内部版本'
 # "invalid value '%1' in '%0'"
-H7E000E39503F: "在'%0'中无效的值'%1'"
+H7E000E39503F: "在 '%0' 中无效的值 '%1'"
 # "invalid value '%1' in '%0', expected one of: %2"
-H22924648CBBA: "在'%0'中无效的值'%1'，期望其中一个：%2"
+H22924648CBBA: "在 '%0' 中无效的值 '%1'，期望其中一个：%2"
 # "invalid value '%1' in '%0', value must be '%2' or greater"
-H38383851595E: "在'%0'中无效的值'%1'，值必须是'%2'或更大"
+H38383851595E: "在 '%0' 中无效的值 '%1'，值必须是 '%2' 或更大"
 # "invalid value '%1' in '%0', value must be 'none' or a positive integer"
-H9E8659EA6C7E: "在'%0'中无效的值'%1'；对齐必须是2的幂次方"
+H9E8659EA6C7E: "在 '%0' 中无效的值 '%1'；对齐必须是 2 的幂次方"
 # "invalid value '%1' in '%0'; alignment must be a power of 2"
-H2DA82E98A2A4: "选项 '%0' 中无效值 '%1'；对齐必须为2的幂"
+H2DA82E98A2A4: "选项 '%0' 中无效值 '%1'；对齐必须为 2 的幂"
 # "invalid value for 'default' clause; expected 'present' or 'none'"
-H8D0169FE239F: "'default'子句的值无效；期望'present'或'none'"
+H8D0169FE239F: "'default' 子句的值无效；期望 'present' 或 'none'"
 # 'invalid vector element type %0'
-HEFB9A08F90A0: "在'%0'中无效的版本号"
+HEFB9A08F90A0: "在 '%0' 中无效的版本号"
 # "invalid version number in '%0'"
-H561E007CCA86: "无效的虚拟文件系统覆盖文件'%0'"
+H561E007CCA86: "无效的虚拟文件系统覆盖文件 '%0'"
 # "invalid virtual filesystem overlay file '%0'"
 HBFF79FC3240A: "无效的虚文件系统覆盖文件 '%0'"
 # "invoking a pointer to a 'const &' member function on an rvalue is a C++20 extension"
@@ -23375,7 +23375,7 @@ HDCED919CDE9E: "对右值调用指向'const &'成员函数的指针与C++20之�
 # "invoking a pointer to a 'const &' member function on an rvalue is incompatible with C++ standards before C++20"
 H06659E61779A: "在C++20之前，对rvalue调用'const &'成员函数指针与C++标准冲突"
 # "isa trait '%0' is not known to the current target; verify the spelling or consider restricting the context selector with the 'arch' selector further"
-H0ED9A7F36C30: "目标架构未识别特性 '%0'；请检查拼写或通过'arch'选择器限制上下文"
+H0ED9A7F36C30: "目标架构未识别特性 '%0'；请检查拼写或通过 'arch' 选择器限制上下文"
 # "it could also be property %select{of type %1|without attribute '%1'|with attribute '%1'|with getter %1|with setter %1}0 declared here"
 H91A939A34A63: "它也可能是属性 %select{类型 %1|无 '%1' 属性|具有 '%1' 属性|具有 getter %1|具有 setter %1}0 在此处声明"
 # 'it delegates to'
@@ -23383,15 +23383,15 @@ H01E41C702CFA: '其委托到'
 # 'it is possible to stop the benchmarking process after some phase'
 H3F4A63E67588: '可以在某些阶段后停止基准测试过程'
 # 'iterator step expression %0 evaluates to 0'
-H68A0F13C3B50: '迭代器步长表达式%0不是整型表达式'
+H68A0F13C3B50: '迭代器步长表达式 %0 不是整型表达式'
 # 'iterator step expression %0 is not the integral expression'
-H5E0FE51F5C8D: '支撑该属性的实例变量%0未在此属性的访问器中被引用'
+H5E0FE51F5C8D: '支撑该属性的实例变量 %0 未在此属性的访问器中被引用'
 # "ivar %0 which backs the property is not referenced in this property's accessor"
 HB68211D86C75: "连接参数期望附加值：'%0'"
 # "joined argument expects additional value: '%0'"
 H67B5A91D2948: "连接参数需要额外值：'%0'"
 # "joined argument treated as '%0'; did you mean '%1'?"
-HAC9E756384DA: "合并的参数被当作'%0'处理；您是指'%1'吗？"
+HAC9E756384DA: "合并的参数被当作 '%0' 处理；您是指 '%1' 吗？"
 # 'jump bypasses OpenMP structured block'
 H38D141B68E15: '跳跃绕过了OpenMP结构化块'
 # 'jump bypasses auto release push of @autoreleasepool block'
@@ -23503,7 +23503,7 @@ HE15267C61E24: 'jump exits try块'
 # 'jump from switch statement to this case label is incompatible with C++98'
 HFD45DFD4341B: '从switch语句跳转到此case标签与C++98不兼容'
 # 'jump from this %select{indirect|asm}0 goto statement to one of its possible targets is incompatible with C++98'
-H6B5196F09490: '从此%select{indirect|asm}0 goto语句跳转到其可能目标与C++98不兼容'
+H6B5196F09490: '从此 %select{indirect|asm}0 goto语句跳转到其可能目标与C++98不兼容'
 # 'jump from this goto statement to its label is a Microsoft extension'
 HF443D2C187C8: '从此goto语句跳转到其标签是Microsoft扩展'
 # 'jump from this goto statement to its label is incompatible with C++98'
@@ -23567,9 +23567,9 @@ H3541695AB458: 'lambda调用运算符不应显式特化或实例化'
 # 'lambda cannot be both mutable and static'
 H057D935E257D: 'lambda不能同时是mutable和static'
 # 'lambda cannot be declared %0'
-H523BA4919111: 'lambda不能被声明为%0'
+H523BA4919111: 'lambda不能被声明为 %0'
 # 'lambda capture %0 is not %select{used|required to be captured for this use}1'
-HED12D4324492: 'lambda捕获%0未被%select{使用|为此用途要求捕获}1'
+HED12D4324492: 'lambda捕获 %0 未被%select{使用|为此用途要求捕获}1'
 # 'lambda closure types are non-literal types before C++17'
 H3BDD817E383F: '在C++17之前lambda闭包类型是非字面类型'
 # 'lambda expression begins here'
@@ -23585,27 +23585,27 @@ H33C909CD1D80: 'lambda模板参数列表不能为空'
 # 'lambda without a parameter clause is a C++23 extension'
 HD70498A5F3EC: '无参数子句的lambda是C++23扩展'
 # 'lambdas are a %select{C++11|clang HLSL}0 extension'
-HD58884723190: 'lambda是%select{C++11|clang HLSL}0扩展'
+HD58884723190: 'lambda是 %select{C++11|clang HLSL}0 扩展'
 # "language not recognized: '%0'"
 H102C1DB9CB0E: "未识别的语言: '%0'"
 # 'large atomic operation may incur significant performance penalty; the access size (%0 bytes) exceeds the max lock-free size (%1 bytes)'
-H31655F77BD73: '大原子操作可能导致显著性能损失；访问大小（%0字节）超过最大无锁大小（%1字节）'
+H31655F77BD73: '大原子操作可能导致显著性能损失；访问大小（%0 字节）超过最大无锁大小（%1 字节）'
 # 'layout blocks in reverse order'
 H19EE0FFEC518: '以逆序排列块布局'
 # 'lcov tracefile output'
 HCE669C9CA888: 'lcov跟踪文件输出'
 # 'left hand operand of type %0 to compound assignment cannot be truncated when used with right hand operand of type %1'
-H00D9FE7F4F87: '类型为%0的左操作数在与类型%1的右操作数复合赋值时不能被截断'
+H00D9FE7F4F87: '类型为 %0 的左操作数在与类型 %1 的右操作数复合赋值时不能被截断'
 # 'left hand operand to %0 must be a %select{|pointer to }1class compatible with the right hand operand, but is %2'
-HE8A81161D486: '复合赋值运算符%0的左操作数必须与右操作数兼容的%select{|指向}1类类型，但实际类型为%2'
+HE8A81161D486: '复合赋值运算符 %0 的左操作数必须与右操作数兼容的%select{|指向}1类类型，但实际类型为 %2'
 # "left hand side of assignment operation('%0') must match one side of the sub-operation on the right hand side('%1' and '%2')"
 HA99FEEFA45D5: '赋值运算的左侧（‘%0’）必须与右侧的子运算（‘%1’和‘%2’）的一侧匹配'
 # 'left operand of comma operator has no effect'
 H1D36CC5E4D5A: '逗号运算符的左操作数无效果'
 # 'left shift of negative value %0'
-HF788BD55C118: '对负值%0进行左移操作'
+HF788BD55C118: '对负值 %0 进行左移操作'
 # "length modifier '%0' results in undefined behavior or no effect with '%1' conversion specifier"
-HDCB24BE7C9E8: "长度修饰符'%0'与'%1'转换说明符组合会导致未定义行为或无效果"
+HDCB24BE7C9E8: "长度修饰符 '%0' 与 '%1' 转换说明符组合会导致未定义行为或无效果"
 # 'libclc builtin preparation tool\n'
 H8679FDE4DA62: 'libclc 内建准备工具\n'
 # 'limit number of targets to consider when doing indirect call promotion on calls. 0 = no limit'
@@ -23623,11 +23623,11 @@ H8A0833C758AF: '行标记指令需要一个正整数参数'
 # 'line splicing in Doxygen comments are not supported'
 HD6510289D84D: 'Doxygen注释中的行拼接不受支持'
 # "linking module '%0': %1"
-H78786E2D2737: "链接模块'%0'时发生错误：%1"
+H78786E2D2737: "链接模块 '%0' 时发生错误：%1"
 # 'linking options'
 H1E4F081C74A1: '链接选项'
 # 'list item of type %0 is not valid for specified reduction operation: unable to provide default initialization value'
-H5FEA755CA374: '类型为%0的列表项不适合指定的约简操作：无法提供默认初始化值'
+H5FEA755CA374: '类型为 %0 的列表项不适合指定的约简操作：无法提供默认初始化值'
 # 'list of functions to always consider for inlining'
 H00FB00D60661: '始终考虑内联的函数列表'
 # 'list of functions to apply frame opts'
@@ -23645,7 +23645,7 @@ H1C3AE7A6EC95: '需要输出的函数列表'
 # 'list of functions to skip'
 HED4CB34A956C: '需要跳过的函数列表'
 # 'list of functions with call sites for which to specialize memcpy() for size 1'
-HD7F5B54EFF49: '为size参数为1时的memcpy调用位址进行专用优化的函数调用位置列表'
+HD7F5B54EFF49: '为size参数为 1 时的memcpy调用位址进行专用优化的函数调用位置列表'
 # "list of sections containing functions used for hugifying hot text. BOLT makes sure these functions are not placed on the same page as the hot text. (default='.stub,.mover')."
 H07A4ADB5443D: "包含用于hugify热点代码的函数的节列表。BOLT会确保这些函数不会与热点代码放在同一页面（默认='.stub,.mover'）。"
 # 'list of sections to reorder'
@@ -23655,9 +23655,9 @@ H6F9EE9EC82ED: '可以重新排序的符号名称列表'
 # 'list of symbol names that cannot be reordered'
 H9016DB56BAB4: '不能重新排序的符号名称列表'
 # 'literal construction method %0 has incompatible signature'
-H9A98E6827407: '文字构造方法%0具有不兼容的函数签名'
+H9A98E6827407: '文字构造方法 %0 具有不兼容的函数签名'
 # 'literal operator %0 must be in a namespace or global scope'
-H6F0C93D8CF92: '文字操作符%0必须位于命名空间或全局作用域中'
+H6F0C93D8CF92: '文字操作符 %0 必须位于命名空间或全局作用域中'
 # 'literal operator cannot have a default argument'
 H2D253A373F0C: '文字操作符不能具有默认参数'
 # 'literal operator must have C++ linkage'
@@ -23735,65 +23735,65 @@ H4E0562614A60: '局部%select{结构|接口|联合|类|枚举}0不能声明为__
 # 'local declaration nearly matches'
 HA030BEFE649C: '局部声明几乎匹配'
 # 'local declaration of %0 hides instance variable'
-H09900D49A0E3: '局部声明的%0会隐藏实例变量'
+H09900D49A0E3: '局部声明的 %0 会隐藏实例变量'
 # 'local type %0 as template argument is incompatible with C++98'
-H6116FD3EFF04: '将局部类型%0作为模板参数与C++98不兼容'
+H6116FD3EFF04: '将局部类型 %0 作为模板参数与C++98不兼容'
 # "local variable '%0' should not be used in 'declare target' directive;"
-HF2D2B034481C: "局部变量'%0'不应在'declare target'指令中使用;"
+HF2D2B034481C: "局部变量 '%0' 不应在'declare target'指令中使用;"
 # "local variable cannot be declared 'constinit'"
-HE35DCF249418: "局部变量不能声明为'constinit'"
+HE35DCF249418: "局部变量不能声明为 'constinit'"
 # "locking '%0' to build module '%1'"
-H36ABFAB03219: "锁定'%0'以构建模块'%1'"
+H36ABFAB03219: "锁定 '%0' 以构建模块 '%1'"
 # 'logical expression with vector %select{type %1 and non-vector type %2|types %1 and %2}0 is only supported in C++'
-H1200F428FBB0: '向量%select{类型%1与非向量类型%2|类型%1和类型%2}0的逻辑表达式仅在C++中支持'
+H1200F428FBB0: '向量%select{类型 %1 与非向量类型 %2|类型 %1 和类型 %2}0的逻辑表达式仅在C++中支持'
 # 'logical not is only applied to the left hand side of this %select{comparison|bitwise operator}0'
 H9E8ECD267F25: '逻辑非仅应用于此%select{比较运算符|位运算符}0的左操作数'
 # 'lookup from the current scope refers here'
 H9AFA3EAEA36F: '当前作用域的查找指向此处'
 # 'lookup in the object type %0 refers here'
-H3FD57FB46E2B: '在对象类型%0中的查找指向此处'
+H3FD57FB46E2B: '在对象类型 %0 中的查找指向此处'
 # 'lookup of %0 in member access expression is ambiguous'
-H52F57D0BB44E: '成员访问表达式中的%0查找是模棱两可的'
+H52F57D0BB44E: '成员访问表达式中的 %0 查找是模棱两可的'
 # 'lookup of %0 in member access expression is ambiguous; using member of %1'
-H632E112FD2AD: '成员访问表达式中的%0查找是模棱两可的；使用%1的成员'
+H632E112FD2AD: '成员访问表达式中的 %0 查找是模棱两可的；使用 %1 的成员'
 # "loop iteration variable in the associated loop of 'omp %1' directive may not be %0, predetermined as %2"
-H777624FA6F75: "与'omp %1'指令关联的循环迭代变量不能是%0，已被预设为%2"
+H777624FA6F75: "与'omp %1'指令关联的循环迭代变量不能是 %0，已被预设为 %2"
 # 'loop step is expected to be %select{negative|positive}0 due to this condition'
 HF9B9B19EF744: '由于此条件，循环步长应为%select{负|正}0'
 # 'loop to be fully unrolled must have a constant trip count'
 HF58CAD452050: '要完全展开的循环必须具有常量迭代次数'
 # 'loop variable %0 %diff{of type $ binds to a temporary constructed from type $|binds to a temporary constructed from a different type}1,2'
-H8E540E772339: '循环变量%0 %diff{类型$绑定到由类型$构造的临时对象|绑定到由不同类型构造的临时对象}1,2'
+H8E540E772339: '循环变量 %0 %diff{类型$绑定到由类型$构造的临时对象|绑定到由不同类型构造的临时对象}1,2'
 # 'loop variable %0 binds to a temporary value produced by a range of type %1'
-HDD2F7E9780FE: '循环变量%0绑定到类型%1的范围生成的临时值'
+HDD2F7E9780FE: '循环变量 %0 绑定到类型 %1 的范围生成的临时值'
 # 'loop variable %0 creates a copy from type %1'
-H0EB738A6DA64: '循环变量%0从类型%1创建副本'
+H0EB738A6DA64: '循环变量 %0 从类型 %1 创建副本'
 # "loop variable %0 may not be declared %select{'extern'|'static'|'__private_extern__'|'auto'|'register'|'constexpr'|'thread_local'}1"
-HD1C2B82FE9FA: "循环变量%0不能被声明为%select{'extern'|'static'|'__private_extern__'|'auto'|'register'|'constexpr'|'thread_local'}1"
+HD1C2B82FE9FA: "循环变量 %0 不能被声明为%select{'extern'|'static'|'__private_extern__'|'auto'|'register'|'constexpr'|'thread_local'}1"
 # "loop variable of loop associated with an OpenACC '%0' construct must be of integer, pointer, or random-access-iterator type (is %1)"
-HDE685F11E1FA: "与OpenACC '%0'结构关联的循环变量必须是整型、指针或随机访问迭代器类型（当前为%1）"
+HDE685F11E1FA: "与OpenACC '%0' 结构关联的循环变量必须是整型、指针或随机访问迭代器类型（当前为 %1）"
 # 'loop will run at most once (loop increment never executed)'
 H41A7771F3080: '该循环最多执行一次（循环增量从未被执行）'
 # "loop with a '%0' clause may not exist in the region of a '%1' clause%select{| on a '%3' construct}2"
-H31D69B81DD7A: "带有'%0'子句的循环不能存在于'%1'子句%select{|的'%3'结构}2区域中"
+H31D69B81DD7A: "带有 '%0' 子句的循环不能存在于 '%1' 子句%select{|的 '%3' 结构}2区域中"
 # 'lower transpose without using a runtime call'
 H1DC7FFF629C0: '在不使用运行时调用的情况下转换转置'
 # 'mac68k alignment pragma is not supported on this target'
 H13A22B895D9E: '此目标不支持mac68k对齐#pragma'
 # 'macro %0 defined here'
-H224BD0DEAAD4: '宏%0在此处定义'
+H224BD0DEAAD4: '宏 %0 在此处定义'
 # 'macro %0 has been marked as deprecated%select{|: %2}1'
-HB9E9BBB38434: '宏%0已被标记为已弃用%select{|: %2}1'
+HB9E9BBB38434: '宏 %0 已被标记为已弃用%select{|: %2}1'
 # 'macro %0 has been marked as final and should not be %select{undefined|redefined}1'
-H416ADCAF4BDC: '宏%0已被标记为最终且不应%select{未定义|重新定义}1'
+H416ADCAF4BDC: '宏 %0 已被标记为最终且不应%select{未定义|重新定义}1'
 # 'macro %0 has been marked as unsafe for use in headers%select{|: %2}1'
-H0BD2BA6647E5: '宏%0已被标记为在头文件中不安全%select{|: %2}1'
+H0BD2BA6647E5: '宏 %0 已被标记为在头文件中不安全%select{|: %2}1'
 # "macro '%0' contains embedded newline; text after the newline is ignored"
-HCA29C3134207: "宏'%0'包含嵌入的换行符；换行符后的文本将被忽略"
+HCA29C3134207: "宏 '%0' 包含嵌入的换行符；换行符后的文本将被忽略"
 # "macro '%0' was %select{defined|undef'd}1 in the AST file '%2' but %select{undef'd|defined}1 on the command line"
-HEF8B87D78B88: "宏'%0'在AST文件'%2'中%select{已定义|未定义}1，但在命令行中%select{未定义|已定义}1"
+HEF8B87D78B88: "宏 '%0' 在AST文件 '%2' 中%select{已定义|未定义}1，但在命令行中%select{未定义|已定义}1"
 # "macro expansion producing 'defined' has undefined behavior"
-H6CE80CBEAD13: "生成'defined'的宏展开会导致未定义行为"
+H6CE80CBEAD13: "生成 'defined' 的宏展开会导致未定义行为"
 # 'macro is not used'
 HB7A93ECCBE4F: '该宏未被使用'
 # "macro marked '%select{deprecated|restrict_expansion|final}0' here"
@@ -23807,9 +23807,9 @@ HA83E076252EC: '宏名必须是标识符'
 # "macro was %select{defined|#undef'd}0 here"
 H90411BE5521B: '宏在此处%select{被定义|#undef}0'
 # 'magnitude of floating-point constant too large for type %0; maximum is %1'
-HC45BAE211EEF: '浮点常量的大小对类型%0来说过大；最大值为%1'
+HC45BAE211EEF: '浮点常量的大小对类型 %0 来说过大；最大值为 %1'
 # 'magnitude of floating-point constant too small for type %0; minimum is %1'
-H77948F2AADFE: '浮点常量的大小对类型%0来说过小；最小值为%1'
+H77948F2AADFE: '浮点常量的大小对类型 %0 来说过小；最小值为 %1'
 # 'main cannot be declared as a variable %select{in the global scope|with C language linkage}0'
 HDFAAFDDA66C4: 'main不能声明为变量%select{在全局作用域中|具有C语言链接性}0'
 # 'main file cannot be included recursively when building a preamble'
@@ -23831,35 +23831,35 @@ H98473149CB24: "sanitizer 忽略列表格式错误: '%0'"
 # "malformed sanitizer metadata ignorelist: '%0'"
 H7E49790904E8: "sanitizer 元数据忽略列表格式错误: '%0'"
 # 'mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature'
-HC8027193700F: '由于函数签名中的非抛出异常规范，在C++17中%0的装饰名称将改变'
+HC8027193700F: '由于函数签名中的非抛出异常规范，在C++17中 %0 的装饰名称将改变'
 # "map type '%0' is previous specified here"
-H3204C79CA043: '映射类型"%0"在此处之前已指定'
+H3204C79CA043: '映射类型 "%0" 在此处之前已指定'
 # 'map type is already specified'
 HF4D36EA9229E: '映射类型已指定'
 # "map type modifier '%0' is not allowed for '#pragma omp %1'"
-H5A1E07271479: "映射类型修饰符'%0'不允许用于'#pragma omp %1'"
+H5A1E07271479: "映射类型修饰符 '%0' 不允许用于'#pragma omp %1'"
 # 'mapper type must be of struct, union or class type'
 H3D3958379C94: '映射器类型必须为结构体、联合或类类型'
 # 'mapping of union members is not allowed'
 HD27CBEC61BC1: '联合成员的映射是不允许的'
 # "mark %0 as '%select{final|sealed}1' to silence this warning"
-HF7273FC85EE1: "将%0标记为'%select{final|sealed}1'以消除此警告"
+HF7273FC85EE1: "将 %0 标记为'%select{final|sealed}1'以消除此警告"
 # "mark 'operator==' as const or add a matching 'operator!=' to resolve the ambiguity"
 H5A25A1F05320: "将'operator=='声明为const，或添加匹配的'operator!='以解决歧义"
 # "mark function boundaries with break instruction to make sure we accidentally don't cross them"
 H5B830E6175D2: '使用断点指令标记函数边界，以确保我们不会意外跨过它们'
 # 'marked %0 here'
-HE33E97AC0225: '此处标记的%0'
+HE33E97AC0225: '此处标记的 %0'
 # "marked as 'declare variant' here"
 H721AFFF82622: "此处标记为'declare variant'"
 # "marked as 'device_type(%0)' here"
 HF283C800233B: "此处标记为'device_type(%0)'"
 # 'mask type size must be between 1-byte and 8-bytes'
-HA5CB60FF0FBF: '掩码类型大小必须在1字节到8字节之间'
+HA5CB60FF0FBF: '掩码类型大小必须在 1 字节到 8 字节之间'
 # 'match functions in binary 2 to binary 1 if they have the same hash of a function in binary 1'
-HAF6822E35564: '如果二进制文件2中的函数与二进制文件1中的函数具有相同的哈希值，则将其匹配到二进制文件1'
+HAF6822E35564: '如果二进制文件 2 中的函数与二进制文件 1 中的函数具有相同的哈希值，则将其匹配到二进制文件 1'
 # "math errno enabled by '%0' after it was implicitly disabled by '%1', this may limit the utilization of the vector library"
-HE93B3822306D: "'%0'启用的数学errno在被'%1'隐式禁用后可能限制向量库的使用效率"
+HE93B3822306D: "'%0' 启用的数学errno在被 '%1' 隐式禁用后可能限制向量库的使用效率"
 # 'mathematical notation character <U+%0> in an identifier is a Clang extension'
 H0378BC9B5A74: '标识符中的数学符号<U+%0>是Clang扩展'
 # 'matrix %select{row|column}0 index is not an integer'
@@ -23877,11 +23877,11 @@ H5D6C3AFD428B: '出于内联目的，函数被视为小的字节最大数量'
 # 'max stack depth tracing'
 H293E22C2DAE9: '最大堆栈深度跟踪'
 # 'maxclusterrank requires sm_90 or higher, CUDA arch provided: %0, ignoring %1 attribute'
-H49A2942ECE44: 'maxclusterrank需要sm_90或更高架构，当前CUDA架构为%0，将忽略%1属性'
+H49A2942ECE44: 'maxclusterrank需要sm_90或更高架构，当前CUDA架构为 %0，将忽略 %1 属性'
 # 'maximal number of instructions to instrument in any given BB'
 H65055BD64342: '在任意给定的基本块（BB）中要插入的指令最大数量'
 # 'maximum address considered valid for heatmap (default 4GB)'
-H617E4DDA7E48: '热图（heatmap）认为有效的最大地址（默认4GB）'
+H617E4DDA7E48: '热图（heatmap）认为有效的最大地址（默认 4GB）'
 # 'maximum function durations'
 H6F70690AFB07: '函数最大持续时间'
 # 'maximum number of bytes to reorder'
@@ -23909,25 +23909,25 @@ H9341327D8697: '可容忍的最大陈旧函数百分比（默认：100）'
 # 'maximum search depth. 0 forces a greedy approach. warning: the algorithm is up to O(2^N), where N is the max depth.'
 H61B898BD8A31: '最大搜索深度。0强制使用贪心算法。警告：该算法的复杂度最高可达O(2^N)，其中N是最大深度。'
 # "meaningless '%0' on asm outside function"
-H7C9CC9A0FF49: "在函数外部的asm语句中使用'%0'没有意义"
+H7C9CC9A0FF49: "在函数外部的asm语句中使用 '%0' 没有意义"
 # 'median function durations'
 H4412290B83EA: '函数中位持续时间'
 # 'member %0 cannot have template arguments'
-H7530E8235E69: '成员%0不能带有模板参数'
+H7530E8235E69: '成员 %0 不能带有模板参数'
 # 'member %0 declared here'
-H523D63E160D3: '此处声明了成员%0'
+H523D63E160D3: '此处声明了成员 %0'
 # 'member %0 first declared here'
-H53F314C373D4: '成员%0首次声明于此'
+H53F314C373D4: '成员 %0 首次声明于此'
 # 'member %0 found in multiple base classes of different types'
-HE96F2F88498F: '成员%0在不同类型的多个基类中找到'
+HE96F2F88498F: '成员 %0 在不同类型的多个基类中找到'
 # 'member %0 has the same name as its class'
-HBDCB2F361AEB: '成员%0与其所属类具有相同的名称'
+HBDCB2F361AEB: '成员 %0 与其所属类具有相同的名称'
 # 'member %0 of %1 is not a template; did you mean %select{|simply }2%3?'
-H88F478FC5C17: '%1的成员%0不是模板；是否应改为%select{|直接}2%3？'
+H88F478FC5C17: '%1 的成员 %0 不是模板；是否应改为%select{|直接}2%3？'
 # 'member %0 used before its declaration'
-H21EA4914C844: '在声明之前使用了成员%0'
+H21EA4914C844: '在声明之前使用了成员 %0'
 # 'member access into incomplete type %0'
-H3F51F529F796: '尝试访问不完整类型%0的成员'
+H3F51F529F796: '尝试访问不完整类型 %0 的成员'
 # 'member declaration does not match because it %select{is|is not}0 const qualified'
 HB51C7FC5370B: '成员声明不匹配，因为其%select{是|不是}0 const限定符'
 # 'member declaration nearly matches'
@@ -23935,27 +23935,27 @@ HA07B45D5B59A: '成员声明几乎匹配'
 # 'member found by ambiguous name lookup'
 H1816E255A34E: '通过模糊名称查找找到的成员'
 # 'member function %0 is not needed and will not be emitted'
-HC39E7B7627B2: '成员函数%0未被使用，将不会被生成'
+HC39E7B7627B2: '成员函数 %0 未被使用，将不会被生成'
 # 'member function specialization matches %0'
-HCDF99A0E6C9D: '成员函数特化与%0匹配'
+HCDF99A0E6C9D: '成员函数特化与 %0 匹配'
 # 'member initializer %0 does not name a non-static data member or base class'
-H35E3E12D1C39: '成员初始化器%0未命名非静态数据成员或基类'
+H35E3E12D1C39: '成员初始化器 %0 未命名非静态数据成员或基类'
 # 'member is declared here'
 H08E5DDE7EA19: '成员在此处声明'
 # "member is not a candidate because range type %0 has no '%select{end|begin}1' member"
-HE822EBF784D6: '成员不是候选，因为范围类型%0没有‘%select{end|begin}1’成员'
+HE822EBF784D6: '成员不是候选，因为范围类型 %0 没有‘%select{end|begin}1’成员'
 # 'member not initialized by constructor'
 H26EC51B7C7A4: '成员未由构造函数初始化'
 # 'member of anonymous %select{struct|union}0 redeclares %1'
-H9C0924E1182A: '匿名%select{struct|union}0的成员重新声明了%1'
+H9C0924E1182A: '匿名 %select{struct|union}0 的成员重新声明了 %1'
 # 'member pointer has incomplete base type %0'
-H9CA90CC9D193: '成员指针具有不完全基类型%0'
+H9CA90CC9D193: '成员指针具有不完全基类型 %0'
 # 'member pointer representation requires a complete class type for %0 to perform this expression'
-HA14D1B995CD2: '成员指针的表示需要%0为完整类类型才能执行此表达式'
+HA14D1B995CD2: '成员指针的表示需要 %0 为完整类类型才能执行此表达式'
 # 'member reference base type %0 is not a structure or union'
-HDDC7E94D7C4D: '成员引用的基类型%0不是结构体或联合体'
+HDDC7E94D7C4D: '成员引用的基类型 %0 不是结构体或联合体'
 # "member reference type %0 is %select{a|not a}1 pointer; did you mean to use '%select{->|.}1'?"
-HCE4396C30D63: '成员引用类型%0是%select{一个|不是}1指针；是否应使用‘%select{->|.}1’？'
+HCE4396C30D63: '成员引用类型 %0 是%select{一个|不是}1指针；是否应使用‘%select{->|.}1’？'
 # 'member reference type %0 is not a pointer'
 H1067A041C0C1: '成员引用类型 %0 不是指针'
 # 'member template declared %0 here'
@@ -24011,23 +24011,23 @@ H630B60C086B7: '方法索引参数类型 %0 不是整数类型'
 # 'method is expected to return an instance of its class type %diff{$, but is declared to return $|, but is declared to return different type}0,1'
 H4EBF90DD6088: '方法应返回其类类型实例%diff{（$ 期望但声明为返回$)|（$ 期望但声明为返回不同类型)}0,1'
 # 'method key parameter type %0 is not object type'
-H93D8788321DF: '方法键参数类型%0不是对象类型'
+H93D8788321DF: '方法键参数类型 %0 不是对象类型'
 # 'method marked as designated initializer of the class here'
 H6D873EC57BBB: '此处标记为类的指定初始化器的方法'
 # "method name referenced in property setter attribute must end with ':'"
 H48FC25BCA089: '在属性设置器属性中引用的方法名称必须以":"结尾'
 # 'method object parameter type %0 is not object type'
-H7C5EC09F4D4E: '方法对象参数类型%0不是对象类型'
+H7C5EC09F4D4E: '方法对象参数类型 %0 不是对象类型'
 # 'method override for the designated initializer of the superclass %objcinstance0 not found'
 H353D09FC8C8A: '未找到超类%objcinstance0的指定初始化器方法覆盖'
 # 'method parameter of type %0 with no explicit ownership'
-H012CAADA6E5A: '类型%0且没有显式所有权的方法参数'
+H012CAADA6E5A: '类型 %0 且没有显式所有权的方法参数'
 # 'method parameter type %diff{$ does not match super class method parameter type $|does not match super class method parameter type}0,1'
 H52F29D4B5323: '与超类方法参数类型%diff{$ does not match super class method parameter type $|does not match super class method parameter type}0,1不匹配'
 # 'method possibly missing a [super %0] call'
 HF2DE0E720AA4: '方法可能缺少对[super %0]的调用'
 # 'method returns unexpected type %0 (should be an object type)'
-HDA228B7E04A3: '方法返回意外类型%0（应为对象类型）'
+HDA228B7E04A3: '方法返回意外类型 %0（应为对象类型）'
 # "method type specifier must start with '-' or '+'"
 H60683402DB43: '方法类型说明符必须以"-"或"+"开头'
 # "method was declared as %select{an 'alloc'|a 'copy'|an 'init'|a 'new'}0 method, but its implementation doesn't match because %select{its result type is not an object pointer|its result type is unrelated to its receiver type}1"
@@ -24035,11 +24035,11 @@ H0332DF98668A: '该方法被声明为%select{一个"alloc"|一个"copy"|一个"i
 # 'methods that %select{override superclass methods|implement protocol requirements}0 cannot be direct'
 H10E1F7CDD559: '%select{覆盖超类方法|实现协议要求}0的方法不能是直接的'
 # "micromips is not supported for target CPU '%0'"
-H17AAF1CF7567: '目标CPU "%0"不支持micromips'
+H17AAF1CF7567: '目标CPU "%0" 不支持micromips'
 # 'minimal size of the basic block that should be aligned'
 H9310AFA3C7C1: '应对其齐的基本块的最小大小'
 # 'minimum address considered valid for heatmap (default 0)'
-HB0C898B37318: '热图视为有效的最小地址（默认0）'
+HB0C898B37318: '热图视为有效的最小地址（默认 0）'
 # 'minimum condition bias (pct) to perform a CMOV conversion, -1 to not account bias'
 HF9B056CCAAE3: '执行CMOV转换的最小条件偏差（pct），-1表示不考虑偏差'
 # 'minimum function durations'
@@ -24051,49 +24051,49 @@ H24AF23851D8A: '分析簇中的最小点数（仅DBSCAN）'
 # 'minimum offset needed between block and successor to allow duplication'
 H75F42A78BFD9: '允许复制块与其后继之间所需的最小偏移量'
 # 'minimum vscale must be an unsigned integer greater than 0'
-H97D216C9F9DC: '最小vscale必须是大于0的无符号整数'
+H97D216C9F9DC: '最小vscale必须是大于 0 的无符号整数'
 # 'minus(-) operator for reductions is deprecated; use + or user defined reduction instead'
 HB503599C3686: '归约操作的减法(-)运算符已弃用；请改用+或用户定义的归约'
 # 'misaligned atomic operation may incur significant performance penalty; the expected alignment (%0 bytes) exceeds the actual alignment (%1 bytes)'
-HB642C05FEFCE: '对齐不正确的原子操作可能导致显著性能损失；期望的对齐(%0字节)超过实际对齐(%1字节)'
+HB642C05FEFCE: '对齐不正确的原子操作可能导致显著性能损失；期望的对齐(%0 字节)超过实际对齐(%1 字节)'
 # "misleading indentation; statement is not part of the previous '%select{if|else|for|while}0'"
 H2D720E07A9B5: '误导性的缩进；该语句不属于前面的"%select{if|else|for|while}0"'
 # "mismatch between architecture and environment in target triple '%0'; did you mean '%1'?"
-HFB1C45E0F3D8: '目标三元组"%0"中的架构和环境不匹配；您是指"%1"吗？'
+HFB1C45E0F3D8: '目标三元组 "%0" 中的架构和环境不匹配；您是指 "%1" 吗？'
 # 'mismatch in number of block parameters and local size arguments passed'
 H297CC009BE30: '传递的块参数数量与本地大小参数数量不匹配'
 # 'misplaced %0; expected %0 here'
-H6EEF8ABBCBBD: '"%0"位置错误；此处应使用%0'
+H6EEF8ABBCBBD: '"%0" 位置错误；此处应使用 %0'
 # 'misplaced attributes; expected attributes here'
 H71DF23AD8094: '位置不当的属性；此处应放置属性'
 # 'misprediction threshold for skipping ICP on an indirect call'
 H2799B1202BB8: '间接调用中跳过ICP的预测错误阈值'
 # 'missing %1 after %0'
-H71A0939C10D8: '在%0之后缺少%1'
+H71A0939C10D8: '在 %0 之后缺少 %1'
 # "missing '(' after '#pragma %0' - ignoring"
-H9BCF4D2D832C: "在#pragma %0后缺少'(' - 忽略"
+H9BCF4D2D832C: "在#pragma %0 后缺少'(' - 忽略"
 # "missing '(' following __VA_OPT__"
 HFEF64C94E397: "__VA_OPT__后缺少'('"
 # "missing ')' after '#pragma %0' - ignoring"
-HD628B31A25D9: "在#pragma %0后缺少')' - 忽略"
+HD628B31A25D9: "在#pragma %0 后缺少')' - 忽略"
 # "missing ')' in macro parameter list"
 HBA1269832ABB: "宏参数列表中缺少')'"
 # "missing '*' in type bound %0 for type parameter %1"
-H0FC1C4510683: "在类型参数%1的类型边界%0中缺少'*'"
+H0FC1C4510683: "在类型参数 %1 的类型边界 %0 中缺少'*'"
 # "missing ',' after %0"
-H36D833E1BE2F: "在%0之后缺少','"
+H36D833E1BE2F: "在 %0 之后缺少','"
 # "missing ',' between base or member initializers"
 HC0E2DA10BD59: "基类或成员初始化器之间的初始化器缺少','"
 # "missing ',' between enumerators"
 H3BCFAD409136: "枚举项之间缺少','"
 # "missing ':' after %0 - ignoring"
-H6D49C0F56471: "在%0之后缺少':' - 忽略"
+H6D49C0F56471: "在 %0 之后缺少':' - 忽略"
 # "missing ':' after %0 modifier"
-H1C42316D6361: "在%0修饰符之后缺少':'"
+H1C42316D6361: "在 %0 修饰符之后缺少':'"
 # "missing ':' in %0"
-HB39748BAFE7C: "在%0中缺少':'"
+HB39748BAFE7C: "在 %0 中缺少':'"
 # "missing ':' or ')' after %0 - ignoring"
-HA24B4C500D05: "在%0之后缺少':'或')' - 忽略"
+HA24B4C500D05: "在 %0 之后缺少':'或')' - 忽略"
 # "missing '@end'"
 H91CC5F3C7087: '缺少@end'
 # "missing '[' at start of message send expression"
@@ -24101,31 +24101,31 @@ H352486DC1A63: "消息发送表达式开头缺少'['"
 # "missing 'export module' declaration in module interface unit"
 H43BE56C41167: "在模块接口单元中缺少'export module'声明"
 # "missing 'export' specifier in module declaration while building module interface"
-H73E9D7F0EE4B: "构建模块接口时，在模块声明中缺少'export'指定符"
+H73E9D7F0EE4B: "构建模块接口时，在模块声明中缺少 'export' 指定符"
 # "missing 'get=' or 'put='"
 H5BBBF3CA84C4: "缺少'get='或'put='"
 # "missing 'module' declaration at end of global module fragment introduced here"
-HECF75AD1494B: "在此处引入的全局模块片段结尾缺少'module'声明"
+HECF75AD1494B: "在此处引入的全局模块片段结尾缺少 'module' 声明"
 # "missing 'template' keyword prior to dependent template name %0"
-H6110BBE085CA: "缺少依赖模板名称%0之前的'template'关键字"
+H6110BBE085CA: "缺少依赖模板名称 %0 之前的 'template' 关键字"
 # "missing 'typename' prior to dependent type name %0"
-H1584997CE5DB: "缺少依赖类型名称%0之前的'typename'"
+H1584997CE5DB: "缺少依赖类型名称 %0 之前的 'typename'"
 # "missing 'typename' prior to dependent type name %0; implicit 'typename' is a C++20 extension"
-H15976F1154C9: "缺少依赖类型名称%0之前的'typename'；隐式'typename'是C++20扩展"
+H15976F1154C9: "缺少依赖类型名称 %0 之前的 'typename'；隐式 'typename' 是C++20扩展"
 # "missing 'typename' prior to dependent type template name %0"
-HB65342C255DD: "缺少依赖类型模板名称%0之前的'typename'"
+HB65342C255DD: "缺少依赖类型模板名称 %0 之前的 'typename'"
 # "missing '}' at end of definition of %q0"
 HAF73F9C8E8E7: "在%q0定义末尾缺少'}'"
 # 'missing actual type specifier for pipe'
 H369BCA42F29A: '管道缺少实际类型说明符'
 # "missing argument to '#pragma %0'%select{|; expected %2}1"
-H85D43DEA45AB: '#pragma %0 指令缺少参数%select{|；期望%2}1'
+H85D43DEA45AB: '#pragma %0 指令缺少参数%select{|；期望 %2}1'
 # "missing argument to '%0'"
-H52AC6CD34BC9: "缺少'%0'的参数"
+H52AC6CD34BC9: "缺少 '%0' 的参数"
 # "missing argument to debug command '%0'"
-H68E5FEB79890: "调试命令'%0'缺少参数"
+H68E5FEB79890: "调试命令 '%0' 缺少参数"
 # "missing argument; expected %select{an integer value|'enable'%select{|, 'full'}1%select{|, 'assume_safety'}2 or 'disable'}0"
-H6DC6E5CF70F4: "缺少参数；期望%select{整数值|'enable'%select{|, 'full'}1%select{|, 'assume_safety'}2 或'disable'}0"
+H6DC6E5CF70F4: "缺少参数；期望%select{整数值|'enable'%select{|, 'full'}1%select{|, 'assume_safety'}2 或 'disable'}0"
 # 'missing context for method declaration'
 HDB791FF5D00C: '方法声明缺少上下文'
 # 'missing context for property implementation declaration'
@@ -24137,35 +24137,35 @@ HC4112B242494: '缺少调试命令'
 # 'missing default argument on parameter'
 H8EC917CC5F93: '参数缺少默认参数'
 # 'missing default argument on parameter %0'
-H8F4C6F0521D4: '参数%0缺少默认参数'
+H8F4C6F0521D4: '参数 %0 缺少默认参数'
 # 'missing field %0 initializer'
-HBCFF05CA88FD: '缺少字段%0初始化器'
+HBCFF05CA88FD: '缺少字段 %0 初始化器'
 # 'missing map type'
 H4AA13FCA7666: '缺少映射类型'
 # 'missing map type modifier'
 H60251948404E: '缺少映射类型修饰符'
 # 'missing numthreads attribute for %0 shader entry'
-HFADE160C1BC1: "'%0'着色器入口缺少numthreads属性"
+HFADE160C1BC1: "'%0' 着色器入口缺少numthreads属性"
 # 'missing object format flag'
 HD57D82290D05: '缺少对象格式标志'
 # "missing or invalid line number following '@' in expected %0"
-H296CBDA95848: '在期望的%0中@后缺少或无效的行号'
+H296CBDA95848: '在期望的 %0 中@后缺少或无效的行号'
 # 'missing parentheses around the size of parameter pack %0'
-HA558CBB9F294: '参数包%0的大小周围缺少括号'
+HA558CBB9F294: '参数包 %0 的大小周围缺少括号'
 # 'missing plugin argument for plugin %0 in %1'
-H8600AE8C89F9: '在%1中，插件%0缺少插件参数'
+H8600AE8C89F9: '在 %1 中，插件 %0 缺少插件参数'
 # 'missing plugin name in %0'
-H4A2F8D6C22D3: '在%0中缺少插件名称'
+H4A2F8D6C22D3: '在 %0 中缺少插件名称'
 # "missing reduction operator, expected '+', '*', 'max', 'min', '&', '|', '^', '&&', or '||', follwed by a ':'"
 H9DF20C9098D2: "缺少规约运算符，期望'+', '*', 'max', 'min', '&', '|', '^', '&&', 或 '||' 后跟一个':'"
 # 'missing return type for function %0; did you mean the constructor name %1?'
-H0096A8359309: '函数%0缺少返回类型；您是否指的是构造函数名称%1？'
+H0096A8359309: '函数 %0 缺少返回类型；您是否指的是构造函数名称 %1？'
 # "missing sanitizer ignorelist: '%0'"
 HE7971DD1E969: "缺少 sanitizer 忽略列表：'%0'"
 # 'missing sentinel in %select{function call|method dispatch|block call}0'
 H10D39CEB9167: '在%select{函数调用|方法分派|块调用}0中缺少哨兵值'
 # 'missing state for %0'
-HCF224168FF82: '%0缺少状态'
+HCF224168FF82: '%0 缺少状态'
 # "missing submodule '%0'"
 H4FF2783EAA28: "缺少子模块 '%0'"
 # 'missing symbol graph output directory, defaulting to working directory'
@@ -24175,7 +24175,7 @@ HC91AE5B6C664: '缺少终止字符%select{‘|’"’}0'
 # "missing terminating ')' character"
 H110B9B84BD50: "缺少终止的 ')' 字符"
 # 'missing type bound %0 for type parameter %1 in %select{@interface|@class}2'
-HCB937BA83DD0: '在%select{@interface|@class}2中的类型参数%1缺少类型边界%0'
+HCB937BA83DD0: '在%select{@interface|@class}2中的类型参数 %1 缺少类型边界 %0'
 # 'mixed CUDA and HIP compilation is not supported'
 HDE7D3706C5B5: '混合 CUDA 和 HIP 编译不受支持'
 # "mixing 'target_clones' specifier mechanisms is permitted for GCC compatibility; use a comma separated sequence of string literals, or a string literal containing a comma-separated list of versions"
@@ -24191,7 +24191,7 @@ HE19598DC2C40: 'mlir-query选项'
 # 'mlir-reduce options'
 H3CAB90C0AD8E: 'mlir-reduce 选项'
 # 'mode %0 is not supported for enumeration types'
-H9D1986A84BDA: '模式%0不支持枚举类型'
+H9D1986A84BDA: '模式 %0 不支持枚举类型'
 # 'mode attribute only supported for integer and floating-point types'
 H759A20BD1268: 'mode属性仅支持整型和浮点类型'
 # 'mode for simplify conditional tail calls'
@@ -24199,37 +24199,37 @@ H7E2CD8BDAB86: '简化条件尾调用的模式'
 # 'moderate strategy'
 H73892DAB539F: '适度策略'
 # 'modification of object of const-qualified type %0 is not allowed in a constant expression'
-H403821CE466D: '对const限定类型%0的对象进行修改在常量表达式中不允许'
+H403821CE466D: '对const限定类型 %0 的对象进行修改在常量表达式中不允许'
 # "modifier '%0' cannot be used along with modifier '%1'"
-HDE467CEB2037: "修饰符'%0'不能与修饰符'%1'一起使用"
+HDE467CEB2037: "修饰符 '%0' 不能与修饰符 '%1' 一起使用"
 # 'modifying constructor parameter %0 that shadows a field of %1'
-H1430708B59D6: '修改构造函数参数%0，该参数覆盖了%1的字段'
+H1430708B59D6: '修改构造函数参数 %0，该参数覆盖了 %1 的字段'
 # 'modularize.\n'
 HA1E9FFD28E50: '模块化。\n'
 # "module %0 does not depend on a module exporting '%1'"
-H85DEF90A3AE0: '模块%0不依赖于导出"%1"的模块'
+H85DEF90A3AE0: '模块 %0 不依赖于导出 "%1" 的模块'
 # "module %0 does not directly depend on a module exporting '%1', which is part of indirectly-used module %2"
-H9D50309367F5: '模块%0不直接依赖于导出"%1"的模块，而该模块属于间接使用的模块%2'
+H9D50309367F5: '模块 %0 不直接依赖于导出 "%1" 的模块，而该模块属于间接使用的模块 %2'
 # "module '%0' %select{in|imported by}4 AST file '%1' found in a different module map file (%2) than when the importing AST file was built (%3)"
-H7F407C161851: "模块'%0' %select{在|被导入的}4AST文件'%1'发现于不同的模块映射文件(%2)，而导入AST文件构建时使用的是(%3)"
+H7F407C161851: "模块 '%0' %select{在|被导入的}4AST文件 '%1' 发现于不同的模块映射文件(%2)，而导入AST文件构建时使用的是(%3)"
 # "module '%0' %select{is incompatible with|requires}1 feature '%2'"
-H4440A0170E90: "模块'%0' %select{与...不兼容|需要}1特性'%2'"
+H4440A0170E90: "模块 '%0' %select{与...不兼容|需要}1特性 '%2'"
 # "module '%0' %select{uses|does not use}1 additional module map '%2'%select{| not}1 used when the module was built"
-HAC53C3FABCDA: "模块'%0' %select{使用|未使用}1附加模块映射'%2'%select{|未}1在模块构建时使用"
+HAC53C3FABCDA: "模块 '%0' %select{使用|未使用}1附加模块映射 '%2'%select{|未}1在模块构建时使用"
 # "module '%0' already re-exported as '%1'"
-H6556B7A46703: "模块'%0'已作为'%1'重新导出"
+H6556B7A46703: "模块 '%0' 已作为 '%1' 重新导出"
 # "module '%0' conflicts with already-imported module '%1': %2"
-HED958876B86C: "模块'%0'与已导入的模块'%1'冲突：%2"
+HED958876B86C: "模块 '%0' 与已导入的模块 '%1' 冲突：%2"
 # "module '%0' in AST file '%1' %select{(imported by AST file '%2') |}4is not defined in any loaded module map file; maybe you need to load '%3'?"
-H951252F32734: "AST文件'%1'中的模块'%0' %select{(被AST文件'%2'导入)|}4未在任何已加载的模块映射文件中定义；是否需要加载'%3'？"
+H951252F32734: "AST文件 '%1' 中的模块 '%0' %select{(被AST文件 '%2' 导入)|}4未在任何已加载的模块映射文件中定义；是否需要加载 '%3'？"
 # "module '%0' is defined in both '%1' and '%2'"
-H9937FAC6E395: "模块'%0'在'%1'和'%2'中均有定义"
+H9937FAC6E395: "模块 '%0' 在 '%1' 和 '%2' 中均有定义"
 # "module '%0' is needed but has not been provided, and implicit use of module files is disabled"
-H8C7DAF453831: "需要模块'%0'但未提供，并且模块文件的隐式使用已禁用"
+H8C7DAF453831: "需要模块 '%0' 但未提供，并且模块文件的隐式使用已禁用"
 # "module '%0' not found"
-H55DF0ED78DC5: "未找到模块'%0'"
+H55DF0ED78DC5: "未找到模块 '%0'"
 # "module '%0' was built in directory '%1' but now resides in directory '%2'"
-H38AD29640B23: "模块'%0'是在目录'%1'构建的，但现在位于目录'%2'"
+H38AD29640B23: "模块 '%0' 是在目录 '%1' 构建的，但现在位于目录 '%2'"
 # "module compilation requires '-fmodules'"
 H6A96D77D9F41: "模块编译需要'-fmodules'选项"
 # 'module declaration can only appear at the top level'
@@ -24289,7 +24289,7 @@ H7FCDBDAE9C59: '移动临时对象会阻止复制省略'
 # 'ms_struct may not produce Microsoft-compatible layouts for classes with base classes or virtual functions'
 H0D36DB1654BA: 'ms_struct 可能无法为具有基类或虚函数的类生成与 Microsoft 兼容的布局'
 # "ms_struct may not produce Microsoft-compatible layouts with fundamental data types with sizes that aren't a power of two"
-H9013C05CB59B: 'ms_struct 可能无法为基本数据类型（其大小不是2的幂次）生成与 Microsoft 兼容的布局'
+H9013C05CB59B: 'ms_struct 可能无法为基本数据类型（其大小不是 2 的幂次）生成与 Microsoft 兼容的布局'
 # 'mtriple'
 H7584397F39BE: 'mtriple'
 # 'multi-character character constant'
@@ -24369,7 +24369,7 @@ H21088B0A235D: '多版本函数的重新声明需要具有相同的 target 属�
 # 'multiversioning attributes cannot be combined'
 HB5E9464B0FCA: '多版本化属性不能组合使用'
 # "must be declared with 'noexcept'"
-H987DB13AD301: "必须用'noexcept'声明"
+H987DB13AD301: "必须用 'noexcept' 声明"
 # 'must be specified at least once!'
 H226887FCC25B: '必须至少指定一次！'
 # 'must explicitly describe intended ownership of an object array parameter'
@@ -24379,19 +24379,19 @@ H10EC7DC2756E: '在获取成员函数地址时必须显式限定其名称'
 # "must handle potential future platforms with '*'"
 H52CBF98EE88A: '必须处理未来平台中可能的"*"'
 # 'must name member using the type of the current context %0'
-H0A063C055ADE: '必须使用当前上下文%0的类型命名该成员'
+H0A063C055ADE: '必须使用当前上下文 %0 的类型命名该成员'
 # "must pass in an explicit %0 gpu architecture to '%1'"
-H748BF240D8AC: "必须向'%1'显式传递%0 GPU架构"
+H748BF240D8AC: "必须向 '%1' 显式传递 %0 GPU架构"
 # "must provide a symbol graph output directory using '--symbol-graph-dir=<directory>'"
 H7FEC01DD8141: "必须使用'--symbol-graph-dir=<目录>'指定符号图输出目录"
 # 'must qualify identifier to find this declaration in dependent base class'
 HB8E730405435: '必须限定标识符才能在依赖基类中查找此声明'
 # "must specify '-fmodule-name=%0' to enter %select{|submodule of }1this module%select{ (current module is %3)|}2"
-HF0DE733FAF70: "必须指定'-fmodule-name=%0'以进入%select{|该模块的子模块}1此模块%select{（当前模块为%3）|}2"
+HF0DE733FAF70: "必须指定'-fmodule-name=%0'以进入%select{|该模块的子模块}1此模块%select{（当前模块为 %3）|}2"
 # 'must specify system root with -isysroot when building a relocatable PCH file'
 H530DD8BE4BB8: '构建可重定位的PCH文件时必须使用-isysroot指定系统根目录'
 # "must use '%1' tag to refer to type %0%select{| in this scope}2"
-H25B19F90B2A8: "必须使用'%1'标签引用类型%0%select{|在此作用域内}2"
+H25B19F90B2A8: "必须使用 '%1' 标签引用类型 %0%select{|在此作用域内}2"
 # 'my-tool options'
 H6F25BE7781B0: 'my-tool 选项'
 # 'name defined in alias declaration must be an identifier'
@@ -24399,11 +24399,11 @@ HF20E175DA10B: '别名声明中定义的名称必须是标识符'
 # 'name defined in concept definition must be an identifier'
 H9F376A6B25D8: '概念定义中定义的名称必须是标识符'
 # 'named bit-field %0 has zero width'
-HB27FCD740169: '命名的位段%0宽度为零'
+HB27FCD740169: '命名的位段 %0 宽度为零'
 # 'named variadic macros are a GNU extension'
 H4A2738C3ADE2: '命名的可变参数宏是GNU扩展'
 # 'namespace %0 defined here'
-H6C2973533802: '命名空间%0在此处定义'
+H6C2973533802: '命名空间 %0 在此处定义'
 # 'namespace alias cannot be inline'
 H69290D9B2469: '命名空间别名不能是内联的'
 # 'namespace alias must be a single identifier'
@@ -24431,9 +24431,9 @@ HEFB4B9AD8E01: '嵌套的命名空间定义是C++17扩展；请分别定义每�
 # 'nested namespace definition is incompatible with C++ standards before C++17'
 H0E35039F1D67: '嵌套的命名空间定义与C++17之前的C++标准不兼容'
 # 'nested parentheses not permitted in %0'
-H34953581058C: '在%0中不允许嵌套的括号'
+H34953581058C: '在 %0 中不允许嵌套的括号'
 # 'nested redefinition of %0'
-H0AC10F45C385: '%0的嵌套重新定义'
+H0AC10F45C385: '%0 的嵌套重新定义'
 # 'nested teams construct here'
 HF6BEE2475F61: '此处的嵌套teams构造'
 # 'nested user conditions in OpenMP context selector not supported (yet)'
@@ -24445,35 +24445,35 @@ H669835729B5F: '从不打印'
 # 'never replace exit value'
 H0750F0A2D157: '从不替换退出值'
 # 'new expression for type %0 contains multiple constructor arguments'
-H0D34CDEC5737: '类型%0的new表达式包含多个构造函数参数'
+H0D34CDEC5737: '类型 %0 的new表达式包含多个构造函数参数'
 # 'new expression for type %0 has incompatible constructor argument of type %1'
-H8E7FF8B53FFB: '类型%0的new表达式具有类型%1的不兼容构造函数参数'
+H8E7FF8B53FFB: '类型 %0 的new表达式具有类型 %1 的不兼容构造函数参数'
 # 'new expression for type %0 requires a constructor argument'
-H55FA18FEEE0E: '类型%0的new表达式需要构造函数参数'
+H55FA18FEEE0E: '类型 %0 的new表达式需要构造函数参数'
 # 'next %select{instance variable declaration|synthesized instance variable}0 is here'
 H6502100189C0: '下一个%select{实例变量声明|合成的实例变量}0在此处'
 # 'next field declaration is here'
 H589A37214DA3: '下一个字段声明在此处'
 # 'no %select{getter|setter}0 defined for property %1'
-HDA010EA6C052: '属性%1未定义%select{getter|setter}0'
+HDA010EA6C052: '属性 %1 未定义 %select{getter|setter}0'
 # 'no %select{struct|interface|union|class|enum}0 named %1 in %2'
-HCA856DA687CE: '在%2中没有名为%1的%select{struct|interface|union|class|enum}0'
+HCA856DA687CE: '在 %2 中没有名为 %1 的 %select{struct|interface|union|class|enum}0'
 # "no 'assign', 'retain', or 'copy' attribute is specified - 'assign' is assumed"
-H5D9A45CF4470: "未指定'assign'、'retain'或'copy'属性，默认使用'assign'"
+H5D9A45CF4470: "未指定 'assign'、'retain' 或 'copy' 属性，默认使用 'assign'"
 # 'no @interface declaration found in class messaging of %0'
-H39108401F4F8: '在%0的类消息中未找到@interface声明'
+H39108401F4F8: '在 %0 的类消息中未找到@interface声明'
 # "no MCU device specified, but '-mhwmult' is set to 'auto', assuming no hardware multiply; use '-mmcu' to specify an MSP430 device, or '-mhwmult' to set the hardware multiply type explicitly"
-HF3E9B95BB7DD: "未指定MCU设备，但'-mhwmult'设置为'auto'，假设没有硬件乘法；使用'-mmcu'指定MSP430设备，或使用'-mhwmult'显式设置硬件乘法类型"
+HF3E9B95BB7DD: "未指定MCU设备，但'-mhwmult'设置为 'auto'，假设没有硬件乘法；使用'-mmcu'指定MSP430设备，或使用'-mhwmult'显式设置硬件乘法类型"
 # 'no PowerPC native vector element order.'
 H49C9870074B0: '不使用PowerPC原生向量元素顺序。'
 # "no analyzer checkers or packages are associated with '%0'"
-H8B728EEF35B9: "没有与'%0'关联的分析检查器或包"
+H8B728EEF35B9: "没有与 '%0' 关联的分析检查器或包"
 # 'no avr-libc installation can be found on the system, cannot link standard libraries'
 H5206EA6489A5: '系统中未找到avr-libc安装，无法链接标准库'
 # 'no candidate function template was found for dependent %select{member|friend}0 function template specialization'
-HC620314BA8FA: '未找到与相关%select{member|friend}0函数模板特化对应的候选函数模板'
+HC620314BA8FA: '未找到与相关 %select{member|friend}0 函数模板特化对应的候选函数模板'
 # "no case matching constant switch condition '%0'"
-HBFE1788B232F: "没有与常量switch条件'%0'匹配的case"
+HBFE1788B232F: "没有与常量switch条件 '%0' 匹配的case"
 # "no closing ']' for '%%[' in scanf format string"
 H5E8D81CB9C26: "scanf格式字符串中的'%%['缺少闭合的']'"
 # 'no corresponding base class here'
@@ -24487,15 +24487,15 @@ H0544B78403CC: '此处没有对应的friend'
 # 'no corresponding superclass here'
 HE11938993661: '此处没有对应的超类'
 # "no declaration found for exported symbol '%0' in dynamic library"
-H247D438751B2: "在动态库中未找到导出符号'%0'的声明"
+H247D438751B2: "在动态库中未找到导出符号 '%0' 的声明"
 # "no declaration was found for exported symbol '%0' in dynamic library"
-H01E907352618: "在动态库中未找到导出符号'%0'的声明"
+H01E907352618: "在动态库中未找到导出符号 '%0' 的声明"
 # "no expected directives found: consider use of '%0-no-diagnostics'"
 H60C61DB5DCD2: "未找到期望的指令；考虑使用'%0-no-diagnostics'"
 # 'no function template matches function template specialization %0'
-H783C344DF4FC: '没有函数模板与函数模板特化%0匹配'
+H783C344DF4FC: '没有函数模板与函数模板特化 %0 匹配'
 # 'no getter method %1 for %select{increment|decrement}0 of property'
-H27A03BEFDE9D: '属性的%select{increment|decrement}0操作没有对应的getter方法%1'
+H27A03BEFDE9D: '属性的 %select{increment|decrement}0 操作没有对应的getter方法 %1'
 # 'no getter method for read from property'
 HC653B7766A2E: '读取属性时没有对应的getter方法'
 # "no handler registered for module format '%0'"
@@ -24509,7 +24509,7 @@ H41C44394DC27: '未找到选择器 %0 的已知 %select{实例|类}1 方法'
 # "no known method %select{%objcinstance1|%objcclass1}0; cast the message send to the method's return type"
 HD141497E30B9: '未找到已知方法 %select{%objcinstance1|%objcclass1}0；请将消息发送转换为目标方法返回类型'
 # "no library '%0' found in the default clang lib directory or in LIBRARY_PATH; use '--libomptarget-%1-bc-path' to specify %1 bitcode library"
-H56082C491F7D: "在默认clang库目录或LIBRARY_PATH中未找到库 '%0'；使用'--libomptarget-%1-bc-path'指定%1比特码库"
+H56082C491F7D: "在默认clang库目录或LIBRARY_PATH中未找到库 '%0'；使用'--libomptarget-%1-bc-path'指定 %1 比特码库"
 # 'no macro named %0'
 HDBF2015FF73B: '没有名为 %0 的宏'
 # 'no matching %0 function for non-allocating placement new expression; include <new>'
@@ -24539,51 +24539,51 @@ H6800794A683C: '%1 中没有成员 %0；尚未实例化该成员'
 # 'no member named %0 in %1'
 H85214E062B3A: '%1 中没有名为 %0 的成员'
 # 'no member named %0 in %1; did you mean %select{|simply }2%3?'
-H5B97925635DE: '在%1中没有名为%0的成员；您是否是指%select{|仅仅 }2%3？'
+H5B97925635DE: '在 %1 中没有名为 %0 的成员；您是否是指%select{|仅仅 }2%3？'
 # "no member named %0 in %1; did you mean to use '->' instead of '.'?"
-HBE0974E3EE78: "在%1中没有名为%0的成员；是否应该使用'->'而不是'.'？"
+HBE0974E3EE78: "在 %1 中没有名为 %0 的成员；是否应该使用'->'而不是'.'？"
 # 'no method with selector %0 is implemented in this translation unit'
-H0CDD4F98E18F: '在此翻译单元中未实现选择器%0对应的方法'
+H0CDD4F98E18F: '在此翻译单元中未实现选择器 %0 对应的方法'
 # 'no module map available for module %0'
-HF688B8490C1B: '模块%0没有可用的模块映射'
+HF688B8490C1B: '模块 %0 没有可用的模块映射'
 # 'no module name provided; specify one with -fmodule-name='
 H99A7BF8D2824: '未提供模块名称；请使用-fmodule-name=指定'
 # "no module named '%0' %select{found|in '%2'}1, parent module must be defined before the submodule"
-H86A38EF918F2: "未找到名为'%0'的模块 %select{找到|在'%2'中}1；父模块必须在子模块之前定义"
+H86A38EF918F2: "未找到名为 '%0' 的模块 %select{找到|在 '%2' 中}1；父模块必须在子模块之前定义"
 # "no module named '%0' declared in module map file '%1'"
-HABF2F4633281: "模块映射文件'%1'中未声明名为'%0'的模块"
+HABF2F4633281: "模块映射文件 '%1' 中未声明名为 '%0' 的模块"
 # "no module named '%0' in '%1'"
-H658500ACD8C1: "在'%1'中没有名为'%0'的模块"
+H658500ACD8C1: "在 '%1' 中没有名为 '%0' 的模块"
 # "no module named '%0' visible from '%1'"
-HA7094B5AEB21: "在'%1'中不可见名为'%0'的模块"
+HA7094B5AEB21: "在 '%1' 中不可见名为 '%0' 的模块"
 # "no more 'if' clause is allowed"
-H8F7A1C6703AA: "不允许再有'if'子句"
+H8F7A1C6703AA: "不允许再有 'if' 子句"
 # "no more than one option '--config' is allowed"
 H3089388E4475: "选项'--config'最多允许指定一次"
 # 'no multilib found matching flags: %0'
-HCDE4340CFBD3: '未找到匹配标志%0的multilib'
+HCDE4340CFBD3: '未找到匹配标志 %0 的multilib'
 # 'no namespace named %0 in %1; did you mean %select{|simply }2%3?'
-HF6FEAE5E55D9: '在%1中没有名为%0的命名空间；您是否是指%select{|仅仅 }2%3？'
+HF6FEAE5E55D9: '在 %1 中没有名为 %0 的命名空间；您是否是指%select{|仅仅 }2%3？'
 # 'no namespace named %0; did you mean %1?'
-H81CE4465B841: '没有名为%0的命名空间；您是否是指%1？'
+H81CE4465B841: '没有名为 %0 的命名空间；您是否是指 %1？'
 # 'no newline at end of file'
 HC3F31DC1712E: '文件末尾没有换行符'
 # 'no output file specified'
 HA94EBB9ACB5A: '未指定输出文件'
 # 'no previous extern declaration for non-static variable %0'
-H8B284B72F880: '非静态变量%0没有之前的extern声明'
+H8B284B72F880: '非静态变量 %0 没有之前的extern声明'
 # 'no previous prototype for function %0'
-H03B77D9B5049: '函数%0没有之前的原型声明'
+H03B77D9B5049: '函数 %0 没有之前的原型声明'
 # 'no profile data available for file "%0"'
-H59152796471E: '文件"%0"没有可用的性能分析数据'
+H59152796471E: '文件 "%0" 没有可用的性能分析数据'
 # 'no return statement in %select{constexpr|consteval}0 function'
-H6CABFAB2482E: '在%select{constexpr|consteval}0函数中没有return语句'
+H6CABFAB2482E: '在 %select{constexpr|consteval}0 函数中没有return语句'
 # "no submodule named %0 in module '%1'"
-H2B7BA310F788: "模块'%1'中没有名为%0的子模块"
+H2B7BA310F788: "模块 '%1' 中没有名为 %0 的子模块"
 # "no submodule named %0 in module '%1'; did you mean '%2'?"
-H7D6A5E92FB55: "模块'%1'中没有名为%0的子模块；是否是指'%2'？"
+H7D6A5E92FB55: "模块 '%1' 中没有名为 %0 的子模块；是否是指 '%2'？"
 # "no submodule named %0 in module '%1'; using top level '%2'"
-H5C502E1660AA: "模块'%1'中没有名为%0的子模块；使用顶层的'%2'"
+H5C502E1660AA: "模块 '%1' 中没有名为 %0 的子模块；使用顶层的 '%2'"
 # "no such %select{public|private|project}1 header file: '%0'"
 H6EFAEBB81765: "没有这样的%select{公开|私有|项目}1头文件：'%0'"
 # "no such excluded %select{public|private}0 header file: '%1'"
@@ -24591,59 +24591,59 @@ HED06FD077272: "没有这样的排除%select{公开|私有}0头文件：'%1'"
 # "no such file or directory: '%0'"
 HE170FBCF53FC: "没有这样的文件或目录：'%0'"
 # "no such file or directory: '%0'; did you mean '%1'?"
-HE112F2418E57: "没有这样的文件或目录：'%0'；是否是指'%1'？"
+HE112F2418E57: "没有这样的文件或目录：'%0'；是否是指 '%1'？"
 # "no such include directory: '%0'"
 H7E37FF613F8F: "没有这样的包含目录：'%0'"
 # "no such sysroot directory: '%0'"
 H7EBC246FEEA8: "没有这样的sysroot目录：'%0'"
 # 'no suitable member %0 in %1'
-H3750344F18EF: '%1中没有合适的成员%0'
+H3750344F18EF: '%1 中没有合适的成员 %0'
 # "no suitable precompiled header file found in directory '%0'"
-HC9D05A0684EB: "目录'%0'中未找到预编译头文件"
+HC9D05A0684EB: "目录 '%0' 中未找到预编译头文件"
 # 'no target microcontroller specified, please pass -mmcu=<mcu name>'
 H861E68DCEBF9: '未指定目标微控制器，请通过-mmcu=<mcu名称>传递参数'
 # 'no template named %0'
-HFC0C70B06D89: '没有名为%0的模板'
+HFC0C70B06D89: '没有名为 %0 的模板'
 # 'no template named %0 in %1'
-H16DB7E6BC24D: '%1中没有名为%0的模板'
+H16DB7E6BC24D: '%1 中没有名为 %0 的模板'
 # 'no template named %0 in %1; did you mean %select{|simply }2%3?'
-HCDFE5581F7D6: '%1中没有名为%0的模板；是否是指%select{|简单}2%3？'
+HCDFE5581F7D6: '%1 中没有名为 %0 的模板；是否是指%select{|简单}2%3？'
 # 'no template named %0; did you mean %1?'
-H32AFF6E21FDC: '没有名为%0的模板；是否是指%1？'
+H32AFF6E21FDC: '没有名为 %0 的模板；是否是指 %1？'
 # 'no type named %0 in %1'
-H6E87E8CAFF42: '%1中没有名为%0的类型'
+H6E87E8CAFF42: '%1 中没有名为 %0 的类型'
 # 'no type named %0 in %1; did you mean %select{|simply }2%3?'
-H014C7B262D03: '%1中没有名为%0的类型；是否是指%select{|简单}2%3？'
+H014C7B262D03: '%1 中没有名为 %0 的类型；是否是指%select{|简单}2%3？'
 # "no type named 'type' in %0; 'enable_if' cannot be used to disable this declaration"
-H03B3775679FC: "%0中没有名为'type'的类型；'enable_if'无法用于禁用此声明"
+H03B3775679FC: "%0 中没有名为 'type' 的类型；'enable_if' 无法用于禁用此声明"
 # 'no type or protocol named %0'
-HFF0D89AB2752: '没有名为%0的类型或协议'
+HFF0D89AB2752: '没有名为 %0 的类型或协议'
 # "no valid clauses specified in OpenACC 'declare' directive"
 H136795D57206: "在OpenACC 'declare' 指令中未指定有效的子句"
 # 'no variable template matches specialization; did you mean to use %0 as function template instead?'
-H702E78FBEC31: '没有与特化匹配的变量模板；是否应将%0用作函数模板？'
+H702E78FBEC31: '没有与特化匹配的变量模板；是否应将 %0 用作函数模板？'
 # 'no variable template matches%select{| partial}0 specialization'
 H0903C7695A91: '没有与%select{| 部分}0 特化匹配的变量模板'
 # 'no viable candidate for explicit instantiation of %0'
-HAEBC7520AFB0: '显式实例化%0时没有可用的候选项'
+HAEBC7520AFB0: '显式实例化 %0 时没有可用的候选项'
 # 'no viable constructor %select{copying variable|copying parameter|initializing template parameter|returning object|initializing statement expression result|throwing object|copying member subobject|copying array element|allocating object|copying temporary|initializing base subobject|initializing vector element|capturing value}0 of type %1'
-HC9B75808C9E9: '在类型%1的%select{复制变量|复制参数|初始化模板参数|返回对象|初始化语句表达式结果|抛出对象|复制成员子对象|复制数组元素|分配对象|复制临时对象|初始化基类子对象|初始化向量元素|捕获值}0时，没有可用的构造函数'
+HC9B75808C9E9: '在类型 %1 的%select{复制变量|复制参数|初始化模板参数|返回对象|初始化语句表达式结果|抛出对象|复制成员子对象|复制数组元素|分配对象|复制临时对象|初始化基类子对象|初始化向量元素|捕获值}0时，没有可用的构造函数'
 # 'no viable constructor %select{copying variable|copying parameter|initializing template parameter|returning object|initializing statement expression result|throwing object|copying member subobject|copying array element|allocating object|copying temporary|initializing base subobject|initializing vector element|capturing value}0 of type %1; C++98 requires a copy constructor when binding a reference to a temporary'
-HBD2DEF3D3EA1: '在类型%1的%select{复制变量|复制参数|初始化模板参数|返回对象|初始化语句表达式结果|抛出对象|复制成员子对象|复制数组元素|分配对象|复制临时对象|初始化基类子对象|初始化向量元素|捕获值}0时，没有可用的构造函数；C++98在绑定临时对象到引用时需要复制构造函数'
+HBD2DEF3D3EA1: '在类型 %1 的%select{复制变量|复制参数|初始化模板参数|返回对象|初始化语句表达式结果|抛出对象|复制成员子对象|复制数组元素|分配对象|复制临时对象|初始化基类子对象|初始化向量元素|捕获值}0时，没有可用的构造函数；C++98在绑定临时对象到引用时需要复制构造函数'
 # 'no viable constructor or deduction guide for deduction of template arguments of %0'
-HECA595B57B5C: '为%0的模板参数推导没有可用的构造函数或推导指引'
+HECA595B57B5C: '为 %0 的模板参数推导没有可用的构造函数或推导指引'
 # 'no viable conversion%diff{ from $ to incomplete type $|}0,1'
 H0DDC152C267D: '无法进行%diff{到不完整类型的转换|}0,1有效转换'
 # 'no viable conversion%select{%diff{ from $ to $|}1,2|%diff{ from returned value of type $ to function return type $|}1,2}0'
 H742AD0829398: '无法进行%select{%diff{从$到$|}1,2|%diff{从类型$的返回值到函数返回类型$|}1,2}0有效转换'
 # 'no viable destructor found for class %0'
-HE8AA8B1D9E66: '未找到类%0的可用析构函数'
+HE8AA8B1D9E66: '未找到类 %0 的可用析构函数'
 # "no viable overloaded '%0'"
-H85F4D23A3BAD: "没有可用的重载'%0'"
+H85F4D23A3BAD: "没有可用的重载 '%0'"
 # 'no viable overloaded operator[] for type %0'
-H2EF71DBEE631: '类型%0没有可用的重载operator[]'
+H2EF71DBEE631: '类型 %0 没有可用的重载operator[]'
 # 'no visible @interface for %0 declares the selector %1'
-HF35FE2A8D9B7: '@interface %0未声明选择器%1'
+HF35FE2A8D9B7: '@interface %0 未声明选择器 %1'
 # 'noexcept expressions are incompatible with C++98'
 H770DCD42AD88: 'noexcept表达式与C++98不兼容'
 # 'noexcept specifications are incompatible with C++98'
@@ -24651,69 +24651,69 @@ HCDFCAD5EB464: 'noexcept说明与C++98不兼容'
 # 'non-ASM statement in naked function is not supported'
 H13FAFC759C77: '带有非ASM语句的裸函数不被支持'
 # 'non-class friend type %0 is a C++11 extension'
-HD60A5C8C49AC: '非类友元类型%0是C++11扩展'
+HD60A5C8C49AC: '非类友元类型 %0 是C++11扩展'
 # 'non-class friend type %0 is incompatible with C++98'
-H4D0DB388513A: '非类友元类型%0与C++98不兼容'
+H4D0DB388513A: '非类友元类型 %0 与C++98不兼容'
 # 'non-const static data member must be initialized out of line'
 HFA5187DD3DCB: '非const静态数据成员必须在类外初始化'
 # 'non-constant static local variable in inline function may be different in different files'
 HDAC621E8867A: '内联函数中的非const静态局部变量在不同文件中可能不同'
 # 'non-constant-expression cannot be narrowed from type %0 to %1 in initializer list'
-H48217DABAA7D: '非常量表达式不能在初始化列表中将类型%0缩小为%1'
+H48217DABAA7D: '非常量表达式不能在初始化列表中将类型 %0 缩小为 %1'
 # 'non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11'
-H996365ACA997: '非常量表达式不能在C++11的初始化列表中将类型%0缩小为%1'
+H996365ACA997: '非常量表达式不能在C++11的初始化列表中将类型 %0 缩小为 %1'
 # 'non-consteval function %0 cannot override a consteval function'
-H3BE45C7BF2C1: '非consteval函数%0不能覆盖consteval函数'
+H3BE45C7BF2C1: '非consteval函数 %0 不能覆盖consteval函数'
 # 'non-constexpr comparison function declared here'
 H6CDFA8CCBBD8: '在此处声明的非constexpr比较函数'
 # 'non-constexpr comparison function would be used to compare %select{|member %1|base class %1}0'
-HFFB83E06B051: '非constexpr比较函数将用于比较%select{|成员%1|基类%1}0'
+HFFB83E06B051: '非constexpr比较函数将用于比较%select{|成员 %1|基类 %1}0'
 # 'non-deducible template parameter %0'
-HD419F387C770: '非推导的模板参数%0'
+HD419F387C770: '非推导的模板参数 %0'
 # 'non-default #pragma pack value changes the alignment of struct or union members in the included file'
 H2C52662649BE: '非默认的#pragma pack值会改变包含文件中结构体或联合体成员的对齐方式'
 # "non-default visibility cannot be applied to 'dllimport' declaration"
-H2A9EC7D43705: "'dllimport'声明无法应用非默认可见性"
+H2A9EC7D43705: "'dllimport' 声明无法应用非默认可见性"
 # 'non-defining declaration of enumeration with a fixed underlying type is only permitted as a standalone declaration%select{|; missing list of enumerators?}0'
 H4D151B6B2BF9: '具有固定基础类型的枚举的非定义声明仅允许作为独立声明%select{|; 缺少枚举列表？}0'
 # 'non-deleted function %0 cannot override a deleted function'
-H2F21A881D5B2: '非删除函数%0不能覆盖已删除的函数'
+H2F21A881D5B2: '非删除函数 %0 不能覆盖已删除的函数'
 # 'non-extern declaration of %0 follows extern declaration'
-H7E386503A2B6: '%0的非extern声明跟在extern声明之后'
+H7E386503A2B6: '%0 的非extern声明跟在extern声明之后'
 # 'non-friend class member %0 cannot have a qualified name'
-H01BBFAF999D6: '非友元类成员%0不能有合格名称'
+H01BBFAF999D6: '非友元类成员 %0 不能有合格名称'
 # 'non-inline external definitions are not permitted in C++ header units'
 H0E67412E5EDC: '不允许在C++头单元中使用非内联外部定义'
 # 'non-inline namespace cannot be reopened as inline'
 H43CE8E47A824: '非内联命名空间不能作为内联重新打开'
 # 'non-literal type %0 cannot be used in a constant expression'
-HFCBBB3F7D771: '非字面类型%0不能用于常量表达式'
+HFCBBB3F7D771: '非字面类型 %0 不能用于常量表达式'
 # 'non-local lambda expression cannot have a capture-default'
 H2B075ACEF012: '非局部lambda表达式不能有捕获默认值'
 # 'non-local variable with sizeless type %0'
-H92600D86A0C5: '具有无大小类型%0的非局部变量'
+H92600D86A0C5: '具有无大小类型 %0 的非局部变量'
 # 'non-namespace scope %0 cannot have a literal operator member'
-H266845A5FE4C: '非命名空间作用域%0不能有字面运算符成员'
+H266845A5FE4C: '非命名空间作用域 %0 不能有字面运算符成员'
 # 'non-object type %0 is not assignable'
-H8FB33F67F675: '非对象类型%0不可赋值'
+H8FB33F67F675: '非对象类型 %0 不可赋值'
 # "non-pointer argument to '__builtin_assume_aligned' is not allowed"
-HD960D71E3301: "传递给'__builtin_assume_aligned'的非指针参数不允许"
+HD960D71E3301: "传递给 '__builtin_assume_aligned' 的非指针参数不允许"
 # 'non-pointer operand type %0 incompatible with %select{NULL|nullptr}1'
-H90B6AFB986DF: '非指针操作数类型%0与%select{NULL|nullptr}1不兼容'
+H90B6AFB986DF: '非指针操作数类型 %0 与 %select{NULL|nullptr}1 不兼容'
 # "non-portable path to file '%0'; specified path differs in case from file name on disk"
-H43FE55A52897: "文件'%0'的路径不可移植；指定的路径与磁盘上的文件名大小写不同"
+H43FE55A52897: "文件 '%0' 的路径不可移植；指定的路径与磁盘上的文件名大小写不同"
 # 'non-predefined allocator must have traits specified'
 HFFB74BA64E52: '非预定义分配器必须指定其特性'
 # 'non-static data member %0 cannot be declared as a template'
-HEE38B2049618: '非静态数据成员%0不能声明为模板'
+HEE38B2049618: '非静态数据成员 %0 不能声明为模板'
 # 'non-static data member cannot be constexpr%select{; did you intend to make it %select{const|static}0?|}1'
-H19D13A6885F4: '非静态数据成员不能声明为constexpr%select{；是否打算将其声明为%select{const|static}0？|}1'
+H19D13A6885F4: '非静态数据成员不能声明为constexpr%select{；是否打算将其声明为 %select{const|static}0？|}1'
 # 'non-static data member defined out-of-line'
 HC4D58BAF82DF: '非静态数据成员在外部定义'
 # 'non-static declaration of %0 follows static declaration'
-H25169BF9CE09: '%0的非静态声明跟在静态声明之后'
+H25169BF9CE09: '%0 的非静态声明跟在静态声明之后'
 # 'non-static member %0 found in multiple base-class subobjects of type %1:%2'
-H1D1EE8E2CCD9: '在类型%1的多个基类子对象中找到非静态成员%0：%2'
+H1D1EE8E2CCD9: '在类型 %1 的多个基类子对象中找到非静态成员 %0：%2'
 # 'non-template declaration found by name lookup'
 HF380F2D95EAA: '名称查找找到非模板声明'
 # 'non-template friend declaration with a requires clause must be a definition'
@@ -24725,17 +24725,17 @@ H5E1276462F94: '非模板声明在此处'
 # 'non-templated function cannot have a requires clause'
 H82190871139C: '非模板函数不能带有requires子句'
 # 'non-thread-local declaration of %0 follows thread-local declaration'
-H015D893F1487: '%0的非线程局部声明跟在线程局部声明之后'
+H015D893F1487: '%0 的非线程局部声明跟在线程局部声明之后'
 # 'non-trivial destruction of lifetime-extended temporary with type %0 used in the result of a constant expression is not yet supported'
-HD2339C077B90: '在常量表达式的结果中使用类型%0的生命周期扩展临时对象的非平凡析构尚未被支持'
+HD2339C077B90: '在常量表达式的结果中使用类型 %0 的生命周期扩展临时对象的非平凡析构尚未被支持'
 # 'non-trivial destruction of type %0 in a constant expression is not supported'
-HE2CD4D9E53E2: '类型%0在常量表达式中的非平凡析构不被支持'
+HE2CD4D9E53E2: '类型 %0 在常量表达式中的非平凡析构不被支持'
 # 'non-trivially copyable type %0 cannot be used in a boxed expression'
-HB2216F42639D: '非平凡可复制的类型%0不能用于装箱表达式'
+HB2216F42639D: '非平凡可复制的类型 %0 不能用于装箱表达式'
 # 'non-type declaration found by destructor name lookup'
 HB02DCE8A7FF1: '析构函数名称查找找到非类型声明'
 # "non-type template argument '%0' is invalid"
-H2399CD2B5610: "非类型模板实参'%0'无效"
+H2399CD2B5610: "非类型模板实参 '%0' 无效"
 # 'non-type template argument containing a dereference operation is a Microsoft extension'
 HD4EF29A775AB: '包含解引用操作的非类型模板实参是微软扩展'
 # 'non-type template argument does not refer to an object or function'
@@ -24827,9 +24827,9 @@ HF77D5E6601B3: "不在'#pragma clang assume_nonnull'指令范围内"
 # "not currently inside '#pragma unsafe_buffer_usage'"
 H658512A345D7: "不在'#pragma unsafe_buffer_usage'指令范围内"
 # 'not enough variable arguments in %0 declaration to fit a sentinel'
-H9930B56495BC: '%0声明中的可变参数数量不足以容纳哨兵'
+H9930B56495BC: '%0 声明中的可变参数数量不足以容纳哨兵'
 # 'not packing field %0 as it is non-POD for the purposes of layout'
-H7FBA81FDAA18: '由于布局目的，字段%0不是POD类型，因此不会被压缩'
+H7FBA81FDAA18: '由于布局目的，字段 %0 不是POD类型，因此不会被压缩'
 # 'not-yet-instantiated member is declared here'
 HACFD1F41F676: '尚未实例化的成员在此处声明'
 # 'null character ignored'
@@ -24837,25 +24837,25 @@ H6B4B3A47C8AC: '空字符被忽略'
 # 'null character(s) preserved in %select{char|string}0 literal'
 H062C86F6116B: '在%select{字符|字符串}0字面量中保留空字符'
 # 'null non-type template argument must be cast to template parameter type %0'
-HDDA635486EF3: '空的非类型模板参数必须转换为模板参数类型%0'
+HDDA635486EF3: '空的非类型模板参数必须转换为模板参数类型 %0'
 # 'null non-type template argument of type %0 does not match template parameter of type %1'
-HCF293B48A07C: '类型%0的空非类型模板参数与类型%1的模板参数不匹配'
+HCF293B48A07C: '类型 %0 的空非类型模板参数与类型 %1 的模板参数不匹配'
 # 'null passed to a callee that requires a non-null argument'
 H5F7D096FCE08: '将空值传递给需要非空参数的调用方'
 # 'null returned from %select{function|method}0 that requires a non-null return value'
 HEA9F26CD4560: '从需要非空返回值的%select{函数|方法}0返回空值'
 # 'nullability keyword %0 cannot be applied to multi-level pointer type %1'
-H9F63F0EFF7CC: '空值限定符%0不能应用于多级指针类型%1'
+H9F63F0EFF7CC: '空值限定符 %0 不能应用于多级指针类型 %1'
 # 'nullability specifier %0 cannot be applied to non-pointer type %1'
-HA1F5D87BE3DF: '空值限定符%0不能应用于非指针类型%1'
+HA1F5D87BE3DF: '空值限定符 %0 不能应用于非指针类型 %1'
 # 'nullability specifier %0 cannot be applied to non-pointer type %1; did you mean to apply the specifier to the %select{pointer|block pointer|member pointer|function pointer|member function pointer}2?'
-H3E269F064E84: '空值限定符%0不能应用于非指针类型%1；是否应将限定符应用于%select{指针|块指针|成员指针|函数指针|成员函数指针}2？'
+H3E269F064E84: '空值限定符 %0 不能应用于非指针类型 %1；是否应将限定符应用于%select{指针|块指针|成员指针|函数指针|成员函数指针}2？'
 # 'nullability specifier %0 conflicts with existing specifier %1'
-H4421DC48369F: '空值限定符%0与现有限定符%1冲突'
+H4421DC48369F: '空值限定符 %0 与现有限定符 %1 冲突'
 # 'number of elements must be either one or match the size of the vector'
-H2A474F4275FA: '元素数量必须为1或与向量的大小匹配'
+H2A474F4275FA: '元素数量必须为 1 或与向量的大小匹配'
 # 'number of entries per line (default 256)'
-H7D63977C73C8: '每行条目数（默认256）'
+H7D63977C73C8: '每行条目数（默认 256）'
 # 'number of functions to display when printing the top largest differences in function activity'
 H4322F776E088: '显示函数活跃度差异最大的前N个函数数量'
 # 'number of hottest functions to print aggregated profile quality stats of.'
@@ -24875,29 +24875,29 @@ HDEB46CD09A6E: 'obj2yaml 选项'
 # 'objc_precise_lifetime is not meaningful for %select{__unsafe_unretained|__autoreleasing}0 objects'
 H3B4A7538E1D6: 'objc精准生命周期对%select{__unsafe_unretained|__autoreleasing}0对象没有意义'
 # 'objc_precise_lifetime only applies to retainable types; type here is %0'
-HCB888D9DBEF6: 'objc精准生命周期仅适用于可保留类型；此处类型为%0'
+HCB888D9DBEF6: 'objc精准生命周期仅适用于可保留类型；此处类型为 %0'
 # 'objc_root_class attribute may only be specified on a root class declaration'
 H8B7E866F5F47: 'objc_root_class属性只能在根类声明中指定'
 # 'object backing %select{|the pointer }0%1 will be destroyed at the end of the full-expression'
-H4CCEF5B24A9C: '支撑%select{|指针 }0%1的对象将在完整表达式结束时被销毁'
+H4CCEF5B24A9C: '支撑%select{|指针 }0%1 的对象将在完整表达式结束时被销毁'
 # 'object backing the pointer %0 will be destroyed at the end of the full-expression'
-H4314D747B320: '支撑指针%0的对象将在完整表达式结束时被销毁'
+H4314D747B320: '支撑指针 %0 的对象将在完整表达式结束时被销毁'
 # 'object backing the pointer will be destroyed at the end of the full-expression'
 HCBDFA4406EFB: '支撑指针的对象将在完整表达式结束时被销毁'
 # 'object expression of non-scalar type %0 cannot be used in a pseudo-destructor expression'
-H8E297F831414: '非标量类型%0的对象表达式不能用于伪析构表达式'
+H8E297F831414: '非标量类型 %0 的对象表达式不能用于伪析构表达式'
 # "object format flags cannot be used with '%0' conversion specifier"
-HAF558B2410E4: "对象格式标志不能与'%0'转换说明符一起使用"
+HAF558B2410E4: "对象格式标志不能与 '%0' 转换说明符一起使用"
 # 'object of type %0 cannot be %select{constructed|copied|moved|assigned|assigned|destroyed}1 because its %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}1 is implicitly deleted'
-H828A944AA309: '类型%0的对象无法%select{构造|拷贝|移动|赋值|赋值|销毁}1，因为其%select{默认构造函数|拷贝构造函数|移动构造函数|拷贝赋值运算符|移动赋值运算符|析构函数}1已被隐式删除'
+H828A944AA309: '类型 %0 的对象无法%select{构造|拷贝|移动|赋值|赋值|销毁}1，因为其%select{默认构造函数|拷贝构造函数|移动构造函数|拷贝赋值运算符|移动赋值运算符|析构函数}1已被隐式删除'
 # 'object of type %0 cannot be compared because its %1 is implicitly deleted'
-H4465935A9154: '类型%0的对象无法进行比较，因为其%1已被隐式删除'
+H4465935A9154: '类型 %0 的对象无法进行比较，因为其 %1 已被隐式删除'
 # 'object of type %0 cannot be placed in read-only memory'
-HD27A532EA3C9: '类型%0的对象无法放置在只读内存中'
+HD27A532EA3C9: '类型 %0 的对象无法放置在只读内存中'
 # 'object of type %0 is not compatible with %select{array element type|dictionary key type|dictionary value type}1 %2'
-HBDF524B06F4F: '类型%0的对象与%select{数组元素类型|字典键类型|字典值类型}1 %2不兼容'
+HBDF524B06F4F: '类型 %0 的对象与%select{数组元素类型|字典键类型|字典值类型}1 %2 不兼容'
 # "object whose reference is captured by '%0' will be destroyed at the end of the full-expression"
-H1329A74CEAA1: "被'%0'捕获引用的对象将在完整表达式结束时被销毁"
+H1329A74CEAA1: "被 '%0' 捕获引用的对象将在完整表达式结束时被销毁"
 # 'object whose reference is captured will be destroyed at the end of the full-expression'
 H04404B93E557: '被捕获引用的对象将在完整表达式结束时被销毁'
 # 'octal integer literals are a C2y extension'
@@ -24907,29 +24907,29 @@ H0A7A0AD8FA23: '八进制整数字面量是Clang扩展'
 # 'octal integer literals are incompatible with standards before C2y'
 HFF58B98B1092: '八进制整数字面量与C2y之前的语言标准不兼容'
 # "octal literals without a '0o' prefix are deprecated"
-H297C91C7799F: "未带'0o'前缀的八进制字面量已被弃用"
+H297C91C7799F: "未带 '0o' 前缀的八进制字面量已被弃用"
 # 'offset of asan shadow mapping [EXPERIMENTAL]'
 HB87160E3C269: 'asan shadow映射的偏移量[实验性]'
 # 'offset of on non-POD type %0'
-H3798D618C09F: '非POD类型%0的结构体成员偏移量'
+H3798D618C09F: '非POD类型 %0 的结构体成员偏移量'
 # 'offset of on non-standard-layout type %0'
-H1C1DF95C948D: '非标准布局类型%0的结构体成员偏移量'
+H1C1DF95C948D: '非标准布局类型 %0 的结构体成员偏移量'
 # 'offset-based plaintext format'
 H4A173EEFA114: '基于偏移的明文格式'
 # 'offsetof of incomplete type %0'
-H01B4054FE86A: 'offsetof的参数%0是不完整类型'
+H01B4054FE86A: 'offsetof的参数 %0 是不完整类型'
 # 'offsetof requires array type, %0 invalid'
-H72E546984F9B: 'offsetof需要数组类型，%0无效'
+H72E546984F9B: 'offsetof需要数组类型，%0 无效'
 # 'offsetof requires struct, union, or class type, %0 invalid'
-H1EED7971DB36: 'offsetof需要结构体、联合或类类型，%0无效'
+H1EED7971DB36: 'offsetof需要结构体、联合或类类型，%0 无效'
 # "old syntax '%0' on '%1' clause was deprecated, use new syntax '%2'"
-H62AFC50986BB: "'%1'子句中的旧语法'%0'已弃用，请改用新语法'%2'"
+H62AFC50986BB: "'%1' 子句中的旧语法 '%0' 已弃用，请改用新语法 '%2'"
 # 'omit the namespace to add attributes to the most-recently pushed attribute group'
 H33451023019A: '省略命名空间以将属性添加到最近添加的属性组'
 # 'omitting the parameter name in a function definition is a C23 extension'
 H239CD59B1E97: '在函数定义中省略参数名是C23扩展'
 # 'on M-profile architectures %0 attribute is not supported on targets missing %1; specify an appropriate -march= or -mcpu='
-HF63DAE65A9BA: '在M架构上，%0属性在缺少%1的目标上不受支持；请指定适当的-march=或-mcpu='
+HF63DAE65A9BA: '在M架构上，%0 属性在缺少 %1 的目标上不受支持；请指定适当的-march=或-mcpu='
 # 'one cluster per opcode'
 H571A5AC320D2: '每个操作码一个簇'
 # "one of 'for', 'parallel', 'sections' or 'taskgroup' is expected"
@@ -24937,13 +24937,13 @@ HA318D6E65846: "期望其中一个：'for', 'parallel', 'sections' 或 'taskgrou
 # 'one possibility'
 HF5AE3D1F7A2D: '一种可能'
 # "only %select{'omp_priv' or 'omp_orig'|'omp_in' or 'omp_out'}0 variables are allowed in %select{initializer|combiner}0 expression"
-HBFBFE733ACC9: "在%select{initializer|combiner}0表达式中，仅允许%select{'omp_priv'或'omp_orig'|'omp_in'或'omp_out'}0变量"
+HBFBFE733ACC9: "在 %select{initializer|combiner}0 表达式中，仅允许%select{'omp_priv' 或 'omp_orig'|'omp_in' 或 'omp_out'}0变量"
 # "only '*' can be exported from an inferred submodule"
 HB1E7869E1AA8: "只能从推导的子模块导出'*'"
 # "only 'device_type(any)' clause is allowed with indirect clause"
 H60FE040D9778: "间接子句仅允许使用'device_type(any)'子句"
 # "only 'unavailable' and 'deprecated' are supported for Swift availability"
-H711C14834055: "Swift可用性仅支持'unavailable'和'deprecated'"
+H711C14834055: "Swift可用性仅支持 'unavailable' 和 'deprecated'"
 # 'only a single match extension allowed per OpenMP context selector'
 H54ED4E173E0C: '每个OpenMP上下文选择器仅允许一个匹配扩展'
 # 'only allow matching call instructions if the name and type signature match.'
@@ -24967,19 +24967,19 @@ H0BDC0C1C20D8: '只有函数可以具有已删除的定义'
 # 'only insert instrumentation on hot functions (needs profile, default: false)'
 H6921A5326E9E: '仅在热点函数中插入分析代码（需要分析资料，默认：false）'
 # "only loop iteration variables are allowed in 'lastprivate' clause in 'omp %0' directives"
-H93109DDAC062: "在'omp %0'指令的'lastprivate'子句中仅允许循环迭代变量"
+H93109DDAC062: "在'omp %0'指令的 'lastprivate' 子句中仅允许循环迭代变量"
 # "only loop iteration variables are allowed in 'linear' clause in distribute directives"
-HB4FBF6AB0B0A: "在distribute指令的'linear'子句中仅允许循环迭代变量"
+HB4FBF6AB0B0A: "在distribute指令的 'linear' 子句中仅允许循环迭代变量"
 # 'only one %0 clause can appear on a requires directive in a single translation unit'
-H67EC4B23D848: '在单个翻译单元中，requires子句只能出现一个%0子句'
+H67EC4B23D848: '在单个翻译单元中，requires子句只能出现一个 %0 子句'
 # 'only one element declaration is allowed'
 HB7E0C8F27CB5: '只能声明一个元素'
 # "only one expression allowed in '%0' clause"
-H200100A1AF70: "在'%0'子句中只能有一个表达式"
+H200100A1AF70: "在 '%0' 子句中只能有一个表达式"
 # 'only one offload target is supported'
 H36578B307452: '仅支持一个卸载目标'
 # "only one parameter on 'main' declaration"
-H09469DD0E50E: "'main'声明只能有一个参数"
+H09469DD0E50E: "'main' 声明只能有一个参数"
 # 'only perform sctc when branch direction is preserved'
 HF40E26771C18: '仅在分支方向被保留时执行sctc'
 # 'only promote call targets eligible for inlining'
@@ -25009,29 +25009,29 @@ H35599F0992E5: '仅顶级模块可以作为公共模块重新导出'
 # 'only use samples from process with specified PID'
 HE4657121A5A3: '仅使用指定PID的进程的采样数据'
 # "only variable %0 is allowed in map clauses of this 'omp declare mapper' directive"
-HCD77D6699FCF: "在此'omp declare mapper'指令的map子句中，仅允许变量%0"
+HCD77D6699FCF: "在此'omp declare mapper'指令的map子句中，仅允许变量 %0"
 # "only variables can be arguments to '#pragma unused'"
 H454069F49B2C: "'#pragma unused'的参数只能是变量"
 # "only virtual member functions can be marked '%0'"
-H88BCFFA5846F: '只有虚成员函数可以被标记为"%0"'
+H88BCFFA5846F: '只有虚成员函数可以被标记为 "%0"'
 # 'only zero-length WebAssembly tables are currently supported'
 H834ECF2F9D5B: '当前仅支持零长度的WebAssembly表'
 # 'opcode to measure, by index, or -1 to measure all opcodes'
 H04C71CF551B6: '要测量的指令码，通过索引指定，或-1表示测量所有指令码'
 # "operand argument to %select{overflow builtin|checked integer operation}0 must be an integer type %select{|other than plain 'char', 'bool', bit-precise, or an enumeration }0(%1 invalid)"
-H232C02FD2560: '%select{溢出内建函数|带检查的整数运算}0的运算数参数必须为整数类型%select{|，而非普通"char"、"bool"、精确位宽或枚举类型}0（%1无效）'
+H232C02FD2560: '%select{溢出内建函数|带检查的整数运算}0的运算数参数必须为整数类型%select{|，而非普通"char"、"bool"、精确位宽或枚举类型}0（%1 无效）'
 # 'operand of ? changes signedness: %0 to %1'
-H034F94202BD7: '问号运算符的运算数改变了符号：%0到%1'
+H034F94202BD7: '问号运算符的运算数改变了符号：%0 到 %1'
 # 'operand of type %0 cannot be cast to a pointer type'
-H39550A20AC28: '类型%0的运算数不能转换为指针类型'
+H39550A20AC28: '类型 %0 的运算数不能转换为指针类型'
 # 'operand of type %0 where arithmetic or pointer type is required'
-H73F559724DF8: '需要算术类型或指针类型的位置却使用了类型%0的运算数'
+H73F559724DF8: '需要算术类型或指针类型的位置却使用了类型 %0 的运算数'
 # 'operands to conditional of types%diff{ $ and $|}0,1 are incompatible in ARC mode'
 HA7936DDDD636: '在ARC模式下，条件运算符的运算数类型%diff{ $和$ |}0,1不兼容'
 # "operator '%0' has lower precedence than '%1'; '%1' will be evaluated first"
-H7655BF3550EE: '运算符"%0"的优先级低于"%1"；"%1"将先被计算'
+H7655BF3550EE: '运算符 "%0" 的优先级低于 "%1"；"%1" 将先被计算'
 # "operator '?:' has lower precedence than '%0'; '%0' will be evaluated first"
-HFCE2B46187B8: '运算符"?: "的优先级低于"%0"；"%0"将先被计算'
+HFCE2B46187B8: '运算符"?: "的优先级低于 "%0"；"%0" 将先被计算'
 # 'operators in fold expression must be the same'
 H1479CC2CDE54: '折叠表达式中的运算符必须相同'
 # 'opt-like flags'
@@ -25155,23 +25155,23 @@ HF36747707003: '将 case 值转换为 switch 条件类型时溢出（%0 到 %1�
 # 'overflow in expression; result is %0 with type %1'
 H5FE3FC44898D: '表达式溢出；结果是 %0，类型为 %1'
 # 'overlapping comparisons always evaluate to %select{false|true}0'
-H9631A49EAD2B: '重叠比较始终评估为%select{false|true}0'
+H9631A49EAD2B: '重叠比较始终评估为 %select{false|true}0'
 # "overload resolution selected deleted operator '%0'%select{|: %2}1"
 HB844E51E83EA: "重载决议选择了已删除的运算符 '%0'%select{|: %2}1"
 # 'overloaded %0 cannot be a static member function'
-HE25D37D77FD9: '重载的%0不能是静态成员函数'
+HE25D37D77FD9: '重载的 %0 不能是静态成员函数'
 # 'overloaded %0 cannot be variadic'
-H49C83B8BBB4E: '重载的%0不能是可变参数的'
+H49C83B8BBB4E: '重载的 %0 不能是可变参数的'
 # 'overloaded %0 cannot have %select{no|a defaulted|more than one}1 parameter before C++23'
-H1FC62986EC90: '在C++23之前，重载的%0不能拥有%select{无|一个默认的|超过一个}1参数'
+H1FC62986EC90: '在C++23之前，重载的 %0 不能拥有%select{无|一个默认的|超过一个}1参数'
 # 'overloaded %0 must be a %select{unary|binary|unary or binary}2 operator (has %1 parameter%s1)'
 HA142B5DEA04D: '重载 %0 必须是 %select{一元|二元|一元或二元}2 运算符（具有 %1 参数%s1）'
 # 'overloaded %0 must be a non-static member function'
-H359B48F5CEFF: '重载的%0必须是非静态成员函数'
+H359B48F5CEFF: '重载的 %0 必须是非静态成员函数'
 # 'overloaded %0 must have at least one parameter of class or enumeration type'
-H329B9199B7C8: '重载的%0必须至少有一个参数是类或枚举类型'
+H329B9199B7C8: '重载的 %0 必须至少有一个参数是类或枚举类型'
 # 'overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension'
-H9DE4D96FF9C0: '带有%select{无|一个默认的|超过一个}1参数的重载%0是C++23的扩展'
+H9DE4D96FF9C0: '带有%select{无|一个默认的|超过一个}1参数的重载 %0 是C++23的扩展'
 # 'overloaded operator %select{>>|<<}0 has higher precedence than comparison operator'
 H3D68DF30B083: '重载的%select{>>|<<}0运算符的优先级高于比较运算符'
 # 'overridden method is here'
@@ -25185,7 +25185,7 @@ HDBB3DF8CB32F: '覆盖默认的PROGRAM入口名称（可能有助于使用其他
 # 'overrides DW_AT_comp_dir, and provides an alternative base location, which is used with DW_AT_dwo_name to construct a path to *.dwo files.'
 HB19702484022: '覆盖DW_AT_comp_dir，并提供一个替代基础位置，该位置与DW_AT_dwo_name一起用于构造*.dwo文件的路径。'
 # "overriding '%0' option with '%1'"
-H0BEA2CFA1C71: "用'%1'覆盖'%0'选项"
+H0BEA2CFA1C71: "用 '%1' 覆盖 '%0' 选项"
 # 'overriding currently unsupported rounding mode on this target'
 HE764C7911186: '覆盖当前目标上不支持的舍入模式'
 # 'overriding currently unsupported use of floating point exceptions on this target'
@@ -25193,9 +25193,9 @@ H4E019EDC5E1E: '覆盖当前目标上不支持的浮点异常使用'
 # 'overriding method has mismatched ns_consumed attribute on its parameter'
 H94209C3B1D29: '覆盖的方法与其参数的ns_consumed属性不匹配'
 # 'overriding method has mismatched ns_returns_%select{not_retained|retained}0 attributes'
-HFA26D6769DAD: '覆盖的方法与其ns_returns_%select{not_retained|retained}0属性不匹配'
+HFA26D6769DAD: '覆盖的方法与其ns_returns_%select{not_retained|retained}0 属性不匹配'
 # 'overriding the module target triple with %0'
-H7A3B62788722: '用%0覆盖模块的目标三元组'
+H7A3B62788722: '用 %0 覆盖模块的目标三元组'
 # 'overriding virtual function must specify the same code segment as its overridden function'
 HD38E3F8D7591: '覆盖的虚函数必须指定与被覆盖函数相同的代码段'
 # 'p'
@@ -25203,15 +25203,15 @@ H516B9783FCA5: 'p'
 # 'pack declaration outside of template'
 HDF7BB0B67932: '包声明位于模板外部'
 # 'pack expansion contains parameter pack %0 that has a different length (%1 vs. %select{|at least }2%3) from outer parameter packs'
-H41600DB01010: '包展开包含参数包%0，其长度与外部参数包不同（%1 与 %select{|至少 }2%3）'
+H41600DB01010: '包展开包含参数包 %0，其长度与外部参数包不同（%1 与 %select{|至少 }2%3）'
 # 'pack expansion contains parameter pack %0 that has a different length (at least %1 vs. %2) from outer parameter packs'
-H477211AA8361: '包展开包含参数包%0，其长度与外部参数包不同（至少%1 与 %2）'
+H477211AA8361: '包展开包含参数包 %0，其长度与外部参数包不同（至少 %1 与 %2）'
 # 'pack expansion contains parameter packs %0 and %1 that have different lengths (%2 vs. %select{|at least }3%4)'
-H4F8FA8F98117: '包展开包含参数包%0和%1，其长度不同（%2 与 %select{|至少 }3%4）'
+H4F8FA8F98117: '包展开包含参数包 %0 和 %1，其长度不同（%2 与 %select{|至少 }3%4）'
 # 'pack expansion does not contain any unexpanded parameter packs'
 H8BAD94174D96: '包展开中不包含任何未展开的参数包'
 # 'pack expansion for initialization of member %0'
-HBD2872B50273: '成员%0的初始化所用的包展开'
+HBD2872B50273: '成员 %0 的初始化所用的包展开'
 # 'pack expansion of using declaration is a C++17 extension'
 H1BE8FC7C5774: 'using声明的包展开是C++17扩展'
 # 'pack expansion used as argument for non-pack parameter of %select{alias template|concept}0'
@@ -25227,33 +25227,33 @@ H1086B8F449EB: '包索引是C++2c扩展'
 # 'pack indexing is incompatible with C++ standards before C++2c'
 H9DAE09EBBEA1: '包索引与C++2c之前的C++标准不兼容'
 # 'packed attribute is unnecessary for %0'
-H08493DD022D1: '对于%0，packed属性是不必要的'
+H08493DD022D1: '对于 %0，packed属性是不必要的'
 # "packoffset at 'y' not match alignment %0 required by %1"
-H1D68367EC4D7: "在'y'处的packoffset与%1要求的%0对齐不匹配"
+H1D68367EC4D7: "在 'y' 处的packoffset与 %1 要求的 %0 对齐不匹配"
 # 'packoffset cannot cross register boundary'
 HA00AFB61162C: 'packoffset不能跨越寄存器边界'
 # 'packoffset overlap between %0, %1'
-H8FBBA6B5715E: '%0和%1之间的packoffset重叠'
+H8FBBA6B5715E: '%0 和 %1 之间的packoffset重叠'
 # 'padding %select{struct|interface|class}0 %1 with %2 %select{byte|bit}3%s2 to align %4'
-HB4806E10E325: '用%2 %select{字节|位}3%s2填充%select{结构体|接口|类}0 %1以对齐%4'
+HB4806E10E325: '用 %2 %select{字节|位}3%s2填充%select{结构体|接口|类}0 %1 以对齐 %4'
 # 'padding %select{struct|interface|class}0 %1 with %2 %select{byte|bit}3%s2 to align anonymous bit-field'
-HE333A36DBC3C: '用%2 %select{字节|位}3%s2填充%select{结构体|接口|类}0 %1以对齐匿名位域'
+HE333A36DBC3C: '用 %2 %select{字节|位}3%s2填充%select{结构体|接口|类}0 %1 以对齐匿名位域'
 # 'padding %select{struct|interface|class}0 %1 with %2 %select{byte|bit}3%s2 to align anonymous field'
-H1B5890218438: '用%2 %select{字节|位}3%s2填充%select{结构体|接口|类}0 %1以对齐匿名成员'
+H1B5890218438: '用 %2 %select{字节|位}3%s2填充%select{结构体|接口|类}0 %1 以对齐匿名成员'
 # 'padding size of %0 with %1 %select{byte|bit}2%s1 to alignment boundary'
-H5BCCA44B6E5B: '用%1 %select{字节|位}2%s1填充%0到对齐边界所需的大小'
+H5BCCA44B6E5B: '用 %1 %select{字节|位}2%s1填充 %0 到对齐边界所需的大小'
 # 'parameter %0 must have a complete type to use function %1 with the %2 calling convention'
-H35B9EA765265: '参数%0必须具有完整的类型才能使用具有%2调用约定的函数%1'
+H35B9EA765265: '参数 %0 必须具有完整的类型才能使用具有 %2 调用约定的函数 %1'
 # 'parameter %0 set but not used'
-HB6BB1AF1B37E: '参数%0被设置但未使用'
+HB6BB1AF1B37E: '参数 %0 被设置但未使用'
 # "parameter %0 was not declared, defaults to 'int'; ISO C99 and later do not support implicit int"
-H41790618129F: "未声明参数%0，默认为'int'；ISO C99及后续版本不支持隐式int类型"
+H41790618129F: "未声明参数 %0，默认为 'int'；ISO C99及后续版本不支持隐式int类型"
 # "parameter '%0' is already documented"
 HF9B7DF355428: '参数“%0”已被文档说明'
 # "parameter '%0' not found in the function declaration"
 HD7CC3BBE6634: '参数“%0”未在函数声明中找到'
 # "parameter '%0' not in expected state when the function returns: expected '%1', observed '%2'"
-H6EE5C60DD591: "函数返回时参数'%0'未处于期望状态：期望'%1'，实际观察到'%2'"
+H6EE5C60DD591: "函数返回时参数 '%0' 未处于期望状态：期望 '%1'，实际观察到 '%2'"
 # "parameter cannot be named '%select{global|unknown}0' while using 'lifetime_capture_by(%select{global|unknown}0)'"
 H56545E5909EB: "在使用'lifetime_capture_by(%select{global|unknown}0)'时，参数不能命名为'%select{global|unknown}0'"
 # 'parameter declarator cannot be qualified'
@@ -25265,35 +25265,35 @@ HFB13BD25F7E6: '参数不能使用地址空间进行限定'
 # 'parameter name cannot have template arguments'
 H4AE4E444760E: '参数名称不能带有模板实参'
 # 'parameter named %0 is missing'
-HE41EE5512047: '命名为%0的参数缺失'
+HE41EE5512047: '命名为 %0 的参数缺失'
 # "parameter of %0 attribute must be 'id' when used on a typedef"
-H95DFECC378EF: "当在typedef上使用%0属性时，其参数必须为'id'"
+H95DFECC378EF: "当在typedef上使用 %0 属性时，其参数必须为 'id'"
 # 'parameter of %0 attribute must be a single name of an Objective-C %select{class|protocol}1'
-H6E3911EE67CF: '%0属性的参数必须是Objective-C %select{类|协议}1的单一名字'
+H6E3911EE67CF: '%0 属性的参数必须是Objective-C %select{类|协议}1的单一名字'
 # 'parameter of %0 cannot have a default argument'
-H9997206462BD: '%0的参数不能有默认参数值'
+H9997206462BD: '%0 的参数不能有默认参数值'
 # "parameter of literal operator must have type 'unsigned long long', 'long double', 'char', 'wchar_t', 'char16_t', 'char32_t', or 'const char *'"
-H18EF0BD0BEB6: "字面量运算符的参数类型必须为'unsigned long long'、'long double'、'char'、'wchar_t'、'char16_t'、'char32_t'或'const char *'"
+H18EF0BD0BEB6: "字面量运算符的参数类型必须为'unsigned long long'、'long double'、'char'、'wchar_t'、'char16_t'、'char32_t' 或'const char *'"
 # 'parameter of overloaded %0 cannot have a default argument'
-H31033CF29CE2: '重载的%0参数不能有默认参数值'
+H31033CF29CE2: '重载的 %0 参数不能有默认参数值'
 # "parameter of overloaded post-%select{increment|decrement}1 operator must have type 'int' (not %0)"
-H42A579D6B7B0: "重载的后置%select{递增|递减}1运算符的参数类型必须为'int'（而非%0）"
+H42A579D6B7B0: "重载的后置%select{递增|递减}1运算符的参数类型必须为 'int'（而非 %0）"
 # 'parameter of overridden method is annotated with __attribute__((noescape))'
 H1DC2A8B6BA41: '被覆盖的方法的参数被标记为__attribute__((noescape))'
 # 'parameter of overriding method should be annotated with __attribute__((noescape))'
 HD9E0E2EF69AC: '覆盖方法的参数应使用__attribute__((noescape))进行注解'
 # "parameter of the 'collapse' clause"
-H978C7D7597CF: "'collapse'子句的参数"
+H978C7D7597CF: "'collapse' 子句的参数"
 # 'parameter of type %0 is declared here'
-HB0D7D36BAAD5: '类型为%0的参数在此处声明'
+HB0D7D36BAAD5: '类型为 %0 的参数在此处声明'
 # 'parameter pack %0 declared here'
-HF649CEA110D0: '参数包%0在此处声明'
+HF649CEA110D0: '参数包 %0 在此处声明'
 # 'parameter pack cannot have a default argument'
 H220429408CBD: '参数包不能有默认参数'
 # 'parameter references not allowed in naked functions'
 HE9A90AF8CF8F: '在naked函数中不允许使用参数引用'
 # "parameterized class %0 already conforms to the protocols listed; did you forget a '*'?"
-H0F239CE68A40: '参数化类%0已经符合列出的协议；是否漏掉了"*"?'
+H0F239CE68A40: '参数化类 %0 已经符合列出的协议；是否漏掉了"*"?'
 # 'parameters for defaulted %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator must have the same type%diff{ (found $ vs $)|}1,2'
 H34C46A5FC53A: '默认的%select{<ERROR>|相等|三向|相等|关系}0比较运算符的参数必须具有相同的类型%diff{(发现$和$不同)|}1,2'
 # "parent region for 'omp %select{cancellation point|cancel}0' construct cannot be nowait"
@@ -25301,9 +25301,9 @@ H10627ACFF3E1: "'omp %select{取消点|取消}0'结构的父区域不能是nowai
 # "parent region for 'omp %select{cancellation point|cancel}0' construct cannot be ordered"
 H2F8AAD55F0CC: "'omp %select{取消点|取消}0'结构的父区域不能是ordered"
 # "parent umbrella does not match: '%0' (provided) vs '%1' (found)"
-H38C90C7CC02F: "父umbrella不匹配：提供的'%0'与发现的'%1'"
+H38C90C7CC02F: "父umbrella不匹配：提供的 '%0' 与发现的 '%1'"
 # "parent umbrella missing from %0: '%1'"
-HCD77F7184E7F: "父umbrella在%0中缺失：'%1'"
+HCD77F7184E7F: "父umbrella在 %0 中缺失：'%1'"
 # 'parentheses are required around macro argument containing braced initializer list'
 H41A73FF55953: '包含花括号初始化列表的宏参数周围需要括号'
 # 'parentheses are required around this expression in a requires clause'
@@ -25313,11 +25313,11 @@ H55DF42498A9B: '地址非类型模板实参周围的括号是C++11扩展'
 # 'parentheses around address non-type template argument are incompatible with C++98'
 H8ACABCA7F85D: '地址非类型模板实参周围的括号与C++98不兼容'
 # "parentheses must be omitted if %0 attribute's argument list is empty"
-H90F4FD29334C: '如果%0属性的参数列表为空，则必须省略括号'
+H90F4FD29334C: '如果 %0 属性的参数列表为空，则必须省略括号'
 # 'parentheses were disambiguated as a function declaration'
 H329AE7B68E6C: '括号被解析为函数声明'
 # 'parentheses were disambiguated as redundant parentheses around declaration of variable named %0'
-H911B6F6318F6: '括号被解析为变量%0声明周围的冗余括号'
+H911B6F6318F6: '括号被解析为变量 %0 声明周围的冗余括号'
 # 'parenthesize the second argument to silence'
 HB3431A17CC77: '将第二个参数用括号括起来以消除歧义'
 # 'parenthesized initialization of a member array is a GNU extension'
@@ -25325,23 +25325,23 @@ HD07F8AE496CA: '成员数组的括号初始化是GNU扩展'
 # 'parse the input, create a PFT, dump it, and exit'
 H8632144C8313: '解析输入，创建PFT，转储并退出'
 # 'partial ordering for explicit instantiation of %0 is ambiguous'
-HE38D1382AB5B: '显式实例化%0的部分排序存在歧义'
+HE38D1382AB5B: '显式实例化 %0 的部分排序存在歧义'
 # 'partial specialization cannot be declared as a friend'
 HA147DDFF5AB9: '偏特化不能声明为友元'
 # 'partial specialization matches %0'
-HA30AC1C7D740: '偏特化与%0匹配'
+HA30AC1C7D740: '偏特化与 %0 匹配'
 # 'partial specialization of %0 does not use any of its template parameters'
-H84CBC790F3FB: '%0的偏特化未使用其任何模板参数'
+H84CBC790F3FB: '%0 的偏特化未使用其任何模板参数'
 # 'pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions'
 HB623B7D5D4C9: '使用 -fsafe-buffer-usage-suggestions 选项以接收代码强化建议'
 # 'passing %0-byte aligned argument to %1-byte aligned parameter %2%select{| of %4}3 may result in an unaligned pointer access'
-H8E7373BFAB19: '传递%0字节对齐的参数给%1字节对齐的参数%2%select{| of %4}3可能导致未对齐指针访问'
+H8E7373BFAB19: '传递 %0 字节对齐的参数给 %1 字节对齐的参数 %2%select{| of %4}3可能导致未对齐指针访问'
 # 'passing %select{address of|reference to}0 local temporary object to musttail function'
 H185CAE78405D: '将局部临时对象的%select{地址|引用}0传递给musttail函数'
 # "passing %select{an object that undergoes default argument promotion|an object of reference type|a parameter declared with the 'register' keyword}0 to 'va_start' has undefined behavior"
-H71043E0BAFE6: "将%select{经过默认参数提升的对象|引用类型对象|用'register'关键字声明的参数}0传递给'va_start'会导致未定义行为"
+H71043E0BAFE6: "将%select{经过默认参数提升的对象|引用类型对象|用 'register' 关键字声明的参数}0传递给 'va_start' 会导致未定义行为"
 # "passing '%0' format string where '%1' format string is expected"
-HB0DCC631BCB0: "在期望'%1'格式字符串的位置传递了'%0'格式字符串"
+HB0DCC631BCB0: "在期望 '%1' 格式字符串的位置传递了 '%0' 格式字符串"
 # "passing a type argument as the first operand to '_Generic' is a C2y extension"
 H9B0C1A1B2AAD: '将类型参数作为_Generic的第一个操作数传递是C2y扩展'
 # "passing a type argument as the first operand to '_Generic' is incompatible with C standards before C2y"
@@ -25349,13 +25349,13 @@ H0B03D58A8538: '将类型参数作为_Generic的第一个操作数传递与C2y�
 # 'passing address of %select{non-local|non-scalar}0 object to __autoreleasing parameter for write-back'
 H8F97A19F11B3: '将%select{非局部|非标量}0对象的地址传递给__autoreleasing参数用于写回'
 # 'passing argument to parameter %0 here'
-H30E4C5FD05FE: '此处传递参数给参数%0'
+H30E4C5FD05FE: '此处传递参数给参数 %0'
 # 'passing argument to parameter here'
 HC7C3DD07B432: '此处传递参数给参数'
 # 'passing arguments to %select{a function|%1}0 without a prototype is deprecated in all versions of C and is not supported in C23'
 H192BBFFB4918: '向%select{函数|%1}0传递参数而不使用原型在所有C版本中已弃用，并且C23不支持'
 # 'passing byval argument %0 with potentially incompatible alignment here'
-H730F797EFCA9: '此处传递的byval参数%0具有可能不兼容的对齐方式'
+H730F797EFCA9: '此处传递的byval参数 %0 具有可能不兼容的对齐方式'
 # "passing no argument for the '...' parameter of a variadic macro is a C++20 extension"
 H6D5DB0C5BBB6: "为可变参数宏的'...'参数不传递参数是C++20扩展"
 # "passing no argument for the '...' parameter of a variadic macro is a C23 extension"
@@ -25365,25 +25365,25 @@ HCA1A72FB669A: "为可变参数宏的'...'参数不传递参数与C23之前的C�
 # "passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20"
 H2B8F35860B3B: "为可变参数宏的'...'参数不传递参数与C++20之前的C++标准不兼容"
 # 'passing non-generic address space pointer to %0 may cause dynamic conversion affecting performance'
-HAEF068C749A4: '将地址空间非通用指针传递给%0可能导致影响性能的动态转换'
+HAEF068C749A4: '将地址空间非通用指针传递给 %0 可能导致影响性能的动态转换'
 # "passing object of class type %0 through variadic %select{function|block|method|constructor}1%select{|; did you mean to call '%3'?}2"
-H39C1EFFB876B: "通过可变%select{函数|块|方法|构造函数}1传递类类型%0的对象%select{|; 你是否想调用'%3'?}2"
+H39C1EFFB876B: "通过可变%select{函数|块|方法|构造函数}1传递类类型 %0 的对象%select{|; 你是否想调用 '%3'?}2"
 # 'passing object of trivial but non-POD type %0 through variadic %select{function|block|method|constructor}1 is incompatible with C++98'
-HD5D2FE67C0FC: '通过可变%select{函数|块|方法|构造函数}1传递平凡但非POD类型%0的对象与C++98不兼容'
+HD5D2FE67C0FC: '通过可变%select{函数|块|方法|构造函数}1传递平凡但非POD类型 %0 的对象与C++98不兼容'
 # "passing only one argument to 'va_start' is incompatible with C standards before C23"
-H0DFF95F6ABB1: "在C23之前的C标准中，向'va_start'仅传递一个参数是不兼容的"
+H0DFF95F6ABB1: "在C23之前的C标准中，向 'va_start' 仅传递一个参数是不兼容的"
 # "passing pointer %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
-H9E268E19A549: "传递指针%1需要持有%0 %select{'%2'|'独占的%2'}3"
+H9E268E19A549: "传递指针 %1 需要持有 %0 %select{'%2'|'独占的 %2'}3"
 # "passing pointer to variable %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
-H0E1F82092409: "传递变量%1的指针需要持有%0 %select{'%2'|'独占的%2'}3"
+H0E1F82092409: "传递变量 %1 的指针需要持有 %0 %select{'%2'|'独占的 %2'}3"
 # "passing the value that %1 points to by reference requires holding %0 %select{'%2'|'%2' exclusively}3"
-HFB2B4F9A02B6: "通过引用传递%1所指的值需要持有%0 %select{'%2'|'独占的%2'}3"
+HFB2B4F9A02B6: "通过引用传递 %1 所指的值需要持有 %0 %select{'%2'|'独占的 %2'}3"
 # 'passing union across security boundary via %select{parameter %1|return value}0 may leak information'
-HA1E50C08E561: '通过%select{参数%1|返回值}0传递联合体跨安全边界可能会泄露信息'
+HA1E50C08E561: '通过%select{参数 %1|返回值}0传递联合体跨安全边界可能会泄露信息'
 # "passing variable %1 by reference requires holding %0 %select{'%2'|'%2' exclusively}3"
-HB011E968C37B: "通过引用传递变量%1需要持有%0 %select{'%2'|'独占的%2'}3"
+HB011E968C37B: "通过引用传递变量 %1 需要持有 %0 %select{'%2'|'独占的 %2'}3"
 # "pasting formed '%0', an invalid preprocessing token"
-H17B929BA26C6: "连接形成无效预处理标记'%0'"
+H17B929BA26C6: "连接形成无效预处理标记 '%0'"
 # "pasting two '/' tokens into a '//' comment is a Microsoft extension"
 HBFF0AAF786C4: "将两个'/'标记连接成'//'注释是微软扩展"
 # 'path to a pass plugin for HIP to SPIR-V passes.'
@@ -25429,7 +25429,7 @@ HB725A707608F: '使用空指针%select{具有|可能具有}0未定义行为的�
 # 'performs disassembly sequentially'
 HDD6DFBE032D2: '按顺序执行反汇编'
 # 'permutation index must be at least 1 and at most %0'
-H0297CCE3F38F: '排列索引必须至少为1且至多%0'
+H0297CCE3F38F: '排列索引必须至少为 1 且至多 %0'
 # 'pick register allocator based on -O option'
 H46CB03DD1B68: '基于 -O 选项选择寄存器分配器'
 # 'pipes packet types cannot be of reference type'
@@ -25437,15 +25437,15 @@ H354A6AC50D78: '管道数据包类型不能是引用类型'
 # "place '...' %select{immediately before declared identifier|here}0 to declare a function parameter pack"
 HD82CBB258C12: "在%select{声明的标识符前直接|此处}0放置'...'以声明函数参数包"
 # 'place all array allocations more than <size> elements on the heap'
-H7583F9BA4C9F: '将元素数超过<size>的数组分配到堆上'
+H7583F9BA4C9F: '将元素数超过 <size> 的数组分配到堆上'
 # 'place all array allocations of dynamic size on the heap'
 H1E67C0E84EC2: '将动态大小的数组分配到堆上'
 # 'place parentheses around comparison expression to evaluate it first'
 H1021BF49A48F: '在比较表达式周围添加括号以优先计算它'
 # 'place parentheses around the %0 expression to evaluate it first'
-HD79F2195D659: "在'%0'表达式周围添加括号以优先计算它"
+HD79F2195D659: "在 '%0' 表达式周围添加括号以优先计算它"
 # "place parentheses around the '%0' expression to silence this warning"
-H7195F835EC30: "在'%0'表达式周围添加括号以消除此警告"
+H7195F835EC30: "在 '%0' 表达式周围添加括号以消除此警告"
 # "place parentheses around the '?:' expression to evaluate it first"
 H9605DB1A560A: "在'?:'表达式周围添加括号以先进行求值"
 # 'place parentheses around the assignment to silence this warning'
@@ -25459,33 +25459,33 @@ H4C0235C28642: '占位符变量是C++2c的扩展'
 # 'placeholder variables are incompatible with C++ standards before C++2c'
 H6BE10CEEDF1B: '占位符变量与C++2c之前的C++标准不兼容'
 # 'placement new would change type of storage from %0 to %1'
-H83FB1C107237: 'placement new会将存储类型从%0更改为%1'
+H83FB1C107237: 'placement new会将存储类型从 %0 更改为 %1'
 # "plain '_Complex' requires a type specifier; assuming '_Complex double'"
-HBC4E2F0D8FF6: "普通的'_Complex'需要类型说明符；假设为'_Complex double'"
+HBC4E2F0D8FF6: "普通的 '_Complex' 需要类型说明符；假设为'_Complex double'"
 # "platform does not match: '%0' (provided) vs '%1' (found)"
-H5C64A2FB6312: "平台不匹配：提供的'%0'与检测到的'%1'"
+H5C64A2FB6312: "平台不匹配：提供的 '%0' 与检测到的 '%1'"
 # "please rebuild precompiled header '%0'"
-HFBA0A20CA8AF: "请重新构建预编译头'%0'"
+HFBA0A20CA8AF: "请重新构建预编译头 '%0'"
 # 'plt'
 H8B8091C3AD1A: 'plt'
 # 'pointer %0 declared here'
-H22E4F3576FCE: '指针%0在此处声明'
+H22E4F3576FCE: '指针 %0 在此处声明'
 # "pointer arguments to kernel functions must reside in '__global', '__constant' or '__local' address space"
-HEE966568F6BF: "内核函数的指针参数必须位于'__global'、'__constant'或'__local'地址空间中"
+HEE966568F6BF: "内核函数的指针参数必须位于 '__global'、'__constant' 或 '__local' 地址空间中"
 # 'pointer cannot be cast to type %0'
-H0546695B4A22: '指针不能转换为类型%0'
+H0546695B4A22: '指针不能转换为类型 %0'
 # 'pointer cannot be mapped along with a section derived from itself'
 HAF06E92DEBA3: '指针不能与其派生的部分同时映射'
 # 'pointer comparisons before C11 need to be between two complete or two incomplete types; %0 is %select{|in}2complete and %1 is %select{|in}3complete'
-H4DB22EDB67C8: 'C11之前的指针比较需要在两种完整类型或两种不完整类型之间；%0是%select{|in}2complete，%1是%select{|in}3complete'
+H4DB22EDB67C8: 'C11之前的指针比较需要在两种完整类型或两种不完整类型之间；%0 是%select{|in}2complete，%1 是%select{|in}3complete'
 # "pointer to function type %0 may not be 'restrict' qualified"
-H909D3E85FCFF: "指向函数类型%0的指针可能不能被'restrict'限定"
+H909D3E85FCFF: "指向函数类型 %0 的指针可能不能被 'restrict' 限定"
 # 'pointer to type %0 is invalid in OpenCL'
-HEF9B07C9C640: '类型%0的指针在OpenCL中无效'
+HEF9B07C9C640: '类型 %0 的指针在OpenCL中无效'
 # 'pointer type mismatch%diff{ ($ and $)|}0,1'
 H8EAA8DFC686A: '指针类型不匹配%diff{ ($和$)|}0,1'
 # 'pointer-to-member function type %0 can only be called on an %select{rvalue|lvalue}1'
-H08EA28E0562A: '成员函数类型%0只能在%select{右值|左值}1上调用'
+H08EA28E0562A: '成员函数类型 %0 只能在%select{右值|左值}1上调用'
 # 'pointer/integer type mismatch in conditional expression%diff{ ($ and $)|}0,1'
 HC15C6EF198BF: '条件表达式中的指针/整数类型不匹配%diff{ ($和$)|}0,1'
 # 'poison on failure'
@@ -25501,7 +25501,7 @@ H338B60F2873D: '用给定的模式毒化未初始化的栈变量'
 # 'poisoning existing macro'
 HDD8F2D4A6FAB: '毒化现有宏'
 # 'position arguments in format strings start counting at 1 (not 0)'
-HC64922328C30: '格式字符串中的位置参数从1（而非0）开始计数'
+HC64922328C30: '格式字符串中的位置参数从 1（而非 0）开始计数'
 # "position-independent code requires '-mabicalls'"
 H69FA922C5B49: "位置无关代码需要选项 '-mabicalls'"
 # 'positional arguments are not supported by ISO C'
@@ -25543,7 +25543,7 @@ H01DD8237CC21: "pragma include_alias 期望的是 '%0'"
 # 'pragma include_alias expected include filename'
 H08BDBEAABFC9: 'pragma include_alias 期望包含的文件名'
 # "pragma pop_macro could not pop '%0', no matching push_macro"
-HF67398D54EBA: 'pragma pop_macro无法弹出"%0"，因为没有对应的push_macro指令'
+HF67398D54EBA: 'pragma pop_macro无法弹出 "%0"，因为没有对应的push_macro指令'
 # "preceding '...' declares a function parameter pack"
 HB271FF2CAE5F: "前面的 '...' 声明了一个函数参数包"
 # 'precompiled'
@@ -25551,9 +25551,9 @@ H5B5680CDE56B: '预编译'
 # "precompiled header '%0' was ignored because '%1' is not first '-include'"
 H47051C658E08: "预编译头 '%0' 被忽略，因为 '%1' 不是第一个 '-include'"
 # "precompiled header '%0' was ignored because it is not a clang PCH file"
-HC110D52BBD02: "预编译头文件'%0'被忽略，因为它不是clang PCH文件"
+HC110D52BBD02: "预编译头文件 '%0' 被忽略，因为它不是clang PCH文件"
 # "precompiled header directory '%0' was ignored because it contains no clang PCH files"
-H3E91139CDF42: "预编译头目录'%0'被忽略，因为它不包含任何clang PCH文件"
+H3E91139CDF42: "预编译头目录 '%0' 被忽略，因为它不包含任何clang PCH文件"
 # 'predefined allocator cannot have traits specified'
 H8666F51519BE: '预定义分配器不能指定特性'
 # 'predefined identifier is only valid inside function'
@@ -25611,7 +25611,7 @@ H5B43AF8F451D: '之前的命令“%select{\\|@}0%1”在这里'
 # 'previous declaration is here'
 H9CAB5B6B1715: '之前的声明在这里'
 # 'previous declaration of class template partial specialization %0 is here'
-H8EF5BDE072C8: '类模板的部分特化%0的之前声明在这里'
+H8EF5BDE072C8: '类模板的部分特化 %0 的之前声明在这里'
 # 'previous declaration of variable template partial specialization is here'
 H5A936ED6E7F5: '变量模板的部分特化的之前声明在这里'
 # 'previous default generic association is here'
@@ -25619,7 +25619,7 @@ H5A119A508D2B: '之前的默认通用关联在这里'
 # 'previous default template argument defined here'
 H828BBDD8C7F9: '之前在这里定义的默认模板参数'
 # 'previous default template argument defined in module %0'
-H2F92B57F5F02: '之前在模块%0中定义的默认模板参数'
+H2F92B57F5F02: '之前在模块 %0 中定义的默认模板参数'
 # 'previous definition is here'
 H0AC845A11A85: '之前的定义在这里'
 # 'previous documentation'
@@ -25637,11 +25637,11 @@ HDD10F14D9687: '之前在这里指定的继承模型'
 # 'previous initialization %select{|with side effects }0is here%select{| (side effects will not occur at run time)}0'
 HFE059F4FA2A1: '之前的初始化%select{|带有副作用 }0在这里%select{|（副作用在运行时不会发生）}0'
 # 'previous initialization for field %0 is here'
-HEF0E98EA391B: '字段%0的先前初始化在这里'
+HEF0E98EA391B: '字段 %0 的先前初始化在这里'
 # 'previous module declaration is here'
 HD052ACC784A7: '之前的模块声明在这里'
 # 'previous non-type template parameter with type %0 is here'
-H5A88D83E2220: '类型为%0的先前非类型模板参数在这里'
+H5A88D83E2220: '类型为 %0 的先前非类型模板参数在这里'
 # 'previous reference is here'
 HEFAE6804D795: '之前的引用在这里'
 # 'previous return statement is here'
@@ -25657,13 +25657,13 @@ H39A31F8B143F: '之前的使用在这里'
 # 'previous uuid specified here'
 H8206D7044433: '之前指定的UUID在这里'
 # "previously declared '%0' here"
-H4ECE9D2CF70E: "之前在这里声明的'%0'"
+H4ECE9D2CF70E: "之前在这里声明的 '%0'"
 # "previously declared '%1' here"
-H6BFF38DE7EEF: "之前在这里声明的'%1'"
+H6BFF38DE7EEF: "之前在这里声明的 '%1'"
 # 'previously declared as %0 here'
-HEA5BCF07D9E2: '之前在这里被声明为%0'
+HEA5BCF07D9E2: '之前在这里被声明为 %0'
 # 'previously defined as an alias for %0'
-HC8CE8DE52E3E: '之前被定义为%0的别名'
+HC8CE8DE52E3E: '之前被定义为 %0 的别名'
 # 'previously defined here'
 H0787B53F4571: '之前在这里定义'
 # 'previously marked as task_reduction with different reduction operation'
@@ -25787,7 +25787,7 @@ HBF6B61DB25E4: '打印具有默认严格语义的指令'
 # 'print output address range for each basic block in the function whenBinaryFunction::print is called'
 H4D2F05339EF5: '当调用 BinaryFunction::print 时，打印函数中每个基本块的输出地址范围'
 # "print pass arguments to pass to 'opt'"
-H6E943315CBC7: "打印传递给'opt'的pass参数"
+H6E943315CBC7: "打印传递给 'opt' 的pass参数"
 # 'print pass details when it is executed'
 H76B02F3EE5E5: '在pass执行时打印详细信息'
 # 'print pass name before it is executed'
@@ -25813,7 +25813,7 @@ HBFCEFB46E060: '打印重新排序后的段内容'
 # 'print statistics about basic block ordering'
 HD0B0C3B01A36: '打印基本块排序的统计信息'
 # 'print the CFG of important functions that changed in binary 2'
-H50C9F66DBC43: '打印在二进制2中发生变化的重要函数的控制流图'
+H50C9F66DBC43: '打印在二进制 2 中发生变化的重要函数的控制流图'
 # 'print the basic blocks showed in top differences'
 H1DA154B840C3: '打印在顶部差异中显示的基本块'
 # 'print the list of functions with stale profile'
@@ -25827,7 +25827,7 @@ H0BBB239D4108: '打印每个优化所花费的时间'
 # 'print time spent in rewriting passes'
 H40857EC64F6B: '打印重写passes所花费的时间。'
 # 'print top <uint> functions with suboptimal code layout on input'
-HBFD8DED23E2E: '打印输入中具有次优代码布局的前<uint>个函数'
+HBFD8DED23E2E: '打印输入中具有次优代码布局的前 <uint> 个函数'
 # 'printing of statistics for each inlined function'
 HCEA14F1643A5: '为每个内联函数打印统计信息'
 # 'prints out offsets for abbrev and debug_info of Skeleton CUs that get patched.'
@@ -25835,7 +25835,7 @@ H71912C66C3FC: '输出被修补的骨架编译单元的abbrev和debug_info的偏
 # 'prioritize low virtual register numbers for test and debug'
 H0A6C1C201BCE: '优先使用低虚寄存器号用于测试和调试'
 # "private API notes file for module '%0' should be named '%0_private.apinotes', not '%1'"
-HB68113D2F79A: "模块'%0'的私有API注释文件应命名为'%0_private.apinotes'，而非'%1'"
+HB68113D2F79A: "模块 '%0' 的私有API注释文件应命名为'%0_private.apinotes'，而非 '%1'"
 # 'private field %0 is not used'
 H3584A3B50C2A: '私有字段 %0 未被使用'
 # 'private module fragment begins here'
@@ -25921,7 +25921,7 @@ H53034807D818: '该属性声明为返回非保留对象；获取器返回保留�
 # 'property declared here'
 H69D70856EBD1: '属性在此处声明'
 # 'property declared in category %0 cannot be implemented in class implementation'
-H04FE1B1065E1: '在类别%0中声明的属性不能在类实现中实现'
+H04FE1B1065E1: '在类别 %0 中声明的属性不能在类实现中实现'
 # 'property does not specify a getter or a putter'
 HD0F5818FB6C8: '属性未指定getter或setter'
 # "property follows Cocoa naming convention for returning 'owned' objects"
@@ -25933,15 +25933,15 @@ HF42022DEA14A: '在无类别声明的类别中实现属性'
 # 'property implementation must be in a class or category implementation'
 HD59CD2B75162: '属性实现必须在类或类别实现中'
 # 'property implementation must have its declaration in interface %0 or one of its extensions'
-HFCF842D4EB86: '属性实现必须在其接口%0或其扩展之一中声明'
+HFCF842D4EB86: '属性实现必须在其接口 %0 或其扩展之一中声明'
 # 'property implementation must have its declaration in the category %0'
-H761B0BB38838: '属性实现必须在其类别%0中声明'
+H761B0BB38838: '属性实现必须在其类别 %0 中声明'
 # 'property is assumed atomic by default'
 H2882A0CD4FD8: '属性默认假设为原子性'
 # 'property is assumed atomic when auto-synthesizing the property'
 HC5E58A6AB217: '在自动合成属性时，默认假设属性为原子性'
 # 'property is synthesized to ivar %0 here'
-H7E91E310D399: '属性在此处被合成到实例变量%0'
+H7E91E310D399: '属性在此处被合成到实例变量 %0'
 # 'property name cannot be a bit-field'
 H8E1C0549C2E5: '属性名称不能是位字段'
 # 'property requires fields to be named'
@@ -25951,13 +25951,13 @@ H32DF2D479322: '属性应改为readwrite'
 # 'property synthesized here'
 H0BB379E6C96C: '属性在此处被合成'
 # 'property type %0 is incompatible with type %1 inherited from %2'
-HDE3695134102: '属性类型%0与从%2继承的类型%1不兼容'
+HDE3695134102: '属性类型 %0 与从 %2 继承的类型 %1 不兼容'
 # "property with '%0' attribute must be of object type"
-H44EF18C35C26: '具有"%0"属性的属性必须是对象类型'
+H44EF18C35C26: '具有 "%0" 属性的属性必须是对象类型'
 # 'protected %select{constructor|destructor}0 can only be used to %select{construct|destroy}0 a base class subobject'
 H8490EFD629C0: '受保护的%select{构造函数|析构函数}0只能用于%select{构造|销毁}0基类子对象'
 # 'protocol %0 has no definition'
-H3F201B2D647A: '协议%0没有定义'
+H3F201B2D647A: '协议 %0 没有定义'
 # 'protocol has circular dependency'
 HBFCB55FB9C5B: '协议存在循环依赖'
 # "protocol has no object type specified; defaults to qualified 'id'"
@@ -25965,7 +25965,7 @@ H79AE64D3788F: "协议未指定对象类型；默认使用限定的 'id'"
 # 'protocol is declared here'
 H63C66770E070: '协议在此处声明'
 # 'protocol method is expected to return an instance of the implementing class, but is declared to return %0'
-HCECBCE2ED619: '协议方法应返回实现类的实例，但声明返回%0'
+HCECBCE2ED619: '协议方法应返回实现类的实例，但声明返回 %0'
 # 'protocol method is here'
 H850DBE7D30DB: '协议方法在此处'
 # 'protocol qualifiers must precede type arguments'
@@ -25995,7 +25995,7 @@ H69C8244E4885: '限定的成员访问引用 %0 中的成员'
 # 'qualified module name can only be used to define modules at the top level'
 HCDFABF1A81DD: '限定的模块名称只能用于在顶层定义模块'
 # 'qualified name refers into a specialization of %select{function|variable}0 template %1'
-H4C7D694E4A70: '限定的名称引用 %select{函数|变量}0模板%1 的特化'
+H4C7D694E4A70: '限定的名称引用 %select{函数|变量}0模板 %1 的特化'
 # 'qualified reference to %0 is a constructor name rather than a %select{template name|type}1 in this context'
 H08AE31B94F15: '在此上下文中，对 %0 的限定引用是构造函数名称而非 %select{模板名称|类型}1'
 # "qualifier 'const' is needed for variables in address space '%0'"
@@ -26013,7 +26013,7 @@ HAF3B1E936CB4: '调用前可用r11，但跳转前不可用'
 # 'r11 not available'
 HD51A31809CB5: 'r11不可用'
 # "range-based 'for' statement uses ':', not '='"
-HC53E3757D97C: "基于范围的'for'语句使用':'而非'='"
+HC53E3757D97C: "基于范围的 'for' 语句使用':'而非'='"
 # 'range-based for loop has empty body'
 H2C4FFAA3CE47: '基于范围的for循环具有空主体'
 # 'range-based for loop initialization statements are a C++20 extension'
@@ -26027,111 +26027,111 @@ H2229A30F511E: '基于范围的for循环与C++98不兼容'
 # 'range-based for loop requires type for loop variable'
 H07E32C6E46BC: '基于范围的for循环需要为循环变量指定类型'
 # 'raw string delimiter longer than 16 characters; use PREFIX( )PREFIX to delimit raw string'
-H00B2DC6A7B32: '原始字符串分隔符超过16个字符；请使用PREFIX( )PREFIX限定原始字符串'
+H00B2DC6A7B32: '原始字符串分隔符超过 16 个字符；请使用PREFIX( )PREFIX限定原始字符串'
 # 'raw string literals are incompatible with C++98'
 H1C93D8A83CA2: '原始字符串文字与C++98不兼容'
 # 'raw string missing terminating delimiter )%0"'
 H7FD087037BE3: '缺少原始字符串的终止分隔符)%0"'
 # "re-exported libraries do not match: '%0' (provided) vs '%1' (found)"
-H6C320DEC171A: "重新导出的库不匹配：'%0'（提供）与'%1'（找到）"
+H6C320DEC171A: "重新导出的库不匹配：'%0'（提供）与 '%1'（找到）"
 # "re-exported library missing from %0: '%1'"
-H552D4BA598A3: "'%1'未包含在%0的重新导出库中"
+H552D4BA598A3: "'%1' 未包含在 %0 的重新导出库中"
 # 're-use space in old .text if possible (relocation mode)'
 H05BFF380B5E6: '如果可能，在重定位模式下重用旧.text段中的空间'
 # 'read of incomplete type %0 is not allowed in a constant expression'
-HCA641211FEEB: '不完全类型%0的读取操作不允许出现在常量表达式中'
+HCA641211FEEB: '不完全类型 %0 的读取操作不允许出现在常量表达式中'
 # 'read of non-const variable %0 is not allowed in a constant expression'
-HD99D6E4F37A4: '非常量变量%0的读取操作不允许出现在常量表达式中'
+HD99D6E4F37A4: '非常量变量 %0 的读取操作不允许出现在常量表达式中'
 # 'read of non-constexpr variable %0 is not allowed in a constant expression'
-HF3D92222C519: '非constexpr变量%0的读取操作不允许出现在常量表达式中'
+HF3D92222C519: '非constexpr变量 %0 的读取操作不允许出现在常量表达式中'
 # 'read of variable %0 of non-integral, non-enumeration type %1 is not allowed in a constant expression'
-H33BFBE7CF01D: '非整型、非枚举类型%1的变量%0的读取操作不允许出现在常量表达式中'
+H33BFBE7CF01D: '非整型、非枚举类型 %1 的变量 %0 的读取操作不允许出现在常量表达式中'
 # "readonly IBOutlet property %0 when auto-synthesized may not work correctly with 'nib' loader"
-H582EA0DF024A: "自动合成时只读IBOutlet属性%0可能无法与'nib'加载器正确配合工作"
+H582EA0DF024A: "自动合成时只读IBOutlet属性 %0 可能无法与 'nib' 加载器正确配合工作"
 # 'reassign registers so as to avoid using REX prefixes in hot code'
 HE2FFC9EC6F02: '重新分配寄存器以避免在热点代码中使用REX前缀'
 # 'received warning after diagnostic serialization teardown was underway: %0'
 H60ECB032353D: '在诊断序列化拆卸过程中收到警告：%0'
 # 'receiver %0 for class message is a forward declaration'
-HAE87B957CEBD: '类消息的接收者%0是一个前向声明'
+HAE87B957CEBD: '类消息的接收者 %0 是一个前向声明'
 # 'receiver %0 is a forward class and corresponding @interface may not exist'
-H2EFCADD231BF: '接收者%0是一个前向类，对应的@interface可能不存在'
+H2EFCADD231BF: '接收者 %0 是一个前向类，对应的@interface可能不存在'
 # 'receiver expression is here'
 H16AA23E5E187: '接收者表达式在此处'
 # 'receiver is instance of class declared here'
 H063C50E49E8E: '接收者是此处声明的类的实例'
 # "receiver is treated with 'id' type for purpose of method lookup"
-H23B037191711: "接收者在方法查找时被当作'id'类型处理"
+H23B037191711: "接收者在方法查找时被当作 'id' 类型处理"
 # 'receiver type %0 for instance message is a forward declaration'
-H4107B7B01A42: '实例消息的接收者类型%0是一个前向声明'
+H4107B7B01A42: '实例消息的接收者类型 %0 是一个前向声明'
 # "receiver type %0 is not 'id' or interface pointer, consider casting it to 'id'"
-HC44380DEE815: "接收者类型%0不是'id'或接口指针，建议将其转换为'id'"
+HC44380DEE815: "接收者类型 %0 不是 'id' 或接口指针，建议将其转换为 'id'"
 # 'receiver type %0 is not an Objective-C class'
-HDF1E1AF5B7B2: '接收者类型%0不是Objective-C类'
+HDF1E1AF5B7B2: '接收者类型 %0 不是Objective-C类'
 # 'record profile for inter-function control flow activity (default: true)'
 HB3410F96E4B8: '记录函数间控制流活动的配置文件（默认：true）'
 # 'recursive evaluation of default argument'
 H9D22EE24805A: '默认参数的递归求值'
 # 'recursive template instantiation exceeded maximum depth of %0'
-H9F7DB4D308D0: '递归模板实例化超过最大深度%0'
+H9F7DB4D308D0: '递归模板实例化超过最大深度 %0'
 # "redeclaration cannot add 'loader_uninitialized' attribute"
-H70EFB9FBF448: "重新声明不能添加'loader_uninitialized'属性"
+H70EFB9FBF448: "重新声明不能添加 'loader_uninitialized' 属性"
 # 'redeclaration has different alignment requirement (%1 vs %0)'
 H2965974DE860: '重新声明的对齐要求不同（%1 vs %0）'
 # "redeclaration of %0 must %select{not |}1have the 'overloadable' attribute"
-H9C609286F3D1: "%0的重新声明必须%select{不具有|}1'overloadable'属性"
+H9C609286F3D1: "%0 的重新声明必须%select{不具有|}1'overloadable' 属性"
 # 'redeclaration of %0 with a different type%diff{: $ vs $|}1,2'
-HEB05B74B4F52: '%0的重新声明具有不同类型%diff{：$ vs $|}1,2'
+HEB05B74B4F52: '%0 的重新声明具有不同类型%diff{：$ vs $|}1,2'
 # 'redeclaration of %q0 cannot add %q1 attribute'
 H437273BF8230: '%q0的重新声明不能添加%q1属性'
 # 'redeclaration of %q0 should not add %q1 attribute'
 HBC3EEF68F79F: '%q0的重新声明不应添加%q1属性'
 # "redeclaration of C++ built-in type 'bool'"
-H4DE1B64751F8: "C++内建类型'bool'的重新声明"
+H4DE1B64751F8: "C++内建类型 'bool' 的重新声明"
 # 'redeclaration of already-defined enum %0 is a GNU extension'
-H3B72AE37DEEE: '已定义的枚举%0的重新声明是GNU扩展'
+H3B72AE37DEEE: '已定义的枚举 %0 的重新声明是GNU扩展'
 # 'redeclaration of deduction guide'
 H6C137FDA5914: '推导指引的重新声明'
 # 'redeclaration of method parameter %0'
-H0D9F6CE9B2EA: '方法参数%0的重复声明'
+H0D9F6CE9B2EA: '方法参数 %0 的重复声明'
 # 'redeclaration of type parameter %0'
-HC29DAC039CAB: '类型参数%0的重复声明'
+HC29DAC039CAB: '类型参数 %0 的重复声明'
 # 'redeclaration of using declaration'
 H96E43918A485: 'using声明的重复声明'
 # 'redeclaration of using-enum declaration'
 H7EA3B309B6C8: 'using-enum声明的重复声明'
 # 'redeclaring non-static %0 as static is a Microsoft extension'
-H853738CC6C0D: '将非静态%0作为静态重新声明是Microsoft扩展'
+H853738CC6C0D: '将非静态 %0 作为静态重新声明是Microsoft扩展'
 # 'redefining builtin macro'
 H6021415EA4BB: '重定义内建宏'
 # 'redefinition of %0'
-HB70C986DD184: '%0的重新定义'
+HB70C986DD184: '%0 的重新定义'
 # 'redefinition of %0 as an alias for a different namespace'
-H97345A757B2F: '将%0重新定义为不同命名空间的别名'
+H97345A757B2F: '将 %0 重新定义为不同命名空间的别名'
 # 'redefinition of %0 as different kind of symbol'
-H9380CBD04275: '将%0重新定义为不同类型符号'
+H9380CBD04275: '将 %0 重新定义为不同类型符号'
 # 'redefinition of %0 will not be visible outside of this function'
-H6605A7137B7E: '%0的重新定义在函数外部不可见'
+H6605A7137B7E: '%0 的重新定义在函数外部不可见'
 # 'redefinition of %0 with a different type%diff{: $ vs $|}1,2'
-HB1C0A119B95E: '使用不同的类型%diff{: $ vs $|}1,2重新定义%0'
+HB1C0A119B95E: '使用不同的类型%diff{: $ vs $|}1,2重新定义 %0'
 # 'redefinition of %select{typedef|type alias}0 for variably-modified type %1'
-HB599B51A5F4D: '为可变修改类型%1重定义%select{typedef|类型别名}0'
+HB599B51A5F4D: '为可变修改类型 %1 重定义%select{typedef|类型别名}0'
 # "redefinition of a 'extern inline' function %0 is not supported in %select{C99 mode|C++}1"
-HF158368144B8: "在%select{C99模式|C++}1中不支持对%0的'extern inline'函数的重新定义"
+HF158368144B8: "在%select{C99模式|C++}1中不支持对 %0 的'extern inline'函数的重新定义"
 # 'redefinition of concept %0 with different template parameters or requirements'
-H4C4283523181: '使用不同的模板参数或要求重新定义概念%0'
+H4C4283523181: '使用不同的模板参数或要求重新定义概念 %0'
 # 'redefinition of default argument'
 H6507C3F7227D: '默认参数的重新定义'
 # 'redefinition of enumerator %0'
-H1EE462BB5E46: '枚举项%0的重新定义'
+H1EE462BB5E46: '枚举项 %0 的重新定义'
 # 'redefinition of forward class %0 of a typedef name of an object type is ignored'
-H06040CF8C316: '将对象类型typedef名称的前向类%0重新定义被忽略'
+H06040CF8C316: '将对象类型typedef名称的前向类 %0 重新定义被忽略'
 # 'redefinition of inferred submodule'
 H43BB40E423BF: '推断子模块的重新定义'
 # 'redefinition of label %0'
-HD4F4A928D72C: '标签%0的重新定义'
+HD4F4A928D72C: '标签 %0 的重新定义'
 # 'redefinition of method parameter %0'
-HE18AEF27C9A1: '方法参数%0的重新定义'
+HE18AEF27C9A1: '方法参数 %0 的重新定义'
 # "redefinition of module '%0'"
 H6249FB58D003: "模块 '%0' 的重新定义"
 # 'redefinition of parameter %0'
@@ -26253,7 +26253,7 @@ H8633F993884D: '将 %0 转换为 %1 的 reinterpret_cast 需要其地址，但�
 # "releasing %0 '%1' that was not held"
 HD16686A7FEA7: "释放未持有的 %0 '%1'"
 # "releasing %0 '%1' using %select{shared|exclusive}2 access, expected %select{shared|exclusive}3 access"
-H2106963D41B0: "使用%select{共享|独占}2访问释放%0 '%1'，期望使用%select{共享|独占}3访问"
+H2106963D41B0: "使用%select{共享|独占}2访问释放 %0 '%1'，期望使用%select{共享|独占}3访问"
 # 'remainder by zero in preprocessor expression'
 HE098B5222CAD: '预处理表达式中的除零余数'
 # 'remaining %0 candidate%s0 omitted; pass -fshow-overloads=all to show them'
@@ -26321,7 +26321,7 @@ H8BD6D24EAB4A: '将表达式替换为 "%0" %select{|或使用 "xor" 而不是 "^
 # 'replace parentheses with an initializer to declare a variable'
 H1CB1AEAC6164: '移除括号并使用初始化器以声明变量'
 # "replacement function %0 cannot be declared 'inline'"
-H8E774898376D: "替换函数%0不能声明为'inline'"
+H8E774898376D: "替换函数 %0 不能声明为 'inline'"
 # 'report accesses through a pointer which has poisoned shadow'
 HDB29EEB5BF15: '报告通过具有中毒阴影的指针的访问'
 # 'report stats in csv'
@@ -26329,39 +26329,39 @@ H4FBFD3CEA227: '以CSV格式报告统计信息'
 # 'report stats in text'
 HDFF33DBA8938: '以文本格式报告统计信息'
 # "requested 'init_priority' %0 is reserved for internal use"
-H2E025E570ED5: "请求的'init_priority' %0保留用于内部使用"
+H2E025E570ED5: "请求的 'init_priority' %0 保留用于内部使用"
 # 'requested alignment %0 is not a positive power of two'
-H9C01C430B004: '请求的对齐值%0不是正的2的幂次方'
+H9C01C430B004: '请求的对齐值 %0 不是正的 2 的幂次方'
 # 'requested alignment is dependent but declaration is not dependent'
 H9D546DA38E42: '请求的对齐依赖于模板参数，但声明本身不依赖于模板参数'
 # 'requested alignment is less than minimum alignment of %1 for type %0'
-H9E0857E89F1F: '请求的对齐值小于类型%0的最小对齐值%1'
+H9E0857E89F1F: '请求的对齐值小于类型 %0 的最小对齐值 %1'
 # 'requested alignment is not a power of 2'
-HC6B6240D895B: '请求的对齐值不是2的幂次方'
+HC6B6240D895B: '请求的对齐值不是 2 的幂次方'
 # 'requested alignment must be %0 bytes or smaller'
-H7B9D334BA24B: '请求的对齐值必须为%0字节或更小'
+H7B9D334BA24B: '请求的对齐值必须为 %0 字节或更小'
 # 'requested alignment must be %0 bytes or smaller; maximum alignment assumed'
-HCDB68D900AC4: '请求的对齐值必须为%0字节或更小；假设最大对齐'
+HCDB68D900AC4: '请求的对齐值必须为 %0 字节或更小；假设最大对齐'
 # 'requested alignment must be %0 or greater'
-H097A66E5C9B7: '请求的对齐值必须为%0或更大'
+H097A66E5C9B7: '请求的对齐值必须为 %0 或更大'
 # 'requested alignment must be %0 or less for type %1; %2 is invalid'
-H6B97FB634040: '类型%1的请求对齐值必须为%0或更小；%2无效'
+H6B97FB634040: '类型 %1 的请求对齐值必须为 %0 或更小；%2 无效'
 # 'requested alignment must be %0 or smaller'
-HEC3786C66ADB: '请求的对齐值必须为%0或更小'
+HEC3786C66ADB: '请求的对齐值必须为 %0 或更小'
 # 'requested shift is a vector of type %0 but the first operand is not a vector (%1)'
-H149741EFCCA5: '请求的移位是一个类型为%0的向量，但第一个操作数不是向量（%1）'
+H149741EFCCA5: '请求的移位是一个类型为 %0 的向量，但第一个操作数不是向量（%1）'
 # 'required alignment of type %0 (%1 bytes) is larger than the supported alignment of C++ exception objects on this target (%2 bytes)'
-HFFCA5AAB79EE: '类型%0的必需对齐值（%1字节）大于此目标支持的C++异常对象的最大对齐值（%2字节）'
+HFFCA5AAB79EE: '类型 %0 的必需对齐值（%1 字节）大于此目标支持的C++异常对象的最大对齐值（%2 字节）'
 # "required by %select{'require_constant_initialization' attribute|'constinit' specifier}0 here"
 H669C2D015B6E: '由%select{require_constant_initialization属性|constinit说明符}0在此处要求'
 # 'requires clause differs in template redeclaration'
 H3C91EEDA34FA: '模板重新声明中的requires子句不同'
 # "requires expression in requirement body; did you intend to place it in a nested requirement? (add another 'requires' before the expression)"
-H818E1323CB5B: "在要求体中使用requires表达式；是否应将其置于嵌套要求中？（在表达式前添加另一个'requires'）"
+H818E1323CB5B: "在要求体中使用requires表达式；是否应将其置于嵌套要求中？（在表达式前添加另一个 'requires'）"
 # "reserved locator 'omp_all_memory' cannot be specified more than once"
-HBB5542941955: "保留的定位符'omp_all_memory'不能指定多次"
+HBB5542941955: "保留的定位符 'omp_all_memory' 不能指定多次"
 # "reserved locator 'omp_all_memory' requires 'out' or 'inout' dependency types"
-H98614BF4F5B5: "保留的定位符'omp_all_memory'需要依赖类型为'out'或'inout'"
+H98614BF4F5B5: "保留的定位符 'omp_all_memory' 需要依赖类型为 'out' 或 'inout'"
 # 'resolve all otherwise unresolved externals to null'
 H0D8FB57C5D95: '将所有其他未解析的外部符号解析为null'
 # 'respect alignment requirements provided by input IR'
@@ -26369,75 +26369,75 @@ H3C9B5ECCDE76: '遵守输入IR提供的对齐要求'
 # 'restrict requires a pointer or reference'
 H044B0871CB3F: 'restrict需要指针或引用'
 # 'restrict requires a pointer or reference (%0 is invalid)'
-HB4AA3977DC42: 'restrict需要指针或引用（%0无效）'
+HB4AA3977DC42: 'restrict需要指针或引用（%0 无效）'
 # "result argument to %select{overflow builtin|checked integer operation}0 must be a pointer to a non-const integer type %select{|other than plain 'char', 'bool', bit-precise, or an enumeration }0(%1 invalid)"
-HD81ECBB4661A: "传给%select{溢出内建函数|有符号整数运算}0的result参数必须是指向非const整数类型的指针%select{|而不是普通的'char'、'bool'、精确位数或枚举类型}0（%1无效）"
+HD81ECBB4661A: "传给%select{溢出内建函数|有符号整数运算}0的result参数必须是指向非const整数类型的指针%select{|而不是普通的 'char'、'bool'、精确位数或枚举类型}0（%1 无效）"
 # "result of '%0' is %1; did you mean '%2' (%3)?"
-H369683737B3D: "'%0'的结果是%1；是否是指'%2' (%3)？"
+H369683737B3D: "'%0' 的结果是 %1；是否是指 '%2' (%3)？"
 # "result of '%0' is %1; did you mean '%2'?"
-H1B6516041439: "'%0'的结果是%1；是否是指'%2'？"
+H1B6516041439: "'%0' 的结果是 %1；是否是指 '%2'？"
 # "result of '%0' is %1; did you mean exponentiation?"
-H6BDF285BA0FF: "'%0'的结果是%1；是否是指指数运算？"
+H6BDF285BA0FF: "'%0' 的结果是 %1；是否是指指数运算？"
 # 'result of comparison %select{%3|%1}0 %2 %select{%1|%3}0 is always %4'
-H3D76D2CD2831: '%select{%3|%1}0 %2 %select{%1|%3}0的比较结果始终为%4'
+H3D76D2CD2831: '%select{%3|%1}0 %2 %select{%1|%3}0的比较结果始终为 %4'
 # 'result of comparison against %select{a string literal|@encode}0 is unspecified (use an explicit string comparison function instead)'
 H42F5B6822163: '与%select{字符串字面量|@encode}0的比较结果未指定（请改用显式字符串比较函数）'
 # 'result of comparison of %select{%3|char expression}0 %2 %select{char expression|%3}0 is always %4, since char is interpreted as unsigned'
-H2652DE195D69: '比较%select{%3|字符表达式}0 %2 %select{字符表达式|%3}0的结果始终为%4，因为char被视为无符号类型'
+H2652DE195D69: '比较%select{%3|字符表达式}0 %2 %select{字符表达式|%3}0的结果始终为 %4，因为char被视为无符号类型'
 # 'result of comparison of %select{%3|unsigned enum expression}0 %2 %select{unsigned enum expression|%3}0 is always %4'
-H86DA5A0E3154: '比较%select{%3|无符号枚举表达式}0 %2 %select{无符号枚举表达式|%3}0的结果始终为%4'
+H86DA5A0E3154: '比较%select{%3|无符号枚举表达式}0 %2 %select{无符号枚举表达式|%3}0的结果始终为 %4'
 # 'result of comparison of %select{%3|unsigned expression}0 %2 %select{unsigned expression|%3}0 is always %4'
-HABA37A2C23DF: '比较%select{%3|无符号表达式}0 %2 %select{无符号表达式|%3}0的结果始终为%4'
+HABA37A2C23DF: '比较%select{%3|无符号表达式}0 %2 %select{无符号表达式|%3}0的结果始终为 %4'
 # 'result of comparison of %select{%4|%1-bit %select{signed|unsigned}2 value}0 %3 %select{%1-bit %select{signed|unsigned}2 value|%4}0 is always %5'
-H3E54DBA92461: '比较%select{%4|%1位%select{有符号|无符号}2类型值}0 %3 和 %select{%1位%select{有符号|无符号}2类型值|%4}0的结果始终为%5'
+H3E54DBA92461: '比较%select{%4|%1 位%select{有符号|无符号}2类型值}0 %3 和 %select{%1 位%select{有符号|无符号}2类型值|%4}0的结果始终为 %5'
 # 'result of comparison of %select{constant %0|true|false}1 with %select{expression of type %2|boolean expression}3 is always %4'
-H0604EEA5685E: '将%select{常量%0|true|false}1与%select{类型%2的表达式|布尔表达式}3比较的结果始终为%4'
+H0604EEA5685E: '将%select{常量 %0|true|false}1与%select{类型 %2 的表达式|布尔表达式}3比较的结果始终为 %4'
 # "result of comparison of constant %0 with expression of type 'BOOL' is always %1, as the only well defined values for 'BOOL' are YES and NO"
-H641A75823917: "与类型'BOOL'的表达式比较的常量%0结果始终为%1，因为'BOOL'的唯一定义值是YES和NO"
+H641A75823917: "与类型 'BOOL' 的表达式比较的常量 %0 结果始终为 %1，因为 'BOOL' 的唯一定义值是YES和NO"
 # "retain'ed block property does not copy the block - use copy attribute instead"
-HD7F1D5C5B0F0: "'retain'的块属性不会复制该块 - 请改用copy属性"
+HD7F1D5C5B0F0: "'retain' 的块属性不会复制该块 - 请改用copy属性"
 # 'return in the catch of a function try block of a constructor is illegal'
 HBC7FDA21A80E: '构造函数的函数try块catch子句中的return语句是非法的'
 # "return state set for an unconsumable type '%0'"
-H2753EF9C9B3B: "为不可消耗类型'%0'设置了返回状态"
+H2753EF9C9B3B: "为不可消耗类型 '%0' 设置了返回状态"
 # "return statement not allowed in coroutine; did you mean 'co_return'?"
-HD15AAC2A320B: "协程中不允许使用return语句；是否应使用'co_return'？"
+HD15AAC2A320B: "协程中不允许使用return语句；是否应使用 'co_return'？"
 # "return type %0 of selected 'operator==' function for rewritten '%1' comparison is not 'bool'"
-HC9853B2276CB: "为重写'%1'比较的选定'operator=='函数，其返回类型%0不是'bool'"
+HC9853B2276CB: "为重写 '%1' 比较的选定'operator=='函数，其返回类型 %0 不是 'bool'"
 # 'return type cannot be qualified with address space'
 H90249355EB7F: '返回类型不能用地址空间修饰'
 # 'return type deduction is incompatible with C++ standards before C++14'
 HB4A5F5EFADA6: '返回类型推导与C++14之前的C++标准不兼容'
 # "return type for defaulted %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator must be 'bool', not %1"
-H2EF639AB940D: "默认实现的%select{<ERROR>|相等|三向|相等|关系}0比较运算符的返回类型必须是'bool'而非%1"
+H2EF639AB940D: "默认实现的%select{<ERROR>|相等|三向|相等|关系}0比较运算符的返回类型必须是 'bool' 而非 %1"
 # "return type of 'await_ready' is required to be contextually convertible to 'bool'"
-H043CECD8EB91: "'await_ready'的返回类型必须能上下文转换为'bool'"
+H043CECD8EB91: "'await_ready' 的返回类型必须能上下文转换为 'bool'"
 # "return type of 'await_suspend' is required to be 'void' or 'bool' (have %0)"
-H64AB2C323A61: "'await_suspend'的返回类型必须是'void'或'bool'（当前为%0）"
+H64AB2C323A61: "'await_suspend' 的返回类型必须是 'void' 或 'bool'（当前为 %0）"
 # "return type of 'coroutine_handle<>::address should be 'void*' (have %0) in order to get capability with existing async C API"
-HA713CB41D910: "'coroutine_handle<>::address'的返回类型应为'void*'（当前为%0），以便通过现有异步C API获取功能"
+HA713CB41D910: "'coroutine_handle<>::address'的返回类型应为'void*'（当前为 %0），以便通过现有异步C API获取功能"
 # "return type of 'main' is not 'int'"
-HFBAC240E8034: "'main'的返回类型不是'int'"
+HFBAC240E8034: "'main' 的返回类型不是 'int'"
 # "return type of defaulted 'operator<=>' cannot be deduced because return type %2 of three-way comparison for %select{|member|base class}0 %1 is not a standard comparison category type"
-H424FC8A53CC9: "默认的'operator<=>'的返回类型无法推导，因为%select{|member|base class}0 %1的三向比较返回类型%2不是标准比较类别类型"
+H424FC8A53CC9: "默认的'operator<=>'的返回类型无法推导，因为%select{|member|base class}0 %1 的三向比较返回类型 %2 不是标准比较类别类型"
 # "return type of defaulted 'operator<=>' cannot be deduced because three-way comparison for %select{|member|base class}0 %1 has a deduced return type and is not yet defined"
-H0105A22E2A8D: "默认的'operator<=>'的返回类型无法推导，因为%select{|member|base class}0 %1的三向比较具有推导出的返回类型且尚未定义"
+H0105A22E2A8D: "默认的'operator<=>'的返回类型无法推导，因为%select{|member|base class}0 %1 的三向比较具有推导出的返回类型且尚未定义"
 # 'return type of out-of-line definition of %q0 differs from that in the declaration'
 H469315680A98: '%q0的外部定义的返回类型与声明中的不同'
 # 'return type of virtual function %0 is not covariant with the return type of the function it overrides (%1 has different qualifiers than %2)'
-H00BA4129869D: '虚函数%0的返回类型与它覆盖的函数的返回类型不协变（%1的限定符与%2不同）'
+H00BA4129869D: '虚函数 %0 的返回类型与它覆盖的函数的返回类型不协变（%1 的限定符与 %2 不同）'
 # 'return type of virtual function %0 is not covariant with the return type of the function it overrides (%1 is incomplete)'
-HE8582E3BF357: '虚函数%0的返回类型与它覆盖的函数的返回类型不协变（%1是不完全类型）'
+HE8582E3BF357: '虚函数 %0 的返回类型与它覆盖的函数的返回类型不协变（%1 是不完全类型）'
 # 'return type of virtual function %0 is not covariant with the return type of the function it overrides (%1 is not derived from %2)'
-H5A21B37900C4: '虚函数%0的返回类型与它覆盖的函数的返回类型不协变（%1不是%2的派生类）'
+H5A21B37900C4: '虚函数 %0 的返回类型与它覆盖的函数的返回类型不协变（%1 不是 %2 的派生类）'
 # 'return type of virtual function %0 is not covariant with the return type of the function it overrides (class type %1 does not have the same cv-qualification as or less cv-qualification than class type %2)'
-H2AB9EE663373: '虚函数%0的返回类型与它覆盖的函数的返回类型不协变（类类型%1的cv限定符资格与类类型%2不同或更严格）'
+H2AB9EE663373: '虚函数 %0 的返回类型与它覆盖的函数的返回类型不协变（类类型 %1 的cv限定符资格与类类型 %2 不同或更严格）'
 # 'return type of virtual function %3 is not covariant with the return type of the function it overrides (ambiguous conversion from derived class %0 to base class %1:%2)'
-H94F1AF985110: '虚函数%3的返回类型与它覆盖的函数的返回类型不协变（从派生类%0到基类%1的转换存在歧义：%2）'
+H94F1AF985110: '虚函数 %3 的返回类型与它覆盖的函数的返回类型不协变（从派生类 %0 到基类 %1 的转换存在歧义：%2）'
 # "return value not in expected state; expected '%0', observed '%1'"
-H8EF54209E2EA: "返回值不在期望状态；期望'%0'，实际观察到'%1'"
+H8EF54209E2EA: "返回值不在期望状态；期望 '%0'，实际观察到 '%1'"
 # 'return value of %0 is a large (%1 bytes) pass-by-value object; pass it by reference instead ?'
-HA1B074D05D38: '%0的返回值是一个较大的（%1字节）按值传递对象；建议改为引用传递？'
+HA1B074D05D38: '%0 的返回值是一个较大的（%1 字节）按值传递对象；建议改为引用传递？'
 # 'returning %select{address of|reference to}0 local temporary object'
 H0D9CD7C30605: '返回%select{地址的|引用的}0局部临时对象'
 # 'returning address of label, which is local'
@@ -26445,15 +26445,15 @@ H7C6FDC7A79CE: '返回局部标签的地址，该标签是局部作用域内的'
 # 'returning block that lives on the local stack'
 HFB5C6DCAD180: '返回存活在局部栈上的代码块'
 # "returning pointer %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
-H524B3D4E5221: "返回指针%1需要持有%0 %select{'%2'|'排他性%2'}3"
+H524B3D4E5221: "返回指针 %1 需要持有 %0 %select{'%2'|'排他性 %2'}3"
 # "returning pointer to variable %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
-HC47B423E80E3: "返回变量%1的指针需要持有%0 %select{'%2'|'排他性%2'}3"
+HC47B423E80E3: "返回变量 %1 的指针需要持有 %0 %select{'%2'|'排他性 %2'}3"
 # 'returning reference to local temporary object'
 H3C7B38DADD40: '返回局部临时对象的引用'
 # "returning the value that %1 points to by reference requires holding %0 %select{'%2'|'%2' exclusively}3"
-HDFB7294684C5: "通过引用来返回%1指向的值需要持有%0 %select{'%2'|'%2'独占}3"
+HDFB7294684C5: "通过引用来返回 %1 指向的值需要持有 %0 %select{'%2'|'%2' 独占}3"
 # "returning variable %1 by reference requires holding %0 %select{'%2'|'%2' exclusively}3"
-H5E5D0E85F387: "通过引用来返回变量%1需要持有%0 %select{'%2'|'%2'独占}3"
+H5E5D0E85F387: "通过引用来返回变量 %1 需要持有 %0 %select{'%2'|'%2' 独占}3"
 # "rewriter doesn't support user-specified control flow semantics for @try/@finally (code may not execute properly)"
 H9C522D3EEF6D: '@try/@finally的用户指定控制流语义rewriter不支持（代码可能无法正确执行）'
 # 'rewriting block literal declared in global scope is not implemented'
@@ -26461,9 +26461,9 @@ HC8DC37202696: '全局作用域中声明的块字面量重写未实现'
 # 'rewriting sub-expression within a macro (may not be correct)'
 H72B7281F7712: '宏内的子表达式重写（可能不准确）'
 # 'right hand operand to %0 has non-pointer-to-member type %1'
-H53A963FA3084: '%0的右操作数具有非成员指针类型%1'
+H53A963FA3084: '%0 的右操作数具有非成员指针类型 %1'
 # "right shifting a 'bool' implicitly converts it to 'int'"
-HEDBEE20D2831: "隐式右移'bool'会将其转换为'int'"
+HEDBEE20D2831: "隐式右移 'bool' 会将其转换为 'int'"
 # 'rocPrim path, required by the HIP Standard Parallel Algorithm Acceleration library, used to implicitly include the rocPrim library'
 HD40BA7FFEFEE: 'rocPrim 路径，由 HIP 标准并行算法加速库所需，用于隐式包含 rocPrim 库'
 # 'rocThrust path, required by the HIP Standard Parallel Algorithm Acceleration library, used to implicitly include the rocThrust library'
@@ -26473,13 +26473,13 @@ H57D5B6539CD2: '运行retpoline插入Pass'
 # 'run veneer elimination pass'
 HC2BE3F62417A: '运行veneer消除Pass'
 # "runpath search paths do not match: '%0' (provided) vs '%1' (found)"
-H2CB428691FF3: "运行路径搜索路径不匹配：'%0'（提供的）与'%1'（检测到的）"
+H2CB428691FF3: "运行路径搜索路径不匹配：'%0'（提供的）与 '%1'（检测到的）"
 # "runpath search paths missing from %0: '%1'"
-H427437B03484: "%0中缺少运行路径搜索路径：'%1'"
+H427437B03484: "%0 中缺少运行路径搜索路径：'%1'"
 # 'rvalue reference %diff{to type $ cannot bind to lvalue of type $|cannot bind to incompatible lvalue}0,1'
 H5D62614FC181: '右值引用%diff{到类型$不能绑定到类型$的左值|无法绑定到不兼容的左值}0,1'
 # 'rvalue reference type %0 is not allowed in exception specification'
-H63B188C37A7C: '异常规范中不允许使用右值引用类型%0'
+H63B188C37A7C: '异常规范中不允许使用右值引用类型 %0'
 # 'rvalue references are a C++11 extension'
 HE6F99D294F8D: '右值引用是C++11扩展'
 # 'rvalue references are incompatible with C++98'
@@ -26495,17 +26495,17 @@ H855EE2722E18: '同一移动修饰符被多次指定'
 # 'same pointer dereferenced in multiple different ways in map clause expressions'
 H176F03468FDB: '映射子句表达式中同一指针被以不同方式解引用'
 # 'sampler initializer has invalid %0 bits'
-H18D45D49E7B9: '采样器初始化器具有无效的%0位'
+H18D45D49E7B9: '采样器初始化器具有无效的 %0 位'
 # 'sampler type cannot be used with the __local and __global address space qualifiers'
 H2695DF30EE8D: '采样器类型不能与__local和__global地址空间限定符一起使用'
 # 'sampler_t initialization requires 32-bit integer, not %0'
-HB7C873D08ECC: 'sampler_t初始化需要32位整数，而非%0'
+HB7C873D08ECC: 'sampler_t初始化需要 32 位整数，而非 %0'
 # 'sampler_t variable required - got %0'
-H54F7785F9F3D: '需要sampler_t变量 - 实际得到%0'
+H54F7785F9F3D: '需要sampler_t变量 - 实际得到 %0'
 # 'sanstats Options'
 H8526EFD0A943: 'sanstats 选项'
 # "satisfaction of constraint '%0' depends on itself"
-H3716B39C40C1: "约束条件'%0'的满足情况依赖于自身"
+H3716B39C40C1: "约束条件 '%0' 的满足情况依赖于自身"
 # 'save recorded profile to a file'
 H0DD7B7A894BB: '将记录的配置文件保存到文件中'
 # 'scalar initialized from empty initializer list is incompatible with C++98'
@@ -26513,11 +26513,11 @@ H4040E7512491: '标量变量由空初始化列表初始化与C++98不兼容'
 # 'scalar initializer cannot be empty'
 HD3067EEE76AC: '标量初始化器不能为空'
 # 'scalar operand type has greater rank than the type of the vector element. (%0 and %1)'
-H2C50DCFF8689: '标量操作数类型比向量元素类型的秩更高. (%0和%1)'
+H2C50DCFF8689: '标量操作数类型比向量元素类型的秩更高. (%0 和 %1)'
 # 'scale argument must be 1, 2, 4, or 8'
-H325DB8FF3A78: 'scale参数必须为1、2、4或8'
+H325DB8FF3A78: 'scale参数必须为 1、2、4或 8'
 # 'scale factor for the latch probability. Value should be greater than 1. Lower values are ignored'
-HAACE1BBE5003: 'latch概率的缩放因子。值应大于1。较小的值将被忽略'
+HAACE1BBE5003: 'latch概率的缩放因子。值应大于 1。较小的值将被忽略'
 # 'scale of asan shadow mapping'
 H538257B2498C: 'ASan阴影映射的缩放比例'
 # 'scale of memprof shadow mapping'
@@ -26531,21 +26531,21 @@ H880FA70730D4: '作用域枚举是C++11扩展'
 # 'scoped enumerations are incompatible with C++98'
 H8FFFE671E01D: '作用域枚举与C++98不兼容'
 # 'score expressions in the OpenMP context selector need to be constant; %0 is not and will be ignored'
-HBAE673BA4B11: 'OpenMP上下文选择器中的评分表达式需要是常量;%0不是常量且将被忽略'
+HBAE673BA4B11: 'OpenMP上下文选择器中的评分表达式需要是常量;%0 不是常量且将被忽略'
 # "search path used: '%0'"
 H5005F53FE066: "使用的搜索路径为: '%0'"
 # "second argument to 'va_arg' is of ARC ownership-qualified type %0"
-H5B02CB112F2F: 'va_arg的第二个参数是ARC所有权限定类型%0'
+H5B02CB112F2F: 'va_arg的第二个参数是ARC所有权限定类型 %0'
 # "second argument to 'va_arg' is of abstract type %0"
-HB0CBA3C6712C: 'va_arg的第二个参数是抽象类型%0'
+HB0CBA3C6712C: 'va_arg的第二个参数是抽象类型 %0'
 # "second argument to 'va_arg' is of array type %0; this va_arg has undefined behavior because arguments will never be compatible with array type"
-H0271D72D02D0: 'va_arg的第二个参数是数组类型%0;此va_arg行为未定义，因为参数永远不会与数组类型兼容'
+H0271D72D02D0: 'va_arg的第二个参数是数组类型 %0;此va_arg行为未定义，因为参数永远不会与数组类型兼容'
 # "second argument to 'va_arg' is of incomplete type %0"
-HBAB6DD203AC7: 'va_arg的第二个参数是不完全类型%0'
+HBAB6DD203AC7: 'va_arg的第二个参数是不完全类型 %0'
 # "second argument to 'va_arg' is of non-POD type %0"
-H6E23523199DB: 'va_arg的第二个参数是非POD类型%0'
+H6E23523199DB: 'va_arg的第二个参数是非POD类型 %0'
 # "second argument to 'va_arg' is of promotable type %0; this va_arg has undefined behavior because arguments will be promoted to %1"
-HD77AAC429CAF: 'va_arg的第二个参数是可提升类型%0;此va_arg行为未定义，因为参数将被提升为%1类型'
+HD77AAC429CAF: 'va_arg的第二个参数是可提升类型 %0;此va_arg行为未定义，因为参数将被提升为 %1 类型'
 # "second argument to 'va_start' is not the last non-variadic parameter"
 H37CA82AB0144: '__builtin_alloca_with_align的第二个参数应以比特为单位'
 # 'second argument to __builtin_alloca_with_align is supposed to be in bits'
@@ -26619,7 +26619,7 @@ H31FAC4015C01: '缩短指令'
 # 'show a graph.'
 HDBFEE5F65752: '显示图形。'
 # 'show execution count of functions in binary 2 as a ratio of the total samples in binary 1 - make sure both profiles have equal collection time and sampling rate for this to make sense'
-H7302A3496B1D: '以二进制文件1的总采样数为基准，显示二进制文件2中函数的执行次数比率——请确保两个配置文件的采集时间和采样率相同，否则此结果可能无意义'
+H7302A3496B1D: '以二进制文件 1 的总采样数为基准，显示二进制文件 2 中函数的执行次数比率——请确保两个配置文件的采集时间和采样率相同，否则此结果可能无意义'
 # 'show in text.'
 H8201270E0209: '以文本显示。'
 # 'show profile density details'
@@ -26669,7 +26669,7 @@ H5666676F632D: '大小必须是 %select{1、2 或 4|1、2、4、12 或 16}'
 # "size of '__builtin_bit_cast' source type %0 does not match destination type %1 (%2 vs %3 bytes)"
 HE2800B62712B: "'__builtin_bit_cast' 的源类型 %0 的大小与目标类型 %1 不匹配（%2 字节 vs %3 字节）"
 # 'size of a heat map block in bytes (default 64)'
-HF50CC8CAD0AC: '热图块的大小（以字节为单位，默认64）'
+HF50CC8CAD0AC: '热图块的大小（以字节为单位，默认 64）'
 # "size of array element of type %0 (%1 bytes) isn't a multiple of its alignment (%2 bytes)"
 H64B3D7C6AA54: '类型 %0 的数组元素的大小（%1 字节）不是其对齐值（%2 字节）的倍数'
 # 'size of array has non-integer type %0'
@@ -26781,79 +26781,79 @@ H593FAF497273: '根据函数执行频率将跳转表节段拆分为热和冷部�
 # 'split-file Options'
 HDBFADA679092: 'split-file 选项'
 # "stack frame size (%0) exceeds limit (%1) in '%2'"
-HCF0AF62F4A65: "栈帧大小（%0）超过限制（%1）在'%2'中"
+HCF0AF62F4A65: "栈帧大小（%0）超过限制（%1）在 '%2' 中"
 # 'stack nearly exhausted; compilation time may suffer, and crashes due to stack overflow are likely'
 HD310C1B31961: '栈几乎耗尽；编译时间可能受到影响，并且可能发生因栈溢出导致的崩溃'
 # "standard library implementation of %0 is not supported; %select{member '%2' does not have expected form|member '%2' is missing|the type is not trivially copyable|the type does not have the expected form}1"
-H8A51A30A514F: '%0的标准库实现不被支持；%select{成员"%2"不符合期望形式|缺少成员"%2"|类型非平凡可复制|类型不符合期望形式}1'
+H8A51A30A514F: '%0 的标准库实现不被支持；%select{成员 "%2" 不符合期望形式|缺少成员 "%2"|类型非平凡可复制|类型不符合期望形式}1'
 # 'standard library not linked and so no interrupt vector table or compiler runtime routines will be linked'
 H3B6E22A7AD97: '未链接标准库，因此不会链接中断向量表或编译器运行时例程'
 # 'star modifier used outside of function prototype'
 HA2B9806ED1A1: '在函数原型之外使用星号修饰符'
 # "state of variable '%0' must match at the entry and exit of loop"
-H7D285ABC5B72: "变量'%0'在循环入口和出口处的状态必须一致"
+H7D285ABC5B72: "变量 '%0' 在循环入口和出口处的状态必须一致"
 # "statement after '#pragma omp dispatch' must be a direct call to a target function or an assignment to one"
 H172FE1A4272E: "在'#pragma omp dispatch'之后的语句必须是直接调用目标函数或将其赋值"
 # "statement associated with OpenACC 'atomic%select{| %1}0' directive is invalid"
 H42056AC9B64A: "与OpenACC 'atomic%select{| %1}0'指令关联的语句无效"
 # "statement attribute %0 has higher precedence than function attribute '%select{always_inline|flatten|noinline}1'"
-H0AF92FCED836: "语句属性%0的优先级高于函数属性'%select{always_inline|flatten|noinline}1'"
+H0AF92FCED836: "语句属性 %0 的优先级高于函数属性'%select{always_inline|flatten|noinline}1'"
 # 'statement expression not allowed at file scope'
 HB4FE90B7D7C8: '文件作用域内不允许使用语句表达式'
 # "statement in 'omp %0' directive must be enclosed into a section region"
 H69791FF123D5: "在'omp %0'指令中的语句必须包含在section区域中"
 # 'statement not allowed in %select{constexpr|consteval}1 %select{function|constructor}0'
-HD56C75E5841E: '在%select{constexpr|consteval}1 %select{函数|构造函数}0中不允许使用该语句'
+HD56C75E5841E: '在 %select{constexpr|consteval}1 %select{函数|构造函数}0中不允许使用该语句'
 # 'statement requires expression of integer type (%0 invalid)'
-H752828F0ECD0: '该语句需要整型表达式（%0无效）'
+H752828F0ECD0: '该语句需要整型表达式（%0 无效）'
 # 'statement requires expression of scalar type (%0 invalid)'
-HFBBF3A578FA4: '该语句需要标量类型表达式（%0无效）'
+HFBBF3A578FA4: '该语句需要标量类型表达式（%0 无效）'
 # 'static %0 runtime is not supported on darwin'
-H52FFB37B4DFA: '在Darwin系统上不支持static %0运行时'
+H52FFB37B4DFA: '在Darwin系统上不支持static %0 运行时'
 # 'static %select{function|variable}0 %1 is used in an inline function with external linkage'
-HBAA29A669BB7: '静态%select{函数|变量}0 %1被用于具有外部链接的内联函数中'
+HBAA29A669BB7: '静态%select{函数|变量}0 %1 被用于具有外部链接的内联函数中'
 # 'static and non-static member functions with the same parameter types cannot be overloaded'
 H455410FE204F: '具有相同参数类型的静态和非静态成员函数不能重载'
 # 'static assertion expression is not an integral constant expression'
 H4896ABC370E3: '静态断言表达式不是整型常量表达式'
 # "static assertion failed due to requirement '%0'%select{: %2|}1"
-H3D43CA56F16F: "静态断言失败，因为要求'%0'%select{：%2|}1"
+H3D43CA56F16F: "静态断言失败，因为要求 '%0'%select{：%2|}1"
 # 'static assertion failed%select{: %1|}0'
 H4F7EABF6B0DD: '静态断言失败%select{：%1|}0'
 # 'static const volatile data member must be initialized out of line'
 H407C919E04E8: '具有static const volatile类型的成员数据必须在外部初始化'
 # 'static data member %0 already has an initializer'
-H6ACB0F956377: '静态数据成员%0已经有一个初始化器'
+H6ACB0F956377: '静态数据成员 %0 已经有一个初始化器'
 # 'static data member %0 in union is a C++11 extension'
-HA330F37BE63B: '联合中的静态数据成员%0是C++11扩展'
+HA330F37BE63B: '联合中的静态数据成员 %0 是C++11扩展'
 # 'static data member %0 in union is incompatible with C++98'
-HEBF9EACD8366: '联合中的静态数据成员%0与C++98标准不兼容'
+HEBF9EACD8366: '联合中的静态数据成员 %0 与C++98标准不兼容'
 # 'static data member %0 not allowed in anonymous %select{struct|interface|union|class|enum}1'
-HC964FFEFDD87: '不允许在匿名%select{struct|interface|union|class|enum}1中的静态数据成员%0'
+HC964FFEFDD87: '不允许在匿名 %select{struct|interface|union|class|enum}1 中的静态数据成员 %0'
 # 'static data member %0 not allowed in local %select{struct|interface|union|class|enum}2 %1'
-HA56CE2DF143E: '不允许在局部%select{struct|interface|union|class|enum}2 %1中的静态数据成员%0'
+HA56CE2DF143E: '不允许在局部 %select{struct|interface|union|class|enum}2 %1 中的静态数据成员 %0'
 # 'static data member definition cannot specify a storage class'
 HF3222609AACF: '静态数据成员的定义不能指定存储类别'
 # 'static data member of type %0 must be initialized out of line'
-H4598A36D5110: '类型为%0的静态数据成员必须在外部初始化'
+H4598A36D5110: '类型为 %0 的静态数据成员必须在外部初始化'
 # 'static declaration of %0 follows non-static declaration'
-H2C721D0B8C3C: '%0的静态声明跟随了非静态声明'
+H2C721D0B8C3C: '%0 的静态声明跟随了非静态声明'
 # 'static lambdas are a C++23 extension'
 H0728106ADDA2: '静态lambda表达式是C++23扩展'
 # 'static lambdas are incompatible with C++ standards before C++23'
 H81C85F6C724E: '静态lambda表达式与C++23之前的C++标准不兼容'
 # 'static member %0 cannot be a bit-field'
-HDFCBA261B7FE: '静态成员%0不能是位域'
+HDFCBA261B7FE: '静态成员 %0 不能是位域'
 # 'static members cannot be declared in an anonymous %select{struct|union}0'
-HF2CC0A1A3C82: '不允许在匿名%select{struct|union}0中声明静态成员'
+HF2CC0A1A3C82: '不允许在匿名 %select{struct|union}0 中声明静态成员'
 # 'static variable %0 is suspiciously used within its own initialization'
-H1CCD7A0167D8: '静态变量%0在其自身初始化中被可疑地使用'
+H1CCD7A0167D8: '静态变量 %0 在其自身初始化中被可疑地使用'
 # 'static_cast between pointer-to-function and pointer-to-object is a Microsoft extension'
 H747267A37B70: '在函数指针和对象指针之间使用static_cast是微软扩展'
 # "std::coroutine_handle isn't a class template"
 H20FD07579F32: 'std::coroutine_handle不是类模板'
 # "std::coroutine_handle must have a member named '%0'"
-HC01B7EC5D8D7: "std::coroutine_handle必须有一个名为'%0'的成员"
+HC01B7EC5D8D7: "std::coroutine_handle必须有一个名为 '%0' 的成员"
 # "std::coroutine_traits isn't a class template"
 H3D3F8F520E5F: 'std::coroutine_traits不是类模板'
 # 'std::initializer_list must be a class template with a single type parameter'
@@ -26861,9 +26861,9 @@ H57E56532E11C: 'std::initializer_list必须是一个具有单个类型参数的�
 # 'std::nothrow must be a valid variable declaration'
 H81985EEDEA6B: 'std::nothrow必须是一个有效的变量声明'
 # 'std::nothrow was not found; include <new> before defining a coroutine which uses get_return_object_on_allocation_failure()'
-H553185766FEB: '未找到std::nothrow；在定义使用get_return_object_on_allocation_failure()的协程之前，请包含<new>头文件'
+H553185766FEB: '未找到std::nothrow；在定义使用get_return_object_on_allocation_failure()的协程之前，请包含 <new> 头文件'
 # "step simple modifier is exclusive and cannot be use with 'val', 'uval' or 'ref' modifier"
-H61FE9B0F27A0: "step简单修饰符是互斥的，不能与'val'、'uval'或'ref'修饰符一起使用"
+H61FE9B0F27A0: "step简单修饰符是互斥的，不能与 'val'、'uval' 或 'ref' 修饰符一起使用"
 # 'still within definition of %q0 here'
 HE0627D20A1B5: '仍在%q0的定义范围内'
 # 'stop processing once we have enough to compare two binaries'
@@ -26879,17 +26879,17 @@ H892362B1790A: '用于将基本块划分为片段的策略'
 # 'stress rotate selection in aggressive ppc isel for bit permutations'
 HAC5B66207D31: '在激进的PPC指令选择中强制进行旋转选择以处理位排列'
 # 'strftime format attribute requires 3rd parameter to be 0'
-H48F53118805C: 'strftime格式属性要求第三个参数为0'
+H48F53118805C: 'strftime格式属性要求第三个参数为 0'
 # 'stride must be greater or equal to the number of rows'
 H8F8F20EB9F60: 'stride必须大于或等于行数'
 # 'string is ill-formed as UTF-8 and will become a null %0 when boxed'
-H978281414E51: '该字符串作为UTF-8格式不合法，打包后将成为空%0'
+H978281414E51: '该字符串作为UTF-8格式不合法，打包后将成为空 %0'
 # "string literal after 'operator' cannot have an encoding prefix"
-HE2D46EB90348: "'operator'之后的字符串字面量不能带有编码前缀"
+HE2D46EB90348: "'operator' 之后的字符串字面量不能带有编码前缀"
 # 'string literal after \'operator\' must be \'""\''
-HB2C541BB7B81: "'operator'之后的字符串字面量必须是''"
+HB2C541BB7B81: "'operator' 之后的字符串字面量必须是''"
 # 'string literal of length %0 exceeds maximum length %1 that %select{C90|ISO C99|C++}2 compilers are required to support'
-H446F1FE51F67: '长度为%0的字符串字面量超过了%select{C90|ISO C99|C++}2编译器必须支持的最大长度%1'
+H446F1FE51F67: '长度为 %0 的字符串字面量超过了%select{C90|ISO C99|C++}2编译器必须支持的最大长度 %1'
 # 'string literal operator templates are a GNU extension'
 HC7C4AAEBD81D: '字符串字面量操作符模板是GNU扩展'
 # 'string literal with user-defined suffix cannot be used here'
@@ -26899,7 +26899,7 @@ HA27BA101BC94: '超过此长度的字符串字面量将使用哈希值作为其�
 # 'string to set default kind values'
 H7121B365791A: '设置默认类型值的字符串'
 # "strip 'repz' prefix from 'repz retq' sequence (on by default)"
-H5E0A0D55638D: "从'repz retq'序列中剥离'repz'前缀（默认启用）"
+H5E0A0D55638D: "从'repz retq'序列中剥离 'repz' 前缀（默认启用）"
 # 'structured binding declaration in a condition is a C++2c extension'
 H7AF1E5D1A2D0: '条件中的结构化绑定声明是C++2c扩展'
 # 'structured binding declaration in a condition is incompatible with C++ standards before C++2c'
@@ -26917,23 +26917,23 @@ H146947FFD26E: '子命令'
 # 'subexpression not valid in a constant expression'
 H9779A11486AE: '子表达式在常量表达式中无效'
 # 'submodule %0.%1 not declared in module map'
-H1DA53EDBF661: '模块映射中未声明子模块%0.%1'
+H1DA53EDBF661: '模块映射中未声明子模块 %0.%1'
 # "submodule of top-level module '%0' implicitly imported here"
-HDAE6F5126C46: "顶级模块'%0'的子模块在此处被隐式导入"
+HDAE6F5126C46: "顶级模块 '%0' 的子模块在此处被隐式导入"
 # 'subobject %select{of type |}0%1 is not initialized'
-HF2C7BC6C2C0D: '子对象%select{of type |}0%1未初始化'
+HF2C7BC6C2C0D: '子对象%select{of type |}0%1 未初始化'
 # 'subobject declared here'
 H554F161157BC: '子对象在此处声明'
 # 'subscript of a pointer to void is a GNU extension'
 H3CC7AA95FFD8: '对void类型的指针进行下标操作是GNU扩展'
 # 'subscript of pointer to %select{incomplete|sizeless}0 type %1'
-H1AFEC4E5E6B6: '对类型%select{不完整|零大小}0的%1的指针进行下标操作'
+H1AFEC4E5E6B6: '对类型%select{不完整|零大小}0的 %1 的指针进行下标操作'
 # 'subscript of pointer to function type %0'
-H768DEE928692: '对函数类型%0的指针进行下标操作'
+H768DEE928692: '对函数类型 %0 的指针进行下标操作'
 # 'subscript of svbool_t is not allowed'
 H8F54745267C0: 'svbool_t的下标操作不被允许'
 # 'subscript requires size of interface %0, which is not constant for this architecture and platform'
-H10B94DBD4388: '接口%0的大小不是该架构和平台的常量，无法进行下标操作'
+H10B94DBD4388: '接口 %0 的大小不是该架构和平台的常量，无法进行下标操作'
 # 'subscripted value is not an array or pointer'
 HFC1E308C6B30: '下标操作的值不是数组或指针'
 # 'subscripted value is not an array, pointer, or vector'
@@ -26945,9 +26945,9 @@ H0CC3DD33E92E: '约束表达式替换后得到非常量表达式'
 # 'subtracted pointers are not elements of the same array'
 HBF5BC0994673: '相减的指针不是同一数组的元素'
 # 'subtraction of pointers to type %0 of zero size'
-HAE88E507C99F: '对大小为零的类型%0的指针进行相减'
+HAE88E507C99F: '对大小为零的类型 %0 的指针进行相减'
 # 'subtraction of pointers to type %0 of zero size has undefined behavior'
-H238100FAEBF4: '对大小为零的类型%0的指针进行相减具有未定义行为'
+H238100FAEBF4: '对大小为零的类型 %0 的指针进行相减具有未定义行为'
 # 'suffix with parentheses to turn this into a function call'
 HBA5C36C9B0F9: '使用带括号的后缀将其转换为函数调用'
 # 'suggest braces around initialization of subobject'
@@ -26959,11 +26959,11 @@ HC924164CBDE2: "对不同文件名的'/Yc'和'/Yu'支持尚未实现；忽略该
 # "support for '/Yc' with more than one source file not implemented yet; flag ignored"
 H7450874B7BA1: "对多个源文件的'/Yc'支持尚未实现；忽略该标志"
 # 'support for HLSL language version %0 is incomplete, recommend using %1 instead'
-H68BB4F93A02C: '对HLSL语言版本%0的支持不完整，建议改用%1'
+H68BB4F93A02C: '对HLSL语言版本 %0 的支持不完整，建议改用 %1'
 # "support for linking stdlibs for microcontroller '%0' is not implemented"
-H8995E8434A04: "对微控制器'%0'的stdlib链接支持尚未实现"
+H8995E8434A04: "对微控制器 '%0' 的stdlib链接支持尚未实现"
 # "support for passing the data section address to the linker for microcontroller '%0' is not implemented"
-H870D8231D796: "对微控制器'%0'向链接器传递数据段地址的支持尚未实现"
+H870D8231D796: "对微控制器 '%0' 向链接器传递数据段地址的支持尚未实现"
 # 'surrounding namespace with visibility attribute ends here'
 H4297D0DA8CEA: '带有可见性属性的外围命名空间在此结束'
 # 'surrounding namespace with visibility attribute starts here'
@@ -26973,9 +26973,9 @@ HE00F78FF32CA: '在数组初始化中可疑地连接字符串字面量；您是�
 # 'switch condition has boolean value'
 HA563E9019204: 'switch条件具有布尔值'
 # 'switch condition has incomplete class type %0'
-HD68BA6071310: 'switch条件具有不完整的类类型%0'
+HD68BA6071310: 'switch条件具有不完整的类类型 %0'
 # 'switch condition type %0 requires explicit conversion to %1'
-HF719378BC596: 'switch条件类型%0需要显式转换为%1'
+HF719378BC596: 'switch条件类型 %0 需要显式转换为 %1'
 # 'switch statement has empty body'
 HD379C27E8554: 'switch语句具有空的主体'
 # "symbol exported in dynamic library, but marked hidden in declaration '%0'"
@@ -26989,17 +26989,17 @@ H4B741D643A7C: '符号化解析函数'
 # 'synchronization scope argument to atomic operation is invalid'
 HE1E237FB50C9: '原子操作的同步作用域参数无效'
 # 'synthesized properties %0 and %1 both claim instance variable %2'
-H9EA52B48540E: '合成属性%0和%1均声明实例变量%2'
+H9EA52B48540E: '合成属性 %0 和 %1 均声明实例变量 %2'
 # 'synthesized properties %0 and %1 both claim setter %2 - use of this setter will cause unexpected behavior'
-HA9255CAB38EC: '合成属性%0和%1均声明setter%2 — 使用此setter会导致意外行为'
+HA9255CAB38EC: '合成属性 %0 和 %1 均声明setter%2 — 使用此setter会导致意外行为'
 # 'synthesized property %0 must either be named the same as a compatible instance variable or must explicitly name an instance variable'
-HC10D22B3B816: '合成属性%0必须与兼容的实例变量同名，或者必须显式指定实例变量'
+HC10D22B3B816: '合成属性 %0 必须与兼容的实例变量同名，或者必须显式指定实例变量'
 # 'synthesized property with variable size type %0 requires an existing instance variable'
-H594CC555D195: '类型%0的可变大小合成属性需要已有的实例变量'
+H594CC555D195: '类型 %0 的可变大小合成属性需要已有的实例变量'
 # 'synthesized setter %0 for null_resettable property %1 does not handle nil'
-H95960177BFF3: 'null_resettable属性%1的合成setter%0无法处理nil'
+H95960177BFF3: 'null_resettable属性 %1 的合成setter%0 无法处理nil'
 # 'synthesizing __weak instance variable of type %0, which does not support weak references'
-H1E4EBACF7211: '合成类型%0的__weak实例变量，而该类型不支持弱引用'
+H1E4EBACF7211: '合成类型 %0 的__weak实例变量，而该类型不支持弱引用'
 # 'system diff used by change reporters'
 HBA4E429740F6: '变更报告程序使用的系统diff'
 # 'system dot used by change reporters'
@@ -27009,7 +27009,7 @@ HDC606CA00EBA: '大小（以字节为单位）超过该值的尾块永远不会�
 # 'tail blocks with size (in bytes) not exceeding the value are always duplicated'
 H2F3A5FED8EF0: '大小（以字节为单位）不超过该值的尾块始终会被复制'
 # 'tail call required by %0 attribute here'
-H9FB91CA4B73B: '此处%0属性要求尾调用'
+H9FB91CA4B73B: '此处 %0 属性要求尾调用'
 # 'tail call requires that the return value, all parameters, and any temporaries created by the expression are trivially destructible'
 HE303C40B04A3: '尾调用要求返回值、所有参数以及表达式创建的任何临时对象都可简单销毁'
 # 'taking address of a capture is not allowed'
@@ -27021,37 +27021,37 @@ H3ACD682CFC45: '不允许获取标准库中不可寻址函数的地址'
 # 'taking address of non-addressable standard library function is incompatible with C++20'
 H888C6C415192: '获取不可取址的标准库函数的地址与C++20不兼容'
 # 'taking address of packed member %0 of class or structure %q1 may result in an unaligned pointer value'
-HD700C27ED0FC: '获取类或结构体%q1的已压缩成员%0的地址可能导致未对齐的指针值'
+HD700C27ED0FC: '获取类或结构体%q1的已压缩成员 %0 的地址可能导致未对齐的指针值'
 # 'taking the absolute value of %select{pointer|function|array}0 type %1 is suspicious'
-HDEB21F2512CF: '对%select{指针|函数|数组}0类型%1取绝对值存在可疑之处'
+HDEB21F2512CF: '对%select{指针|函数|数组}0类型 %1 取绝对值存在可疑之处'
 # 'taking the absolute value of unsigned type %0 has no effect'
-H8F6DAEC8BECD: '对无符号类型%0取绝对值不会有影响'
+H8F6DAEC8BECD: '对无符号类型 %0 取绝对值不会有影响'
 # 'taking the address of a destructor'
 H7B853F7C78AC: '获取析构函数的地址'
 # 'taking the address of a temporary object of type %0'
-HD39DC5626A0A: '获取类型%0的临时对象的地址'
+HD39DC5626A0A: '获取类型 %0 的临时对象的地址'
 # 'taking the max of %select{a value and unsigned zero|unsigned zero and a value}0 is always equal to the other value'
 H75EF0725015B: '对%select{一个值和无符号零|无符号零和一个值}0取最大值始终等于另一个值'
 # 'target %select{constructor|destructor}0 is declared here'
 HD59E728E618B: '目标%select{构造函数|析构函数}0在这里声明'
 # "target '%0' does not support exception handling; 'catch' block is ignored"
-H06DD0F5375FE: "目标'%0'不支持异常处理；'catch'代码块将被忽略"
+H06DD0F5375FE: "目标 '%0' 不支持异常处理；'catch' 代码块将被忽略"
 # "target '%0' does not support exception handling; 'throw' is assumed to be never reached"
-H29FDCCFA5847: "目标'%0'不支持异常处理；'throw'将被认为不可达"
+H29FDCCFA5847: "目标 '%0' 不支持异常处理；'throw' 将被认为不可达"
 # "target '%0' is not a supported OpenMP host target"
-H6B6204612E53: "目标'%0'不是支持的OpenMP主机目标"
+H6B6204612E53: "目标 '%0' 不是支持的OpenMP主机目标"
 # "target '%0' is unsupported by -fsanitize-kcfi-arity"
-HCFEF0540C5A0: "目标'%0'不受-fsanitize-kcfi-arity支持"
+HCFEF0540C5A0: "目标 '%0' 不受-fsanitize-kcfi-arity支持"
 # 'target construct with nested teams region contains statements outside of the teams construct'
 HB05FDB001094: '目标构造中的嵌套团队区域包含位于团队构造外部的语句'
 # "target does not support 'protected' visibility; using 'default'"
-H9354CE031F68: "目标不支持'protected'可见性；使用'default'"
+H9354CE031F68: "目标不支持 'protected' 可见性；使用 'default'"
 # 'target exception specification is not superset of source'
 H14AD31786EFD: '目标异常规范不是源的超集'
 # 'target function %select{is a member of different class%diff{ (expected $ but has $)|}1,2|has different number of parameters (expected %1 but has %2)|has type mismatch at %ordinal3 parameter%diff{ (expected $ but has $)|}1,2|has different return type%diff{ ($ expected but has $)|}1,2}0'
-HFEFD6F95E799: '目标函数%select{属于不同类%diff{（期望$ 但实际为$)|}1,2|参数数量不同（期望%1 但实际为%2)|第%ordinal3个参数类型不匹配%diff{（期望$ 但实际为$)|}1,2|返回类型不同%diff{（$ 期望但实际为$)|}1,2}0'
+HFEFD6F95E799: '目标函数%select{属于不同类%diff{（期望$ 但实际为$)|}1,2|参数数量不同（期望 %1 但实际为 %2)|第%ordinal3个参数类型不匹配%diff{（期望$ 但实际为$)|}1,2|返回类型不同%diff{（$ 期望但实际为$)|}1,2}0'
 # 'target function has calling convention %1 (expected %0)'
-HE7D037C49FE5: '目标函数的调用约定为%1（期望%0）'
+HE7D037C49FE5: '目标函数的调用约定为 %1（期望 %0）'
 # 'target of using declaration'
 HCB1C9C62D72D: 'using声明的目标'
 # 'target of using declaration conflicts with declaration already in scope'
@@ -27063,13 +27063,13 @@ H48B3A7876AE7: '基于target-attribute的函数重载不被NVCC支持，将被�
 # 'tbd'
 H1D9C8AC0B205: 'tbd'
 # 'template %0 has no definition and no %select{|viable }1deduction guides for deduction of template arguments'
-H39A2D17F6485: '模板%0没有定义，也没有%select{|可行的 }1推导指南来推导模板参数'
+H39A2D17F6485: '模板 %0 没有定义，也没有%select{|可行的 }1推导指南来推导模板参数'
 # 'template argument / label address difference / what did you expect?'
 H4022196FB5B0: '模板参数/标签地址差异/您期望的是什么？'
 # 'template argument does not refer to a class or alias template, or template template parameter'
 H10B27B45B43C: '模板参数不引用类或别名模板，或模板模板参数'
 # 'template argument for non-type template parameter is treated as function type %0'
-HF7C463216541: '非类型模板参数的模板参数被解释为函数类型%0'
+HF7C463216541: '非类型模板参数的模板参数被解释为函数类型 %0'
 # 'template argument for non-type template parameter must be an expression'
 HA6F518CB9F6F: '非类型模板参数的模板参数必须是一个表达式'
 # 'template argument for template template parameter must be a class template%select{| or type alias template}0'
@@ -27077,15 +27077,15 @@ H4605CB1853A3: '模板模板参数的模板参数必须是一个类模板%select
 # 'template argument for template type parameter must be a type'
 H9FFBB255FD4F: '模板类型参数的模板参数必须是一个类型'
 # "template argument for template type parameter must be a type; did you forget 'typename'?"
-H477EE50BCF4B: "模板类型参数的模板参数必须是一个类型；是否漏掉了'typename'？"
+H477EE50BCF4B: "模板类型参数的模板参数必须是一个类型；是否漏掉了 'typename'？"
 # "template argument for template type parameter must be a type; omitted 'typename' is a Microsoft extension"
-H0CC2569F4810: "模板类型参数的模板参数必须是一个类型；省略'typename'是Microsoft扩展"
+H0CC2569F4810: "模板类型参数的模板参数必须是一个类型；省略 'typename' 是Microsoft扩展"
 # 'template argument is the type of an unresolved overloaded function'
 H1DDFBAF8CEBB: '模板参数是未解析的重载函数类型'
 # 'template argument refers to function template %0, here'
-H59E0A4B6EEC0: '模板参数引用函数模板%0，此处'
+H59E0A4B6EEC0: '模板参数引用函数模板 %0，此处'
 # 'template argument uses local type %0'
-H8CFAA5F55F9C: '模板参数使用局部类型%0'
+H8CFAA5F55F9C: '模板参数使用局部类型 %0'
 # 'template argument uses unnamed type'
 H1A9FF29A8094: '模板参数使用未命名类型'
 # 'template declaration from hidden source: %0'
@@ -27093,13 +27093,13 @@ H607A13711E91: '来自隐藏源的模板声明：%0'
 # 'template is declared here'
 H8B583108C6ED: '模板在此处声明'
 # 'template name refers to non-type template %0'
-HD8E4D2A7EC89: '模板名称引用非类型模板%0'
+HD8E4D2A7EC89: '模板名称引用非类型模板 %0'
 # 'template non-type parameter has a different type %0 in template %select{|template parameter }1redeclaration'
-H29D49A380D2B: '模板%select{|模板参数 }1重新声明中，模板非类型参数具有不同类型%0'
+H29D49A380D2B: '模板%select{|模板参数 }1重新声明中，模板非类型参数具有不同类型 %0'
 # 'template non-type parameter has a different type %0 in template argument'
-H83C8844C296B: '模板参数中的非类型参数具有不同类型%0'
+H83C8844C296B: '模板参数中的非类型参数具有不同类型 %0'
 # "template parameter '%0' is already documented"
-H4188A9C61053: "模板参数'%0'已被文档记录"
+H4188A9C61053: "模板参数 '%0' 已被文档记录"
 # "template parameter '%0' not found in the template declaration"
 H1A80B68DAC8D: "模板参数 '%0' 未在模板声明中找到"
 # 'template parameter declared here'
@@ -27123,7 +27123,7 @@ H1F8E29374B19: '模板参数列表也在此处声明'
 # "template parameter list for literal operator must be either 'char...' or 'typename T, T...'"
 H409CCC2DB745: "字面量运算符的模板参数列表必须为 'char...' 或 'typename T, T...'"
 # "template parameter list matching the non-templated nested type %0 should be empty ('template<>')"
-HE4D93F6B6699: "与非模板嵌套类型%0匹配的模板参数列表应为空 ('template<>)'"
+HE4D93F6B6699: "与非模板嵌套类型 %0 匹配的模板参数列表应为空 ('template<>)'"
 # 'template parameter lists have a different number of parameters (%0 vs %1)'
 HB5785F1417CF: '模板参数列表的参数数量不同（%0 对比 %1）'
 # 'template parameter missing a default argument'
@@ -27139,7 +27139,7 @@ H8C66CF577C62: '模板参数重新定义了默认参数'
 # 'template specialization declaration cannot be a friend'
 HA8ECAC04AF8C: '模板特化声明不能是友元'
 # 'template specialization or definition requires a template parameter list corresponding to the nested type %0'
-HC868EA3957FF: '模板特化或定义需要与嵌套类型%0对应的模板参数列表'
+HC868EA3957FF: '模板特化或定义需要与嵌套类型 %0 对应的模板参数列表'
 # "template specialization requires 'template<>'"
 H1ADEE7A736DF: "模板特化需要使用 'template<>'"
 # 'template template argument %0 is more constrained than template template parameter %1'
@@ -27165,65 +27165,65 @@ H013054578BC3: '与分配对象的引用成员绑定的临时对象将在完整�
 # 'temporary created here'
 H6CF924D32FF7: '临时对象在此处创建'
 # 'temporary of type %0 has %select{private|protected}1 destructor'
-HA776568AF253: '类型为%0的临时对象具有%select{私有|受保护}1的析构函数'
+HA776568AF253: '类型为 %0 的临时对象具有%select{私有|受保护}1的析构函数'
 # 'tentative array definition assumed to have one element'
 H1578DBDB8944: '暂定数组定义假定有一个元素'
 # 'tentative definition has type %0 that is never completed'
-H2533423DBC92: '暂定定义具有未完成的类型%0'
+H2533423DBC92: '暂定定义具有未完成的类型 %0'
 # 'tentative definition of variable with internal linkage has incomplete non-array type %0'
-H137EE1AFC5D6: '具有内部链接的变量的暂定定义具有不完整的非数组类型%0'
+H137EE1AFC5D6: '具有内部链接的变量的暂定定义具有不完整的非数组类型 %0'
 # 'tenths of percents of main entry frequency to use as a threshold when evaluating whether a basic block is cold (0 means it is only considered cold if the block has zero samples). Default: 0 '
 HB4A505AFFDA6: '在评估基本块是否为冷块时，用作阈值的百分比十分之一。0 表示仅当块的采样数为零时才视为冷块。默认值：0'
 # "test module file extension '%0' has different version (%1.%2) than expected (%3.%4)"
-HD419260C8BE7: "测试模块文件扩展名'%0'的版本(%1.%2)与期望版本(%3.%4)不匹配"
+HD419260C8BE7: "测试模块文件扩展名 '%0' 的版本(%1.%2)与期望版本(%3.%4)不匹配"
 # 'the #__include_macros directive is only for internal use by -imacros'
 H1FBDC6FD510E: '#__include_macros 指令仅用于 -imacros 的内部使用'
 # 'the %0 sub-architecture does not support unaligned accesses'
 H8EEF78B6F581: '%0 子架构不支持非对齐访问'
 # 'the %0 type cannot be used to declare a program scope variable'
-HCC2A02E45E01: '类型%0 不能用于声明程序作用域变量'
+HCC2A02E45E01: '类型 %0 不能用于声明程序作用域变量'
 # 'the %0 type cannot be used to declare a structure or union field'
-H3AA824360E4A: '类型%0不能用于声明结构体或联合体的字段'
+H3AA824360E4A: '类型 %0 不能用于声明结构体或联合体的字段'
 # 'the %select{1st|2nd|3rd}1 template parameter of %0 needs to be %select{a type|an integer or enum value}2'
-HC15D25E5BA46: '模板%0的第%select{1位|2位|3位}1个模板参数需要是%select{一个类型|一个整数或枚举值}2'
+HC15D25E5BA46: '模板 %0 的第%select{1位|2位|3位}1个模板参数需要是%select{一个类型|一个整数或枚举值}2'
 # 'the %select{function or variable|function}0 specified in an %select{alias|ifunc}1 must refer to its mangled name'
 H2A963C3F164E: '在%select{别名|ifunc}1中指定的%select{函数或变量|函数}0必须引用其mangled名称'
 # "the %select{message|string}0 object in %select{this static assertion|this asm operand}0 is missing %select{a 'size()' member function|a 'data()' member function|'data()' and 'size()' member functions}1"
 HF8EFF7FCD3A1: "在%select{此静态断言|此asm操作数}0中的%select{消息|string}0对象缺少%select{'size()'成员函数|'data()'成员函数|'data()'和'size()'成员函数}1"
 # "the '%0' unit is not supported with this instruction set"
-H66612647AED8: "单元'%0'不受当前指令集支持"
+H66612647AED8: "单元 '%0' 不受当前指令集支持"
 # "the '%select{&|*|->}0' operator is unsupported in HLSL"
 H831B25ED6E8C: "操作符'%select{&|*|->}0'在HLSL中不受支持"
 # "the '[[_Noreturn]]' attribute spelling is deprecated in C23; use '[[noreturn]]' instead"
 H584C1C164ECE: "在C23中，'[[Noreturn]]'属性拼写已弃用；请改用'[[noreturn]]'"
 # "the 'copyprivate' clause must not be used with the 'nowait' clause"
-H026F61D558F6: "'copyprivate'子句不能与'nowait'子句一起使用"
+H026F61D558F6: "'copyprivate' 子句不能与 'nowait' 子句一起使用"
 # "the 'static' modifier for the array size is not legal in new expressions"
-H285525BB6E11: "在new表达式中，不允许使用'static'修饰符来指定数组大小"
+H285525BB6E11: "在new表达式中，不允许使用 'static' 修饰符来指定数组大小"
 # "the ApplicationExtensionSafe flag does not match: '%0' (provided) vs '%1' (found)"
-H74ECAC68920E: "ApplicationExtensionSafe标志不匹配：提供的'%0'与找到的'%1'"
+H74ECAC68920E: "ApplicationExtensionSafe标志不匹配：提供的 '%0' 与找到的 '%1'"
 # 'the GNU address of label extension is not allowed in coroutines'
 HEE9FFF3C021C: '协程中不允许使用GNU的标签地址扩展'
 # "the NotForDyldSharedCache flag does not match: '%0' (provided) vs '%1' (found)"
-HAD9256F7D2F3: "NotForDyldSharedCache标志不匹配：提供的'%0'与找到的'%1'"
+HAD9256F7D2F3: "NotForDyldSharedCache标志不匹配：提供的 '%0' 与找到的 '%1'"
 # 'the __block storage type is not permitted'
 H2951C6144658: '__block存储类型不允许使用'
 # 'the address of a declaration with unknown type can only be cast to a pointer type'
 H6D4B76B01E9C: '未知类型的声明的地址只能转换为指针类型'
 # "the argument '%0' is not supported for option '%1'. Mapping to '%1%2'"
-HA4EFCA49DC99: "选项'%1'不支持参数'%0'。映射到'%1%2'"
+HA4EFCA49DC99: "选项 '%1' 不支持参数 '%0'。映射到'%1%2'"
 # "the clang compiler does not support '%0'"
-HCB0DF6FD34A3: "clang编译器不支持'%0'"
+HCB0DF6FD34A3: "clang编译器不支持 '%0'"
 # "the clang compiler does not support '%0' for C++ on Darwin/i386"
-HAB9E0C38E134: "clang编译器在Darwin/i386的C++中不支持'%0'"
+HAB9E0C38E134: "clang编译器在Darwin/i386的C++中不支持 '%0'"
 # "the clang compiler does not support '%0', %1"
-H70791B1776AF: "clang编译器不支持'%0'，%1"
+H70791B1776AF: "clang编译器不支持 '%0'，%1"
 # 'the clang compiler does not support -pg option on %select{Darwin|versions of OS X 10.9 and later}0'
 HEC221F97986E: 'clang编译器在%select{Darwin|OS X 10.9及更高版本}0上不支持-pg选项'
 # 'the clustering algorithm to use'
 HEE034B797939: '要使用的聚类算法'
 # "the combination of '%0' and '%1' is incompatible"
-H04D1D2EB3A72: "'%0'和'%1'的组合不兼容"
+H04D1D2EB3A72: "'%0' 和 '%1' 的组合不兼容"
 # "the context %select{set|selector|property}0 '%1' was used already in the same 'omp declare variant' directive; %select{set|selector|property}0 ignored"
 H6268D8504255: "在同一个 'omp declare variant' 指令中已经使用了上下文 %select{set|selector|property}0 '%1'；忽略该 %select{set|selector|property}0"
 # "the context property '%0' can be nested in the context selector '%1' which is nested in the context set '%2'; try 'match(%2={%1(%0)})'"
@@ -27271,15 +27271,15 @@ H822B183C153E: '头单元的实现尚处于实验阶段'
 # "the implicit output of reduced BMI may be overrided by the output file specified by '--precompile'. please consider use '-fmodule-output=' to specify the output file for reduced BMI explicitly"
 HC77BA90C9A9E: "简化的BMI的隐式输出可能被'--precompile'指定的输出文件覆盖。建议使用'-fmodule-output='显式指定简化的BMI的输出文件"
 # "the inscan reduction list item must appear as a list item in an 'inclusive' or 'exclusive' clause on an inner 'omp scan' directive"
-H5A6903CB5B88: "inscan缩减列表项必须出现在内部'omp scan'指令的'inclusive'或'exclusive'子句的列表项中"
+H5A6903CB5B88: "inscan缩减列表项必须出现在内部'omp scan'指令的 'inclusive' 或 'exclusive' 子句的列表项中"
 # "the last '/TC' or '/TP' option takes precedence over earlier instances"
 H1D4C07143ED6: "最后一个'/TC'或'/TP'选项覆盖前面的实例"
 # "the library '%0=%1' is not supported, OpenMP will not be enabled"
 H8332E220148A: "库'%0=%1'不受支持，OpenMP将不会启用"
 # "the list item must appear in 'reduction' clause with the 'inscan' modifier of the parent directive"
-H331559E5A96C: "列表项必须出现在父指令的'reduction'子句中带有'inscan'修饰符的位置"
+H331559E5A96C: "列表项必须出现在父指令的 'reduction' 子句中带有 'inscan' 修饰符的位置"
 # 'the loop %select{initializer|condition}0 expression depends on the current loop control variable'
-H092C392BA41E: '循环%select{initializer|condition}0表达式依赖于当前循环控制变量'
+H092C392BA41E: '循环 %select{initializer|condition}0 表达式依赖于当前循环控制变量'
 # 'the maximum number of instructions analyzed for may throw during attribute inference in inlined body'
 HDB567B6559C9: '在内联体的属性推断期间，对may throw进行分析时要分析的最大指令数'
 # 'the mode to run'
@@ -27287,7 +27287,7 @@ H1067F4A3FF41: '要运行的模式'
 # 'the name of the PDB file to write'
 H3B634F1D4C6F: '要写入的PDB文件的名称'
 # "the name of the construct must be specified in presence of 'hint' clause"
-HF664729B6FC3: "在存在'hint'子句的情况下，必须指定构造名称"
+HF664729B6FC3: "在存在 'hint' 子句的情况下，必须指定构造名称"
 # 'the number of preprocessor source tokens (%0) exceeds this token limit (%1)'
 H205DE1F2F79F: '预处理器源标记的数量（%0）超过此限制（%1）'
 # 'the object size sanitizer has no effect at -O0, but is explicitly enabled: %0'
@@ -27295,7 +27295,7 @@ H314C428C1C64: '对象大小检查器在-O0时无效，但被显式启用：%0'
 # "the option '-flto=thin' is a work in progress"
 H5F57C367214A: "选项'-flto=thin'尚在开发中"
 # "the other acquisition of %0 '%1' is here"
-HF9475FC44959: "另一个对%0 '%1'的获取在此处"
+HF9475FC44959: "另一个对 %0 '%1' 的获取在此处"
 # 'the parameter for an explicitly-defaulted %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}0 may not be volatile'
 HEAA7EB9FB2E0: '显式默认的%select{默认构造函数|拷贝构造函数|移动构造函数|拷贝赋值运算符|移动赋值运算符|析构函数}0的参数不能是volatile类型'
 # 'the parameter for an explicitly-defaulted copy assignment operator must be an lvalue reference type'
@@ -27305,13 +27305,13 @@ H34E3C1F201FC: '显式默认的移动%select{构造函数|赋值运算符}0的�
 # 'the parameter for this explicitly-defaulted copy %select{constructor|assignment operator}0 is const, but a member or base requires it to be non-const'
 H7307965D0004: '此显式默认的拷贝%select{构造函数|赋值运算符}0的参数是const，但某个成员或基类要求其为非const'
 # "the parameter of the 'ordered' clause must be greater than or equal to the parameter of the 'collapse' clause"
-H21ACD6E7D4C2: "'ordered'子句的参数必须大于或等于'collapse'子句的参数"
+H21ACD6E7D4C2: "'ordered' 子句的参数必须大于或等于 'collapse' 子句的参数"
 # 'the pointee of the 2nd argument must match the element type of the 1st argument (%0 != %1)'
 H13AC040EDF7B: '第二个参数的被指类型必须与第一个参数的元素类型一致（%0 != %1）'
 # 'the pointer decremented by %0 refers before the beginning of the array'
-H9FD5D86B7BD7: '减去%0后的指针指向数组的起始位置之前'
+H9FD5D86B7BD7: '减去 %0 后的指针指向数组的起始位置之前'
 # 'the pointer incremented by %0 refers past the end of the array (that has type %1)'
-H2098AEB20194: '指针增加%0后指向的地址超出了类型为%1的数组末尾'
+H2098AEB20194: '指针增加 %0 后指向的地址超出了类型为 %1 的数组末尾'
 # 'the pointer incremented by %0 refers past the last possible element for an array in %1-bit address space containing %2-bit (%3-byte) elements (max possible %4 element%s5)'
 H85FE07542C80: '在 %1 位地址空间中，包含 %2 位（%3 字节）元素的数组的最后一个元素后，指针增加 %0 的结果越界（最大可能元素数 %4 element%s5）'
 # "the previous context %select{set|selector|property}0 '%1' used here"
@@ -27321,7 +27321,7 @@ H10756E8D2178: '提供的选择与感兴趣的AST节点没有重叠'
 # 'the referenced item is not found in any private clause on the same directive'
 HBDA357C86E91: '在同一个指令中的任何私有子句中都未找到引用项'
 # "the result of a delegate init call must be immediately returned or assigned to 'self'"
-HA6A6824B2746: "委托初始化调用的结果必须立即返回或赋值给'self'"
+HA6A6824B2746: "委托初始化调用的结果必须立即返回或赋值给 'self'"
 # 'the resulting value is always non-negative after implicit conversion'
 H9908ECBF3885: '隐式转换后的结果始终为非负值'
 # "the second argument of '-fpatchable-function-entry' must be smaller than the first argument"
@@ -27333,9 +27333,9 @@ HC3B7DF91CF84: '无法提取所选表达式'
 # 'the selected expression is too simple to extract'
 HEFB1186DBBA0: '所选表达式过于简单无法提取'
 # 'the semantics of this intrinsic changed with GCC version 4.4 - the newer semantics are provided here'
-H1D55F6813757: '该内建函数的语义在GCC版本4.4后有所变化 - 这里提供的是新版本的语义'
+H1D55F6813757: '该内建函数的语义在GCC版本 4.4后有所变化 - 这里提供的是新版本的语义'
 # 'the sign of a  flushed-to-zero number is preserved in the sign of 0'
-HE7436E3F21CE: '被冲刷到零的数的符号保留在0的符号中'
+HE7436E3F21CE: '被冲刷到零的数的符号保留在 0 的符号中'
 # 'the specified comparator type does not provide a viable const call operator'
 H327A107A2A90: '指定的比较器类型未提供有效的const调用运算符'
 # 'the specified hash functor does not provide a viable const call operator'
@@ -27357,29 +27357,29 @@ H106E8810ABCE: "'atomic write'的语句必须是形式为'x = expr;'的表达式
 # "the statement for 'atomic write' must be an expression statement of form 'x = expr;', where x is a lvalue expression with scalar type"
 HAEE051C701D8: "用于'atomic write'的语句必须是形式为'x = expr;'的表达式语句，其中x是标量类型的左值表达式"
 # "the statement for 'atomic' must be an expression statement of form '++x;', '--x;', 'x++;', 'x--;', 'x binop= expr;', 'x = x binop expr' or 'x = expr binop x', where x is an lvalue expression with scalar type"
-H182C909CFBBD: "用于'atomic'的语句必须是形式为'++x;'、'--x;'、'x++;'、'x--;'、'x binop= expr;'、'x = x binop expr'或'x = expr binop x'的表达式语句，其中x是标量类型的左值表达式"
+H182C909CFBBD: "用于 'atomic' 的语句必须是形式为'++x;'、'--x;'、'x++;'、'x--;'、'x binop= expr;'、'x = x binop expr'或'x = expr binop x'的表达式语句，其中x是标量类型的左值表达式"
 # "the target architecture '%0' is not supported by the target '%1'"
-H9EB5284C09D2: "目标架构'%0'不受目标'%1'支持"
+H9EB5284C09D2: "目标架构 '%0' 不受目标 '%1' 支持"
 # 'the total number of preprocessor source tokens (%0) exceeds the token limit (%1)'
 H8A02325A6920: '预处理器源代码标记总数(%0)超过了标记限制(%1)'
 # 'the two-parameter std::span construction is unsafe as it can introduce mismatch between buffer size and the bound information'
 HB6B2C19333E2: '两个参数的std::span构造可能因缓冲区大小和边界信息不匹配而存在风险'
 # 'the type %0 is already explicitly ownership-qualified'
-H462F56962031: '类型%0已经显式具有所有权限定符'
+H462F56962031: '类型 %0 已经显式具有所有权限定符'
 # 'the type %0 is not a pointer to a fast-enumerable object'
-HF043D197C95F: '类型%0不是指向快速可枚举对象的指针'
+HF043D197C95F: '类型 %0 不是指向快速可枚举对象的指针'
 # 'the type of object expression %diff{($) does not match the type being destroyed ($)|does not match the type being destroyed}0,1 in pseudo-destructor expression'
 HF8245CD4DD36: '对象表达式%diff{($)的类型与伪析构表达式中正在销毁的类型($)|不匹配}0,1'
 # 'the type of the explicit object parameter of an explicitly-defaulted %select{copy|move}0 assignment operator should be reference to %1'
-H48B3F2D609BF: '显式默认的%select{拷贝|移动}0赋值运算符的显式对象参数类型应为%1的引用'
+H48B3F2D609BF: '显式默认的%select{拷贝|移动}0赋值运算符的显式对象参数类型应为 %1 的引用'
 # 'the user condition in the OpenMP context selector needs to be constant; %0 is not'
-H518CAE3CEA63: 'OpenMP上下文选择器中的用户条件需要是常量；%0不是'
+H518CAE3CEA63: 'OpenMP上下文选择器中的用户条件需要是常量；%0 不是'
 # "the value of 'simdlen' parameter must be less than or equal to the value of the 'safelen' parameter"
-H05F684C1DEC1: "'simdlen'参数的值必须小于或等于'safelen'参数的值"
+H05F684C1DEC1: "'simdlen' 参数的值必须小于或等于 'safelen' 参数的值"
 # "the value of the size argument in 'strncat' is too large, might lead to a buffer overflow"
-H7CBEE5BA8363: "'strncat'的size参数值过大，可能导致缓冲区溢出"
+H7CBEE5BA8363: "'strncat' 的size参数值过大，可能导致缓冲区溢出"
 # "the value of the size argument to 'strncat' is wrong"
-H10EE22A40549: "'strncat'的size参数值有误"
+H10EE22A40549: "'strncat' 的size参数值有误"
 # 'the vecreturn attribute can only be used on a POD (plain old data) class or structure (i.e. no virtual functions)'
 HB24B6E1BF839: 'vecreturn属性只能用于POD（普通旧数据）类或结构体（即没有虚函数）'
 # 'the vecreturn attribute can only be used on a class or structure with one member, which must be a vector'
@@ -27393,17 +27393,17 @@ H99C4AECFC4C8: '在给定位置没有找到符号'
 # 'this builtin is available only on AIX 7.2 and later operating systems'
 H6E604B084F43: '该内建函数仅适用于AIX 7.2及更高版本操作系统'
 # 'this builtin is only available on 32-bit targets'
-H56D31FAC556E: '该内建函数仅支持32位目标平台'
+H56D31FAC556E: '该内建函数仅支持 32 位目标平台'
 # 'this builtin is only available on 64-bit targets'
-HC0C706B2D8E7: '此内建函数仅在64位目标平台上可用'
+HC0C706B2D8E7: '此内建函数仅在 64 位目标平台上可用'
 # 'this builtin is only available on x86-64 and aarch64 targets'
 H81BF150D8949: '此内建函数仅在x86-64和aarch64目标平台上可用'
 # "this builtin requires 'dsp r2' ASE, please use -mdspr2"
 HF59F7FBACC6E: "此内建函数需要'dsp r2' ASE，请使用-mdspr2选项"
 # "this builtin requires 'dsp' ASE, please use -mdsp"
-H2B317AB4FDC4: "此内建函数需要'dsp' ASE，请使用-mdsp选项"
+H2B317AB4FDC4: "此内建函数需要 'dsp' ASE，请使用-mdsp选项"
 # "this builtin requires 'msa' ASE, please use -mmsa"
-H25EA8026E312: "此内建函数需要'msa' ASE，请使用-mmsa选项"
+H25EA8026E312: "此内建函数需要 'msa' ASE，请使用-mmsa选项"
 # 'this builtin requires ABI -mabi=%0'
 H6643558E97E9: '此内建函数需要ABI -mabi=%0'
 # 'this coroutine may be split into pieces; not every piece is guaranteed to be inlined'
@@ -27425,7 +27425,7 @@ HB435423839CE: '这通常是由多个路径下找到同名模块所导致的'
 # 'this placement new expression is not supported in constant expressions %select{|before C++2c}0'
 HFED2CB8F9A5D: '在常量表达式中不支持此placement new表达式%select{|在C++2c之前}0'
 # 'this pragma cannot appear in %0 declaration'
-HCE58A657A4E9: '此#pragma不能出现在%0声明中'
+HCE58A657A4E9: '此#pragma不能出现在 %0 声明中'
 # 'this style of line directive is a GNU extension'
 H0B9D785486F6: '这种形式的行指令是GNU扩展'
 # 'this target does not support pointer authentication'
@@ -27443,19 +27443,19 @@ HB0419777F950: '线程安全Beta警告'
 # 'thread safety verbose warning'
 H313BE85969C3: '线程安全详细警告'
 # 'thread warning in function %0'
-H36B44B602302: '函数%0中的线程警告'
+H36B44B602302: '函数 %0 中的线程警告'
 # 'thread-local declaration of %0 follows non-thread-local declaration'
-HEFF70126975B: '%0的线程局部声明紧跟非线程局部声明'
+HEFF70126975B: '%0 的线程局部声明紧跟非线程局部声明'
 # 'thread-local declaration of %0 with %select{static|dynamic}1 initialization follows declaration with %select{dynamic|static}1 initialization'
-H912C45CDB374: '%0的线程局部声明带有%select{静态|动态}1初始化，而之前的声明使用的是%select{动态|静态}1初始化'
+H912C45CDB374: '%0 的线程局部声明带有%select{静态|动态}1初始化，而之前的声明使用的是%select{动态|静态}1初始化'
 # 'thread-local storage is not supported for the current target'
 H98D675ADC45A: '当前目标平台不支持线程局部存储'
 # 'thread-local variable has non-trivial ownership: type is %0'
-H6F11C930F55E: '线程局部变量具有非平凡的所有权：类型为%0'
+H6F11C930F55E: '线程局部变量具有非平凡的所有权：类型为 %0'
 # 'threadprivate variable with incomplete type %0'
-HCB733257A55A: '线程私有变量具有不完整类型%0'
+HCB733257A55A: '线程私有变量具有不完整类型 %0'
 # "threadprivate variables are not allowed in '%0' clause"
-HEEB356882606: "'%0'子句中不允许使用线程私有变量"
+HEEB356882606: "'%0' 子句中不允许使用线程私有变量"
 # 'threadprivate variables cannot be used in target constructs'
 HB21F31B22998: '线程私有变量不能在目标构造中使用'
 # 'three-way comparison between pointer and zero'
@@ -27465,7 +27465,7 @@ H00B5B249986A: '向量之间的三向比较不被支持'
 # "three-way comparison cannot be synthesized because there is no viable function for %select{'=='|'<'}0 comparison"
 H6263B6389D1C: '无法合成三向比较，因为没有可用的%select{等于|小于}0比较函数'
 # 'threshold (in percent) for selecting functions to process in lite mode. Higher threshold means fewer functions to process. E.g threshold of 90 means only top 10 percent of functions with profile will be processed.'
-HC3919B9CBB6D: '阈值（百分比）用于在轻量级模式下选择要处理的函数。阈值越高，需要处理的函数越少。例如，阈值设为90表示仅处理具有profile的前10%的函数。'
+HC3919B9CBB6D: '阈值（百分比）用于在轻量级模式下选择要处理的函数。阈值越高，需要处理的函数越少。例如，阈值设为 90 表示仅处理具有profile的前 10%的函数。'
 # 'tile arguments must refer to different tiles'
 HC74F5110780C: '瓦片参数必须引用不同的瓦片'
 # 'time BOLT aggregator'
@@ -27475,11 +27475,11 @@ H18422D3F506F: '统计分析步骤的时间范围'
 # 'time icf steps'
 H17EA53E3423A: '记录ICF步骤的时间'
 # "timed out waiting to acquire lock file for module '%0'"
-HD7ADFA168199: "等待获取模块'%0'的锁文件超时"
+HD7ADFA168199: "等待获取模块 '%0' 的锁文件超时"
 # 'tls_model must be "global-dynamic", "local-dynamic", "initial-exec" or "local-exec"'
 H2BCDC88FA47E: 'tls_model必须是"global-dynamic"、"local-dynamic"、"initial-exec"或"local-exec"'
 # 'to match this %0'
-HDA13A5D2D868: '与这个%0匹配'
+HDA13A5D2D868: '与这个 %0 匹配'
 # "to match this ']'"
 HEF9A1EC0D665: "与这个']'匹配"
 # "to match this '{'"
@@ -27491,23 +27491,23 @@ H13889DCFA50D: "用 ',' 和 __VA_ARGS__ 进行标记粘贴是GNU扩展"
 # 'too %select{few|many}0 arguments in call to %1'
 H55C9E37AE906: '调用 %1 时参数%select{太少|太多}0'
 # 'too %select{few|many}0 initializers in list for type %1 (expected %2 but found %3)'
-HD545C2517E80: '类型%1的列表中初始化器%select{太少|太多}0（期望%2但找到%3）'
+HD545C2517E80: '类型 %1 的列表中初始化器%select{太少|太多}0（期望 %2 但找到 %3）'
 # 'too %select{few|many}0 parameters in the signature specified by the %1 attribute (expected %2; got %3)'
-H6F4276FDBDF1: '由%1属性指定的签名中参数%select{太少|太多}0（期望%2；找到%3）'
+H6F4276FDBDF1: '由 %1 属性指定的签名中参数%select{太少|太多}0（期望 %2；找到 %3）'
 # 'too %select{many|few}0 type arguments for class %1 (have %2, expected %3)'
-H35A08DFD5F2A: '类%1的类型参数%select{太多|太少}0（已有%2，期望%3）'
+H35A08DFD5F2A: '类 %1 的类型参数%select{太多|太少}0（已有 %2，期望 %3）'
 # 'too few %select{|||execution configuration }0%select{|non-object }2arguments to %select{function|block|method|kernel function}0 call, at least argument %1 must be specified'
 HF6BA10037D33: '调用 %select{函数|代码块|方法|内核函数}0 时，%select{|||执行配置 }0%select{|非对象 }2参数不足，至少必须指定参数 %1'
 # 'too few %select{|||execution configuration }0%select{|non-object }2arguments to %select{function|block|method|kernel function}0 call, single argument %1 was not specified'
 H9CA8A408A5C7: '调用 %select{函数|代码块|方法|内核函数}0 时，%select{|||执行配置 }0%select{|非对象 }2参数不足，单个参数 %1 未指定'
 # 'too few %select{|||execution configuration }0%select{|non-object }3arguments to %select{function|block|method|kernel function}0 call, expected %1, have %2'
-H5939FAB31ED6: '调用%select{函数|块|方法|内核函数}0时%select{|||执行配置 }0%select{|非对象 }3参数太少，期望%1，实际%2'
+H5939FAB31ED6: '调用%select{函数|块|方法|内核函数}0时%select{|||执行配置 }0%select{|非对象 }3参数太少，期望 %1，实际 %2'
 # 'too few %select{|||execution configuration }0%select{|non-object }3arguments to %select{function|block|method|kernel function}0 call, expected %1, have %2; did you mean %4?'
-HF20F679C52F2: '调用%select{函数|块|方法|内核函数}0时%select{|||执行配置 }0%select{|非对象 }3参数太少，期望%1，实际%2；您是否是指%4？'
+HF20F679C52F2: '调用%select{函数|块|方法|内核函数}0时%select{|||执行配置 }0%select{|非对象 }3参数太少，期望 %1，实际 %2；您是否是指 %4？'
 # 'too few %select{|||execution configuration }0%select{|non-object }3arguments to %select{function|block|method|kernel function}0 call, expected at least %1, have %2'
-HD24171A04B0B: '调用%select{函数|块|方法|内核函数}0时%select{|||执行配置 }0%select{|非对象 }3参数太少，期望至少%1，实际%2'
+HD24171A04B0B: '调用%select{函数|块|方法|内核函数}0时%select{|||执行配置 }0%select{|非对象 }3参数太少，期望至少 %1，实际 %2'
 # 'too few %select{|||execution configuration }0%select{|non-object }3arguments to %select{function|block|method|kernel function}0 call, expected at least %1, have %2; did you mean %4?'
-HD3BBC6D9EFC0: '调用%select{函数|块|方法|内核函数}0时%select{|||执行配置 }0%select{|非对象 }3参数太少，期望至少%1，实际%2；您是否是指%4？'
+HD3BBC6D9EFC0: '调用%select{函数|块|方法|内核函数}0时%select{|||执行配置 }0%select{|非对象 }3参数太少，期望至少 %1，实际 %2；您是否是指 %4？'
 # 'too few arguments provided to function-like macro invocation'
 H1E346A7B8B3C: '函数式宏调用提供的参数太少'
 # 'too many %select{|||execution configuration }0%select{|non-object }3arguments to %select{function|block|method|kernel function}0 call, expected %1, have %2'
@@ -27531,13 +27531,13 @@ H208E3BCCF078: '报告了过多的错误，现在停止'
 # 'too many function parameters; subsequent parameters will be ignored'
 H803517A338E0: '函数参数过多；后续参数将被忽略'
 # "too many parameters (%0) for 'main': must be 0, 2, or 3"
-H39E16B39631F: "'main'函数的参数过多（%0）：必须为0、2或3"
+H39E16B39631F: "'main' 函数的参数过多（%0）：必须为 0、2或 3 "
 # 'tool-template options'
 HBCF3F3069BB4: 'tool-template 选项'
 # 'top-level comma expression in array subscript is deprecated in C++20 and unsupported in C++23'
 HE89EE6B0F334: '数组下标中的顶层逗号表达式在C++20中已弃用，并在C++23中不受支持'
 # 'total number of threads cannot exceed %0'
-H1884DB567221: '线程总数不能超过%0'
+H1884DB567221: '线程总数不能超过 %0'
 # 'total token limit set here'
 HC6BF74A3FD57: '此处设置的总标记限制'
 # 'toy compiler\n'
@@ -27567,17 +27567,17 @@ H4518B36E2611: '失败时触发陷阱'
 # 'treat the string as an argument to avoid this'
 H276A4BE7C44E: '将字符串视为参数以避免此错误'
 # "treating #%select{include|import|include_next|__include_macros}0 as an import of module '%1'"
-HCF878B660176: "将#%select{include|import|include_next|__include_macros}0视为模块'%1'的导入"
+HCF878B660176: "将#%select{include|import|include_next|__include_macros}0 视为模块 '%1' 的导入"
 # "treating '%0' input as '%1' when in C++ mode, this behavior is deprecated"
-H0FA024F7C782: "在C++模式下将'%0'输入视为'%1'，此行为已弃用"
+H0FA024F7C782: "在C++模式下将 '%0' 输入视为 '%1'，此行为已弃用"
 # 'treating Ctrl-Z as end-of-file is a Microsoft extension'
 H2B9F3B693225: '将Ctrl-Z视为文件结束符是Microsoft扩展'
 # "treating Unicode character <U+%0> as an identifier character rather than as '%1' symbol"
-H50914464E633: "将Unicode字符<U+%0>视为标识符字符而不是'%1'符号"
+H50914464E633: "将Unicode字符<U+%0>视为标识符字符而不是 '%1' 符号"
 # 'treating Unicode character as whitespace'
 HF7B2E2527DE4: '将Unicode字符视为空白符'
 # "trigraph converted to '%0' character"
-HED476D72F781: "三元组转换为'%0'字符"
+HED476D72F781: "三元组转换为 '%0' 字符"
 # 'trigraph ends block comment'
 H52594FE74E90: '三元组结束块注释'
 # 'trigraph ignored'
@@ -27589,33 +27589,33 @@ H766B462800CF: "尝试'match(%0={%1%2})'"
 # 'try to preserve basic block alignment'
 H8B07C548FF85: '尽量保留基本块的对齐'
 # 'trying to recursively use %0 as superclass of %1'
-H22C1DF007CBE: '尝试递归使用%0作为%1的超类'
+H22C1DF007CBE: '尝试递归使用 %0 作为 %1 的超类'
 # 'turn on the stoke analysis'
 H0C2490B9B2A0: '启用Stoke分析'
 # 'type %0 can only be used as a function parameter in OpenCL'
-H43CCACC05DF1: '类型%0只能在OpenCL中用作函数参数'
+H43CCACC05DF1: '类型 %0 只能在OpenCL中用作函数参数'
 # 'type %0 cannot be decomposed'
-HAD575CEF4CDD: '类型%0无法分解'
+HAD575CEF4CDD: '类型 %0 无法分解'
 # 'type %0 cannot be narrowed to %1 in initializer list'
-HA66630D471E5: '类型%0在初始化列表中无法缩小为%1'
+HA66630D471E5: '类型 %0 在初始化列表中无法缩小为 %1'
 # 'type %0 cannot be narrowed to %1 in initializer list in C++11'
-H121C0CF66257: '类型%0在C++11的初始化列表中无法缩小为%1'
+H121C0CF66257: '类型 %0 在C++11的初始化列表中无法缩小为 %1'
 # "type %0 cannot be used prior to '::' because it has no members"
-HB29A2AE6A5EB: "类型%0在'::'之前无法使用，因为它没有成员"
+HB29A2AE6A5EB: "类型 %0 在'::'之前无法使用，因为它没有成员"
 # 'type %0 decomposes into %3 %plural{1:element|:elements}2, but %select{%plural{0:no|:only %1}1|%1}4 %plural{1:name was|:names were}1 provided'
-HF59CA2FD696F: '类型%0分解为%3 %plural{1:元素|:元素}2，但%select{%plural{0:没有提供|:只提供 %1}1|%1}4 %plural{1:名字|:名字}1'
+HF59CA2FD696F: '类型 %0 分解为 %3 %plural{1:元素|:元素}2，但%select{%plural{0:没有提供|:只提供 %1}1|%1}4 %plural{1:名字|:名字}1'
 # 'type %0 does not provide a %select{subscript|call}1 operator'
-HCAF6714D32F7: '类型%0未提供%select{subscript|call}1运算符'
+HCAF6714D32F7: '类型 %0 未提供 %select{subscript|call}1 运算符'
 # 'type %0 found by destructor name lookup'
-H35BD375D3364: '通过析构函数名称查找找到类型%0'
+H35BD375D3364: '通过析构函数名称查找找到类型 %0'
 # 'type %0 has incompatible definitions in different translation units'
-HB192C667507F: '类型%0在不同的翻译单元中具有不兼容的定义'
+HB192C667507F: '类型 %0 在不同的翻译单元中具有不兼容的定义'
 # 'type %0 has unexpected layout'
-H8C8909F11F0A: '类型%0具有意外的布局'
+H8C8909F11F0A: '类型 %0 具有意外的布局'
 # 'type %0 in generic association compatible with previously specified type %1'
-H1178A958ED5C: '通用关联中的类型%0与之前指定的类型%1兼容'
+H1178A958ED5C: '通用关联中的类型 %0 与之前指定的类型 %1 兼容'
 # 'type %0 in generic association is a variably modified type'
-HCA8F3A82743E: '通用关联中的类型%0是一个variably modified type'
+HCA8F3A82743E: '通用关联中的类型 %0 是一个variably modified type'
 # 'type %0 in generic association not an object type'
 H9CBDAFFFD0D2: '类型 %0 在泛型关联中不是对象类型'
 # 'type %0 is incomplete'
@@ -27631,7 +27631,7 @@ H546F4F02218C: '非类型模板参数的类型 %0 不是结构性类型'
 # 'type %0 requires %1 bytes of alignment and the default allocator only guarantees %2 bytes'
 H82A5F7C1A758: '类型 %0 需要 %1 字节的对齐，而默认分配器仅保证 %2 字节'
 # 'type %2 of %select{explicit instantiation|explicit specialization|partial specialization|redeclaration}0 of %1 does not match expected type %3'
-H34154FB5D28F: '类型%2的%select{显式实例化|显式特化|部分特化|重新声明}0 %1与期望类型%3不匹配'
+H34154FB5D28F: '类型 %2 的%select{显式实例化|显式特化|部分特化|重新声明}0 %1 与期望类型 %3 不匹配'
 # "type argument %0 cannot be qualified with '%1'"
 HF21B2C8937B4: '类型参数 %0 不能用 "%1" 进行限定'
 # 'type argument %0 cannot explicitly specify nullability'
@@ -27669,7 +27669,7 @@ H51291DDF6B58: 'constexpr %select{函数|构造函数}0 中的类型定义与C++
 # 'type inference of a declaration other than a plain identifier with optional trailing attributes is a Clang extension'
 HB4EF9FC7F52F: '非普通标识符（可带尾置属性）的类型推导是Clang扩展'
 # 'type is given name %0 for linkage purposes by this %select{typedef|alias}1 declaration'
-HFEABA5A13E20: '此%select{typedef|别名}1声明为链接目的将类型命名为%0'
+HFEABA5A13E20: '此%select{typedef|别名}1声明为链接目的将类型命名为 %0'
 # 'type is not C-compatible due to this %select{base class|default member initializer|lambda expression|friend declaration|member declaration}0'
 H8BEB926AC2A7: '由于以下%select{基类|默认成员初始化器|lambda表达式|友元声明|成员声明}0，类型不兼容C兼容'
 # 'type name does not allow %select{<ERROR>|constexpr|consteval|constinit}0 specifier to be specified'
@@ -27681,7 +27681,7 @@ HD221C2943356: '类型名称不允许指定存储类'
 # 'type name requires a specifier or qualifier'
 H9BCBB335F47F: '类型名称需要指定说明符或限定符'
 # 'type nullability specifier %0 is a Clang extension'
-HFDBD8198839C: '类型空值限定符%0是Clang扩展'
+HFDBD8198839C: '类型空值限定符 %0 是Clang扩展'
 # 'type of %ordinal0 parameter of local declaration does not match definition%diff{ ($ vs $)|}1,2'
 HC35F751A0E20: '本地声明第%ordinal0参数的类型与定义不匹配%diff{ ($ vs $)|}1,2'
 # 'type of %ordinal0 parameter of member declaration does not match definition%diff{ ($ vs $)|}1,2'
@@ -27695,7 +27695,7 @@ HCC37C6223BD0: '机器模式类型与基类型类型不匹配'
 # 'type of machine mode does not support base vector types'
 HC82FE5FB775E: '机器模式类型不支持基础向量类型'
 # 'type of property %0 (%1) does not match type of accessor %2 (%3)'
-H588E7AE2B664: '属性%0 (%1)的类型与访问器%2 (%3)的类型不匹配'
+H588E7AE2B664: '属性 %0 (%1)的类型与访问器 %2 (%3)的类型不匹配'
 # 'type of property %0 (%1) does not match type of instance variable %2 (%3)'
 H73BAE4F8734B: '属性 %0 (%1) 的类型与实例变量 %2 (%3) 的类型不匹配'
 # 'type of property %0 does not match type of accessor %1'
@@ -27771,7 +27771,7 @@ H48D73D54C838: '无法创建目标："%0"'
 # 'unable to execute command: %0'
 H1274C3267D8B: '无法执行命令：%0'
 # "unable to find %0 directory, expected to be in '%1' found via %2"
-HFA08DE02A86A: "无法找到%0目录，期望位于'%1'，通过%2找到的位置"
+HFA08DE02A86A: "无法找到 %0 目录，期望位于 '%1'，通过 %2 找到的位置"
 # "unable to find %select{'::operator new(size_t, nothrow_t)'|'::operator new(size_t, align_val_t, nothrow_t)'}1 for %0"
 HD53B43D38AB3: "无法为 %0 找到 %select{'::operator new(size_t, nothrow_t)'|'::operator new(size_t, align_val_t, nothrow_t)'}1"
 # 'unable to find a Visual Studio installation; try running Clang from a developer command prompt'
@@ -27801,23 +27801,23 @@ H9ABA30151CEC: '无法打开CC_PRINT_HEADERS文件：%0（使用标准错误输�
 # 'unable to open CC_PRINT_OPTIONS file: %0'
 HEA741366E890: '无法打开CC_PRINT_OPTIONS文件：%0'
 # 'unable to open file %0 for serializing diagnostics (%1)'
-HD09A684B5E47: '无法打开文件%0用于序列化诊断信息（%1）'
+HD09A684B5E47: '无法打开文件 %0 用于序列化诊断信息（%1）'
 # "unable to open output file '%0': '%1'"
 H1FD155FFBE98: '无法打开输出文件“%0”：“%1”'
 # "unable to open statistics output file '%0': '%1'"
 HDC9884A86150: '无法打开统计信息输出文件“%0”：“%1”'
 # 'unable to overwrite file %0: %1'
-HF040F371E4DB: '无法覆盖文件%0：%1'
+HF040F371E4DB: '无法覆盖文件 %0：%1'
 # 'unable to protect inline asm that clobbers stack pointer against stack clash'
 H57F37138A9DF: '无法保护破坏堆栈指针的内联汇编以防止堆栈冲突'
 # "unable to read PCH file %0: '%1'"
-H53BCE7FDE626: '无法读取PCH文件%0：“%1”'
+H53BCE7FDE626: '无法读取PCH文件 %0：“%1”'
 # 'unable to remove file: %0'
 HA87F741C0BFD: '无法删除文件：%0'
 # "unable to rename temporary '%0' to output file '%1': '%2'"
 H621AA5D0DBAB: '无法将临时文件“%0”重命名为输出文件“%1”：“%2”'
 # 'unable to resolve declare reduction construct for type %0'
-H4CBC0B2EAEEC: '无法解析类型%0的声明式规约构造'
+H4CBC0B2EAEEC: '无法解析类型 %0 的声明式规约构造'
 # 'unable to set working directory: %0'
 H1915AC32A7BB: '无法设置工作目录：%0'
 # 'unannotated fall-through between switch labels'
@@ -27825,43 +27825,43 @@ HD2F0C0FDF581: 'switch标签间的未注释穿透'
 # 'unannotated fall-through between switch labels in partly-annotated function'
 H8BA6FF77BB8B: '部分注释的函数中switch标签间的未注释穿透'
 # "unary fold expression has empty expansion for operator '%0' with no fallback value"
-HE62A3703EA3A: "一元折叠表达式为操作符'%0'的展开为空且无备用值"
+HE62A3703EA3A: "一元折叠表达式为操作符 '%0' 的展开为空且无备用值"
 # 'unary operator not supported, only increment and decrement operations permitted'
 HCFDDCEAA7D4F: '不支持的一元运算符，仅允许增量和减量操作'
 # 'undeclared identifier %0 in destructor name'
-H9E161BF60045: '析构函数名称中未声明的标识符%0'
+H9E161BF60045: '析构函数名称中未声明的标识符 %0'
 # 'undeclared selector %0'
-H76DFE4FB888F: '未声明的选择器%0'
+H76DFE4FB888F: '未声明的选择器 %0'
 # 'undeclared selector %0; did you mean %1?'
-HFF50CB7951F9: '未声明的选择器%0；是否是指%1？'
+HFF50CB7951F9: '未声明的选择器 %0；是否是指 %1？'
 # "undeclared variable %0 used as an argument for '#pragma unused'"
-H1A926D40EA78: "未声明的变量%0被用作'#pragma unused'的参数"
+H1A926D40EA78: "未声明的变量 %0 被用作'#pragma unused'的参数"
 # 'undef all system defines'
 H5E817AACEB7A: '取消定义所有系统宏定义'
 # 'undefining builtin macro'
 H855B9F8C6AE6: '试图取消定义内建宏'
 # 'under -fcoro-aligned-allocation, the non-aligned allocation function for the promise type %0 has higher precedence than the global aligned allocation function'
-H677A6074184D: '在-fcoro-aligned-allocation下，承诺类型%0的非对齐分配函数比全局对齐分配函数具有更高的优先级'
+H677A6074184D: '在-fcoro-aligned-allocation下，承诺类型 %0 的非对齐分配函数比全局对齐分配函数具有更高的优先级'
 # 'underaligned exception object thrown'
 H67F3421C41BE: '抛出未对齐的异常对象'
 # "unelaborated friend declaration is a C++11 extension; specify '%select{struct|interface|union|class|enum}0' to befriend %1"
-H85486A35A143: "未详细声明的友元声明是C++11扩展；请指定'%select{struct|interface|union|class|enum}0'来与%1建立友元关系"
+H85486A35A143: "未详细声明的友元声明是C++11扩展；请指定'%select{struct|interface|union|class|enum}0'来与 %1 建立友元关系"
 # 'unexpected %0 in function call; perhaps remove the %0?'
-HF91D5DDAC941: '函数调用中出现意外的%0；是否需要移除%0？'
+HF91D5DDAC941: '函数调用中出现意外的 %0；是否需要移除 %0？'
 # "unexpected %0, expected to see one of %select{|'best_case', 'full_generality', }1'single_inheritance', 'multiple_inheritance', or 'virtual_inheritance'"
-H715E4C7A8362: "意外的%0，期望看到%select{|'best_case', 'full_generality', }1'single_inheritance', 'multiple_inheritance'或'virtual_inheritance'之一"
+H715E4C7A8362: "意外的 %0，期望看到%select{|'best_case', 'full_generality', }1'single_inheritance', 'multiple_inheritance' 或 'virtual_inheritance' 之一"
 # "unexpected '#pragma acc ...' in program"
 H1E1E01704393: "程序中出现意外的'#pragma acc ...'"
 # "unexpected '#pragma omp ...' in program"
 H46D7021997C2: "程序中出现意外的'#pragma omp ...'"
 # "unexpected '%0' clause, '%1' is specified already"
-H5B200478E6AE: "意外的'%0'子句，'%1'已被指定"
+H5B200478E6AE: "意外的 '%0' 子句，'%1' 已被指定"
 # "unexpected '%0' clause, only %select{'device_type'|'enter' or 'link'|'enter', 'link' or 'device_type'|'device_type', 'indirect'|'enter', 'link', 'device_type' or 'indirect'}1 clauses expected"
-H3763BE9D9C9F: "意外的'%0'子句，仅允许%select{'device_type'|'enter'或'link'|'enter', 'link'或'device_type'|'device_type', 'indirect'|'enter', 'link', 'device_type'或'indirect'}1子句"
+H3763BE9D9C9F: "意外的 '%0' 子句，仅允许%select{'device_type'|'enter' 或 'link'|'enter', 'link' 或 'device_type'|'device_type', 'indirect'|'enter', 'link', 'device_type' 或 'indirect'}1子句"
 # "unexpected '%0' clause, only %select{'device_type'|'to' or 'link'|'to', 'link' or 'device_type'|'device_type', 'indirect'|'to', 'link', 'device_type' or 'indirect'}1 clauses expected"
-H1A9F6651CC12: "意外的'%0'子句，仅期望%select{'device_type'|'to'或'link'|'to', 'link'或'device_type'|'device_type', 'indirect'|'to', 'link', 'device_type'或'indirect'}1子句"
+H1A9F6651CC12: "意外的 '%0' 子句，仅期望%select{'device_type'|'to' 或 'link'|'to', 'link' 或 'device_type'|'device_type', 'indirect'|'to', 'link', 'device_type' 或 'indirect'}1子句"
 # "unexpected '(', only 'to', 'link' or 'device_type' clauses expected for 'begin declare target' directive"
-H5361030EF185: "在'begin declare target'指令中，'('意外，仅期望'to'、'link'或'device_type'子句"
+H5361030EF185: "在'begin declare target'指令中，'('意外，仅期望 'to'、'link' 或 'device_type' 子句"
 # "unexpected ':' in nested name specifier; did you mean '::'?"
 HC8B611B07937: "嵌套名称限定符中的意外 ':'，您是否想输入 '::'？"
 # "unexpected ';' before %0"
@@ -27883,13 +27883,13 @@ H1C5752C27ACF: "在指令 '#pragma omp %1' 中，OpenMP 子句 '%0' 意外"
 # "unexpected OpenMP directive %select{|'#pragma omp %1'}0"
 HEF8086A19118: "意外的 OpenMP 指令 %select{|'#pragma omp %1'}0"
 # "unexpected argument '%0' to '#pragma %1'%select{|; expected %3}2"
-HB8C385DE07A5: "对'#pragma %1'的意外参数'%0'%select{|；期望%3}"
+HB8C385DE07A5: "对'#pragma %1'的意外参数 '%0'%select{|；期望 %3}"
 # "unexpected argument '%0' to '#pragma clang attribute'; expected 'push' or 'pop'"
-H3133E5143B09: "对'#pragma clang attribute'的意外参数'%0'；期望'push'或'pop'"
+H3133E5143B09: "对'#pragma clang attribute'的意外参数 '%0'；期望 'push' 或 'pop'"
 # "unexpected argument '%0' to '#pragma clang fp %1'; expected %select{'fast' or 'on' or 'off'|'on' or 'off'|'on' or 'off'|'ignore', 'maytrap' or 'strict'|'source', 'double' or 'extended'}2"
-H371571C43BD4: "对'#pragma clang fp %1'的意外参数'%0'；期望%select{'fast'或'on'或'off'|'on'或'off'|'on'或'off'|'ignore', 'maytrap'或'strict'|'source', 'double'或'extended'}2"
+H371571C43BD4: "对'#pragma clang fp %1'的意外参数 '%0'；期望%select{'fast' 或 'on' 或 'off'|'on' 或 'off'|'on' 或 'off'|'ignore', 'maytrap' 或 'strict'|'source', 'double' 或 'extended'}2"
 # "unexpected argument '%0' to '#pragma clang optimize'; expected 'on' or 'off'"
-H1485FAA86056: "对'#pragma clang optimize'的意外参数'%0'；期望'on'或'off'"
+H1485FAA86056: "对'#pragma clang optimize'的意外参数 '%0'；期望 'on' 或 'off'"
 # 'unexpected argument to debug command'
 H3827CC068DE1: '调试命令的意外参数'
 # 'unexpected character <U+%0>'
@@ -27911,13 +27911,13 @@ HD169A0238D64: "#pragma clang optimize 指令意外多出参数 '%0'"
 # 'unexpected extra tokens at end of @import declaration'
 HC94D2D8555A6: '@import声明末尾存在意外的额外标记'
 # 'unexpected interface name %0: expected expression'
-HD34771026F11: '意外的接口名称%0：期望表达式'
+HD34771026F11: '意外的接口名称 %0：期望表达式'
 # 'unexpected namespace name %0: expected expression'
-HD2F7F8269F1D: '意外的命名空间名称%0：期望表达式'
+HD2F7F8269F1D: '意外的命名空间名称 %0：期望表达式'
 # 'unexpected namespace scope prior to decltype'
 H276642EE3F52: '在decltype之前存在意外的命名空间作用域'
 # "unexpected operation specified in 'append_args' clause, expected 'interop'"
-H7343FC2DA837: "'append_args'子句中指定了意外操作，期望'interop'"
+H7343FC2DA837: "'append_args' 子句中指定了意外操作，期望 'interop'"
 # "unexpected output symbol graph '%1'; please provide '--symbol-graph-dir=<directory>' instead"
 H16E9C665ACBA: "意外的输出符号图 '%1'；请改为提供 '--symbol-graph-dir=<directory>'"
 # "unexpected parameter '%0' in availability attribute, not permitted in %select{HLSL|C/C++}1"
@@ -27927,11 +27927,11 @@ H279452517A7B: 'Objective-C字符串之后存在意外的标记'
 # 'unexpected token in pragma diagnostic'
 HF7F8BD94B55D: '在#pragma diagnostic指令中检测到意外的标记'
 # 'unexpected type name %0: expected expression'
-H5096D6005D2D: '意外的类型名称%0：期望表达式'
+H5096D6005D2D: '意外的类型名称 %0：期望表达式'
 # 'unexpected type name %0: expected identifier'
 HECE4BA85049C: '意外的类型名称 %0：期望标识符'
 # "unexpected value; use 'true' or 'false'"
-HBC54A5A54D19: "意外的值；请使用'true'或'false'"
+HBC54A5A54D19: "意外的值；请使用 'true' 或 'false'"
 # 'unguarded header; consider using #ifdef guards or #pragma once'
 H1B291D4D56CA: '未受保护的头文件；建议使用#ifdef保护或#pragma once'
 # 'unicode literals are incompatible with C standards before C23'
@@ -27945,7 +27945,7 @@ H413288F05A72: 'Unicode字面量与C99不兼容'
 # 'unimplemented constexpr lambda feature: %0 (coming soon!)'
 H49A46ED86D09: '未实现的constexpr lambda特性: %0 (即将推出!)'
 # 'unimplemented pure virtual method %0 in %1'
-H6BCBAEFB56A1: '%1中的纯虚方法%0未实现'
+H6BCBAEFB56A1: '%1 中的纯虚方法 %0 未实现'
 # 'uninitialized reference member is here'
 HD2F77230D93D: '未初始化的引用成员在此处'
 # 'uninitialized variable in a constexpr %select{function|constructor}0 is a C++20 extension'
@@ -27953,9 +27953,9 @@ HD0E4F93C0D47: 'constexpr %select{函数|构造函数}0中的未初始化变量�
 # 'uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20'
 HB023F58DC7FA: 'constexpr %select{函数|构造函数}0中的未初始化变量与C++20前的标准不兼容'
 # 'union member %0 has reference type %1'
-H0725C5FA90A3: '联合体成员%0具有引用类型%1'
+H0725C5FA90A3: '联合体成员 %0 具有引用类型 %1'
 # 'union member %0 has reference type %1, which is a Microsoft extension'
-H717E84EDF789: '联合体成员%0具有引用类型%1，这是Microsoft扩展'
+H717E84EDF789: '联合体成员 %0 具有引用类型 %1，这是Microsoft扩展'
 # 'unions cannot be base classes'
 H3537D21C3F62: '联合体不能作为基类'
 # 'unions cannot have base classes'
@@ -27975,9 +27975,9 @@ H6C064E2FEAA1: '通用字符名仅在C99或C++中有效'
 # "universal character names are only valid in C99 or C++; treating as '\\' followed by identifier"
 H57AF83D90AE3: "通用字符名仅在C99或C++中有效；将其视为反斜杠'\\'后接标识符"
 # "unknown %0 warning specifier: '%1'"
-HE021FCA9FD45: "未知的%0警告说明符: '%1'"
+HE021FCA9FD45: "未知的 %0 警告说明符: '%1'"
 # 'unknown %select{type|class}1 name %0; did you mean %2?'
-H3C8376ED6B78: '未知的%select{类型|类}1名称%0；您是否指%2？'
+H3C8376ED6B78: '未知的%select{类型|类}1名称 %0；您是否指 %2？'
 # "unknown %select{warning|remark}0 option '%1'%select{|; did you mean '%3'?}2"
 HE86784D7A808: "未知的 %select{警告|备注}0 选项 '%1'%select{|; 你是否是指 '%3'?}2"
 # "unknown '-mindirect-jump=' option '%0'"
@@ -28109,7 +28109,7 @@ H97B49477D381: '不支持的MC/DC布尔表达式；条件数量（%0）超过最
 # 'unsupported MC/DC boolean expression; number of test vectors (%0) exceeds max (%1). Expression will not be covered'
 HA1952652ED2D: '不支持的MC/DC布尔表达式；测试向量数量（%0）超过最大值（%1）。该表达式将不会被覆盖'
 # 'unsupported OpenCL extension %0 - ignoring'
-H90715CF4E48F: '不支持的OpenCL扩展%0 - 忽略'
+H90715CF4E48F: '不支持的OpenCL扩展 %0 - 忽略'
 # "unsupported architecture '%0' for MS-style inline assembly"
 H4CDA8CDAE447: "不支持的架构 '%0' 用于MS风格的内联汇编"
 # "unsupported architecture '%0' for host compilation"
@@ -28189,9 +28189,9 @@ HED8DED50ECC0: '更新可执行文件中的DWARF调试部分'
 # 'update address2ProbesMap with output block address'
 H5AFCEC7A601F: '使用输出块地址更新address2ProbesMap'
 # 'use %select{__bridge_retained|CFBridgingRetain call}1 to make an ARC object available as a +1 %0'
-H2F547772958A: '使用 %select{__bridge_retained|CFBridgingRetain 调用}1 将ARC对象作为+1 %0可用'
+H2F547772958A: '使用 %select{__bridge_retained|CFBridgingRetain 调用}1 将ARC对象作为+1 %0 可用'
 # 'use %select{__bridge_transfer|CFBridgingRelease call}1 to transfer ownership of a +1 %0 into ARC'
-HF8A351DB4284: '使用 %select{__bridge_transfer|CFBridgingRelease 调用}1 将+1 %0的所有权转移到ARC'
+HF8A351DB4284: '使用 %select{__bridge_transfer|CFBridgingRelease 调用}1 将+1 %0 的所有权转移到ARC'
 # 'use %select{an alias declaration|a typedef declaration|a reference|a const variable|a constexpr variable}0 instead'
 H31FA52067035: '改用 %select{别名声明|typedef声明|引用|const变量|constexpr变量}0'
 # "use '!=' to turn this compound assignment into an inequality comparison"
@@ -28251,9 +28251,9 @@ HF999F719DC1E: '使用 __bridge 进行直接转换（不改变所有权）'
 # 'use __bridge with C-style cast to convert directly (no change in ownership)'
 H25381B224554: '使用 __bridge 结合 C 风格强制转换进行直接转换（不改变所有权）'
 # 'use __bridge_retained with C-style cast to make an ARC object available as a +1 %0'
-H89038B186CBF: '使用 __bridge_retained 结合 C 风格强制转换，使+1 %0在ARC中可用'
+H89038B186CBF: '使用 __bridge_retained 结合 C 风格强制转换，使+1 %0 在ARC中可用'
 # 'use __bridge_transfer with C-style cast to transfer ownership of a +1 %0 into ARC'
-H0BF38DCCAF48: '使用 __bridge_transfer 结合 C 风格强制转换，将+1 %0的所有权转移给ARC'
+H0BF38DCCAF48: '使用 __bridge_transfer 结合 C 风格强制转换，将+1 %0 的所有权转移给ARC'
 # "use a function's hot size when doing clustering"
 H10032CBF870F: '在进行聚类时使用函数的热点大小'
 # 'use a lock file so only one process in the system can run this pass at once. useful to avoid mangled debug output in multithreaded environments.'
@@ -28293,15 +28293,15 @@ H244914CD834D: '对所有访问使用带有慢路径的插桩'
 # 'use misprediction frequency for determining whether or not ICP should be applied at a callsite.  The -indirect-call-promotion-mispredict-threshold value will be used by this heuristic'
 H3115132EB120: '使用间接调用处的误预测频率来决定是否应用ICP。-indirect-call-promotion-mispredict-threshold值将由该启发式方法使用'
 # 'use non-reference type %0'
-HE4A5CE8520B2: '使用非引用类型%0'
+HE4A5CE8520B2: '使用非引用类型 %0'
 # 'use non-reference type %0 to make construction explicit or type %1 to prevent copying'
-HAB8A2938766C: '使用非引用类型%0显式构造，或使用类型%1防止复制'
+HAB8A2938766C: '使用非引用类型 %0 显式构造，或使用类型 %1 防止复制'
 # 'use nullability type specifier %0 to affect the innermost pointer type of %1'
-HA9A4302606C7: '使用空值类型说明符%0影响%1的最内层指针类型'
+HA9A4302606C7: '使用空值类型说明符 %0 影响 %1 的最内层指针类型'
 # 'use of %0 with tag type that does not match previous declaration'
-H4AAB2FCDDAB1: '使用与之前声明不匹配的标签类型%0'
+H4AAB2FCDDAB1: '使用与之前声明不匹配的标签类型 %0'
 # 'use of %select{class template|function template|variable template|alias template|template template parameter|concept|template}0 %1 requires template arguments'
-H8F99144D2E34: '使用%select{类模板|函数模板|变量模板|别名模板|模板模板参数|概念|模板}0 %1需要模板实参'
+H8F99144D2E34: '使用%select{类模板|函数模板|变量模板|别名模板|模板模板参数|概念|模板}0 %1 需要模板实参'
 # 'use of %select{infinity|NaN}0%select{| via a macro}1 is undefined behavior due to the currently enabled floating-point options'
 H18AE2A8F681F: '使用%select{无穷大|NaN}0%select{|通过宏}1由于当前启用的浮点选项导致未定义行为'
 # 'use of %select{type|declaration}0 %1 requires %2 support'
@@ -28423,15 +28423,15 @@ H0FD6FA3111E8: '使用 volatile 限定类型 %0 的赋值结果属于已弃用�
 # "use of right-shift operator ('>>') in template argument will require parentheses in C++11"
 H4B1C2F8BF668: "在 C++11 中模板实参中使用右移运算符 ('>>') 需要显式添加括号"
 # 'use of the %0 attribute is a C++14 extension'
-HD7333826DEB8: '使用%0属性是C++14的扩展'
+HD7333826DEB8: '使用 %0 属性是C++14的扩展'
 # 'use of the %0 attribute is a C++17 extension'
-H9D6E9F75124A: '使用%0属性是C++17的扩展'
+H9D6E9F75124A: '使用 %0 属性是C++17的扩展'
 # 'use of the %0 attribute is a C++20 extension'
-H85EE1317CADA: '使用%0属性是C++20的扩展'
+H85EE1317CADA: '使用 %0 属性是C++20的扩展'
 # 'use of the %0 attribute is a C++23 extension'
-H3769FB94DD63: '使用%0属性是C++23的扩展'
+H3769FB94DD63: '使用 %0 属性是C++23的扩展'
 # 'use of this expression in an %0 attribute requires parentheses'
-H4B6BF2EAA0DF: '在%0属性中使用此表达式需要括号'
+H4B6BF2EAA0DF: '在 %0 属性中使用此表达式需要括号'
 # 'use of this statement in a constexpr %select{function|constructor}0 is a C++14 extension'
 H009816A3B264: '在constexpr %select{函数|构造函数}0中使用此语句是C++14的扩展'
 # 'use of this statement in a constexpr %select{function|constructor}0 is a C++20 extension'
@@ -28449,21 +28449,21 @@ H6516CAF74372: '使用typeid需要-frtti选项'
 # 'use of unary operator that may be intended as compound assignment (%0=)'
 H52686183E946: '使用可能意图作为复合赋值运算符（%0=）的一元运算符'
 # 'use of undeclared %0'
-H4249B6D3D66A: '使用未声明的%0'
+H4249B6D3D66A: '使用未声明的 %0'
 # 'use of undeclared %0; did you mean %1?'
-H152AECD0CF73: '使用未声明的%0；是否是指%1？'
+H152AECD0CF73: '使用未声明的 %0；是否是指 %1？'
 # 'use of undeclared identifier %0'
-H2DA2A4EF5956: '使用未声明的标识符%0'
+H2DA2A4EF5956: '使用未声明的标识符 %0'
 # 'use of undeclared identifier %0; did you mean %1?'
-H448AE4CE2F58: '使用未声明的标识符%0；是否是指%1？'
+H448AE4CE2F58: '使用未声明的标识符 %0；是否是指 %1？'
 # 'use of undeclared identifier %0; unqualified lookup into dependent bases of class template %1 is a Microsoft extension'
-HB6A34859F540: '使用未声明的标识符%0；类模板%1的依赖基类中未限定查找是Microsoft扩展'
+HB6A34859F540: '使用未声明的标识符 %0；类模板 %1 的依赖基类中未限定查找是Microsoft扩展'
 # 'use of undeclared label %0'
-H685C1928674B: '使用未声明的标签%0'
+H685C1928674B: '使用未声明的标签 %0'
 # "use of undefined marker '%0'"
-HAEC3C6045C74: "使用未定义的标记'%0'"
+HAEC3C6045C74: "使用未定义的标记 '%0'"
 # 'use of unknown builtin %0'
-HBFCE16721923: '使用未知的内建函数%0'
+HBFCE16721923: '使用未知的内建函数 %0'
 # 'use old code sequence for promoted calls'
 H27311E45E8D5: '为提升的调用使用旧代码序列'
 # 'use perf data directly when constructing the call graph for stale functions'
@@ -28471,7 +28471,7 @@ H9C843E88A00A: '在构建过时函数的调用图时直接使用perf数据'
 # 'use precise runtime behavior'
 H864CB2EB7B9A: '使用精确的运行时行为'
 # 'use reference type %0 to prevent copying'
-H96F12D2BC3F2: '使用引用类型%0以防止拷贝'
+H96F12D2BC3F2: '使用引用类型 %0 以防止拷贝'
 # 'use register liveness analysis to try to find more opportunities for -reg-reassign optimization'
 H7BCD305B01BE: '使用寄存器存活分析尝试为-reg-reassign优化寻找更多机会'
 # 'use regular size pages for code alignment'
@@ -28483,7 +28483,7 @@ HA2145EBF1AF4: '在二进制中使用重定位信息（默认=自动检测）'
 # 'use same count for BBs that should have equivalent count (used in non-LBR and shrink wrapping)'
 H2FCA1FC45D12: '为应具有等效计数的BB块使用相同计数（用于非LBR和收缩包装场景）'
 # "use same version number separators '_' or '.'; as in 'major[.minor[.subminor]]'"
-H152CFF6748B3: "请使用相同的版本号分隔符'_'或'.'，例如'major[.minor[.subminor]]'"
+H152CFF6748B3: "请使用相同的版本号分隔符 '_' 或'.'，例如'major[.minor[.subminor]]'"
 # 'use short granules in allocas and outlined checks'
 H1D7871DD27F1: '在allocas和分离检查中使用短粒度'
 # 'use strict dwarf'
@@ -28491,21 +28491,21 @@ HD69F3507E82F: '使用严格DWARF'
 # 'use stricter verifier for HLFIR intrinsic operations'
 H7296989D6AE9: '为HLFIR内建操作使用更严格的验证器'
 # "use the GNU '__attribute__' syntax"
-H7DBF5BB23C34: "使用GNU的'__attribute__'语法"
+H7DBF5BB23C34: "使用GNU的 '__attribute__' 语法"
 # 'used here'
 H1359FF249380: '在此处使用'
 # 'used in initialization here'
 H9614905D4DE2: '在此初始化中使用'
 # 'used type %0 where __hlsl_resource_t is required'
-HB0299AD4C891: '此处使用类型%0，但需要__hlsl_resource_t类型'
+HB0299AD4C891: '此处使用类型 %0，但需要__hlsl_resource_t类型'
 # 'used type %0 where arithmetic or pointer type is required'
-HEF054774D419: '此处使用类型%0，但需要算术类型或指针类型'
+HEF054774D419: '此处使用类型 %0，但需要算术类型或指针类型'
 # 'used type %0 where floating point type is not allowed'
-HF095E0FB08EE: '此处使用类型%0，但不允许使用浮点类型'
+HF095E0FB08EE: '此处使用类型 %0，但不允许使用浮点类型'
 # 'used type %0 where integer is required'
-HCD053F3A5F86: '此处使用类型%0，但需要整数类型'
+HCD053F3A5F86: '此处使用类型 %0，但需要整数类型'
 # 'used type %0 where integer or floating point type is required'
-H46DF1623ED73: '此处使用类型%0，但需要整数或浮点类型'
+H46DF1623ED73: '此处使用类型 %0，但需要整数或浮点类型'
 # 'used%select{| in pointer arithmetic| in buffer access}0 here'
 H2D0FA9F859F9: '此处%select{使用|在指针运算中使用|在缓冲区访问中使用}0'
 # "user-defined literal suffixes %select{<ERROR>|not starting with '_'|containing '__'}0 are reserved%select{; no literal will invoke this operator|}1"
@@ -28513,21 +28513,21 @@ H414028466FC2: '用户定义的字面量后缀%select{<ERROR>|不以"_"开头|�
 # 'using'
 H92BD75EBD8FD: '使用'
 # 'using %0 directive in %select{NSString|CFString}1 which is being passed as a formatting argument to the formatting %select{method|CFfunction}2'
-HFA21A8452E12: '在%select{NSString|CFString}1中使用%0指令，该指令作为格式参数传递给格式%select{方法|CF函数}2'
+HFA21A8452E12: '在 %select{NSString|CFString}1 中使用 %0 指令，该指令作为格式参数传递给格式%select{方法|CF函数}2'
 # 'using %0 with a literal is redundant'
-HA26F40AA0176: '与字面量一起使用%0是多余的'
+HA26F40AA0176: '与字面量一起使用 %0 是多余的'
 # 'using %select{integer|floating point|complex}1 absolute value function %0 when argument is of %select{integer|floating point|complex}2 type'
-H2A1C61EF88A1: '当参数为%select{整数|浮点|复数}2类型时，使用%select{整数|浮点|复数}1类型的绝对值函数%0'
+H2A1C61EF88A1: '当参数为%select{整数|浮点|复数}2类型时，使用%select{整数|浮点|复数}1类型的绝对值函数 %0'
 # "using '%%P' format specifier with an Objective-C pointer results in dumping runtime object structure, not object value"
 H513C1ECC12E7: '在Objective-C指针中使用"%%P"格式说明符会导致转储运行时对象结构，而不是对象值'
 # "using '%%P' format specifier without precision"
 HE89A56274479: '未指定精度时使用"%%P"格式说明符'
 # "using '%0' format specifier annotation outside of os_log()/os_trace()"
-H2CE6DDE79E74: '在os_log()/os_trace()之外使用"%0"格式说明符注释'
+H2CE6DDE79E74: '在os_log()/os_trace()之外使用 "%0" 格式说明符注释'
 # "using '%0' format specifier, but argument has boolean value"
-HDDBB822724E7: "使用'%0'格式说明符，但参数具有布尔值"
+HDDBB822724E7: "使用 '%0' 格式说明符，但参数具有布尔值"
 # "using declaration annotated with 'using_if_exists' here"
-HDB8ACBC0FBF5: "此处使用标注有'using_if_exists'的声明"
+HDB8ACBC0FBF5: "此处使用标注有 'using_if_exists' 的声明"
 # 'using declaration cannot refer to a constructor'
 HF62840A086D5: 'using声明不能引用构造函数'
 # 'using declaration cannot refer to a destructor'
@@ -28547,9 +28547,9 @@ H52802307DDAC: 'using声明引用作用域枚举与C++20之前的标准不兼容
 # 'using declaration pack expansion at block scope produces multiple values'
 HFC5BC61E58BC: '块作用域中的using声明包展开会产生多个值'
 # 'using declaration referring to %1 with %select{internal|module|unknown}0 linkage cannot be exported'
-HFDD1D0A3610E: '引用具有%select{内部|模块|未知}0链接的%1的using声明无法导出'
+HFDD1D0A3610E: '引用具有%select{内部|模块|未知}0链接的 %1 的using声明无法导出'
 # "using declaration referring to inaccessible member '%0' (which refers to accessible member '%1') is a Microsoft compatibility extension"
-HA7AB89787DCC: "引用不可访问成员'%0'（其指向可访问成员'%1'）是Microsoft兼容扩展"
+HA7AB89787DCC: "引用不可访问成员 '%0'（其指向可访问成员 '%1'）是Microsoft兼容扩展"
 # 'using declaration refers into %0, which is not a base class of %1'
 HE8EC9FE5FD16: 'using 声明引用到 %0，但该类型不是 %1 的基类'
 # 'using declaration refers to its own class'
@@ -28569,13 +28569,13 @@ HCAD96DA2A48D: "使用长度修饰符 '%0' 与转换说明符 '%1' 不受ISO C�
 # 'using namespace directive in global context in header'
 HDFF3F4F00DD3: '头文件全局作用域中使用using命名空间指令'
 # "using sysroot for '%0' but targeting '%1'"
-H23CBFE9436FA: "使用'%0'的sysroot，但目标平台是'%1'"
+H23CBFE9436FA: "使用 '%0' 的sysroot，但目标平台是 '%1'"
 # 'using the result of an assignment as a condition without parentheses'
 HD808A1E3A9FB: '将赋值表达式的结果用作条件时未使用括号'
 # 'using the undeclared type %0 as a default template argument is a Microsoft extension'
-H9BAAEE7535FA: '将未声明的类型%0作为默认模板参数是Microsoft扩展'
+H9BAAEE7535FA: '将未声明的类型 %0 作为默认模板参数是Microsoft扩展'
 # 'using unversioned Android target directory %0 for target %1; unversioned directories will not be used in Clang 19 -- provide a versioned directory for the target version or lower instead'
-H120D3110B47A: '为目标%1使用未版本化的Android目标目录%0；Clang 19将不再使用未版本化的目录——请为对应版本提供版本化的目录或使用更低版本'
+H120D3110B47A: '为目标 %1 使用未版本化的Android目标目录 %0；Clang 19将不再使用未版本化的目录——请为对应版本提供版本化的目录或使用更低版本'
 # 'using-enum cannot name a dependent type'
 H3DC57F2168E8: 'using-enum不能命名一个相关依赖类型'
 # 'usual LSP protocol'
@@ -28585,77 +28585,77 @@ H1FAF5254B686: 'uuid属性包含格式错误的GUID'
 # 'uuid does not match previous declaration'
 H1E8E115FA4D8: 'uuid与之前的声明不匹配'
 # 'valid %0 clauses start with %1; %select{token|tokens}2 will be ignored'
-HA977999237FF: '有效的%0子句以%1开头；%select{token|tokens}2将被忽略'
+HA977999237FF: '有效的 %0 子句以 %1 开头；%select{token|tokens}2 将被忽略'
 # 'valid target CPU values are: %0'
 HB573A028A656: '有效的目标CPU值为：%0'
 # 'value %0 is outside the range of representable values of type %1'
-H76B206381D68: '值%0超出类型%1可表示的范围'
+H76B206381D68: '值 %0 超出类型 %1 可表示的范围'
 # 'value %1 cannot be represented in type %0'
-H0FCCEC09B538: '值%1无法用类型%0表示'
+H0FCCEC09B538: '值 %1 无法用类型 %0 表示'
 # "value '%0' out of range for constraint '%1'"
-H2964C78586A1: "值'%0'超出约束'%1'的范围"
+H2964C78586A1: "值 '%0' 超出约束 '%1' 的范围"
 # 'value is not an integer: %0'
 HDF6724275715: '值不是整数：%0'
 # 'value of #pragma pack(show) == %0'
-H78F0B6172824: '#pragma pack(show)的值为%0'
+H78F0B6172824: '#pragma pack(show)的值为 %0'
 # 'value of the aligned pointer (%0) is not a multiple of the asserted %1 %plural{1:byte|:bytes}1'
-HCBC69FE1B218: '对齐指针的值(%0)不是声明的%1 %plural{1:字节|:字节}1的倍数'
+HCBC69FE1B218: '对齐指针的值(%0)不是声明的 %1 %plural{1:字节|:字节}1的倍数'
 # "value of type %0 is not contextually convertible to 'bool'"
-H8D6D08CCD77E: "类型%0的值无法上下文转换为'bool'"
+H8D6D08CCD77E: "类型 %0 的值无法上下文转换为 'bool'"
 # 'value of type %0 is not implicitly convertible to %1'
-H7F07136EE80D: '类型%0的值无法隐式转换为%1'
+H7F07136EE80D: '类型 %0 的值无法隐式转换为 %1'
 # "value returned by '__builtin_counted_by_ref' cannot be %select{assigned to a variable|passed into a function|returned from a function}0"
-H0D53FCA7346F: "由'__builtin_counted_by_ref'返回的值不能%select{被赋值给变量|被传递给函数|从函数返回}0"
+H0D53FCA7346F: "由 '__builtin_counted_by_ref' 返回的值不能%select{被赋值给变量|被传递给函数|从函数返回}0"
 # "value returned by '__builtin_counted_by_ref' cannot be used in %select{an array subscript|a binary}0 expression"
-H4F263548602C: "'__builtin_counted_by_ref'返回的值不能用于%select{数组下标|二进制}0表达式"
+H4F263548602C: "'__builtin_counted_by_ref' 返回的值不能用于%select{数组下标|二进制}0表达式"
 # 'value size does not match register size specified by the constraint and modifier'
 H45E5585EA0B2: '值大小与约束和修饰符指定的寄存器大小不匹配'
 # 'varargs not allowed in requires expression'
 H65BA20F3C0FC: 'requires表达式中不允许使用可变参数'
 # "variable %0 cannot be declared both 'extern' and with the 'loader_uninitialized' attribute"
-H66B3CD6187EF: "变量%0不能同时声明为'extern'和带有'loader_uninitialized'属性"
+H66B3CD6187EF: "变量 %0 不能同时声明为 'extern' 和带有 'loader_uninitialized' 属性"
 # 'variable %0 cannot be implicitly captured in a lambda with no capture-default specified'
-H17BA614E3EF4: '在未指定捕获默认方式的lambda中不允许隐式捕获变量%0'
+H17BA614E3EF4: '在未指定捕获默认方式的lambda中不允许隐式捕获变量 %0'
 # 'variable %0 cannot be threadprivate because it is %select{thread-local|a global named register variable}1'
-HF72C764C6D1B: '变量%0不能是线程私有变量，因为它%select{是线程局部变量|是命名寄存器全局变量}1'
+HF72C764C6D1B: '变量 %0 不能是线程私有变量，因为它%select{是线程局部变量|是命名寄存器全局变量}1'
 # 'variable %0 declared with deduced type %1 cannot appear in its own initializer'
-H9648530537F2: '具有推导类型%1的变量%0不能出现在自身的初始化器中'
+H9648530537F2: '具有推导类型 %1 的变量 %0 不能出现在自身的初始化器中'
 # 'variable %0 is %select{decremented|incremented}1 both in the loop header and in the loop body'
 H5880C36D679C: '变量 %0 在循环头和循环体中均被%select{递减|递增}1'
 # "variable %0 is %select{used|captured}1 uninitialized whenever %select{'%3' condition is %select{true|false}4|'%3' loop %select{is entered|exits because its condition is false}4|'%3' loop %select{condition is true|exits because its condition is false}4|switch %3 is taken|its declaration is reached|%3 is called}2"
-H5B3E786190C7: "当%select{'%3'条件%select{为真|为假}4|'%3'循环%select{被进入|因条件为假退出}4|'%3'循环%select{条件为真|因条件为假退出}4|switch %3 被选中|其声明被访问|%3 被调用}2时，变量 %0 在%select{使用|被捕获}1时未初始化"
+H5B3E786190C7: "当%select{'%3' 条件%select{为真|为假}4|'%3' 循环%select{被进入|因条件为假退出}4|'%3' 循环%select{条件为真|因条件为假退出}4|switch %3 被选中|其声明被访问|%3 被调用}2时，变量 %0 在%select{使用|被捕获}1时未初始化"
 # 'variable %0 is declared here'
-H9C1D29CE922D: '变量%0在此处声明'
+H9C1D29CE922D: '变量 %0 在此处声明'
 # 'variable %0 is uninitialized when %select{used here|captured by block}1'
-HC11F7DAD1A0E: '变量%0在%select{此处使用时|被捕获到块中时}1时未初始化'
+HC11F7DAD1A0E: '变量 %0 在%select{此处使用时|被捕获到块中时}1时未初始化'
 # 'variable %0 is uninitialized when passed as a const reference argument here'
-H12F79B618200: '变量%0在作为常量引用参数传递时未初始化'
+H12F79B618200: '变量 %0 在作为常量引用参数传递时未初始化'
 # 'variable %0 is uninitialized when used within its own initialization'
-H9B3210B51205: '变量%0在自身初始化过程中使用时未初始化'
+H9B3210B51205: '变量 %0 在自身初始化过程中使用时未初始化'
 # 'variable %0 is%select{| explicitly}1 captured here'
-HC5A87C36FF05: '变量%0%select{被显式|}1在此处捕获'
+HC5A87C36FF05: '变量 %0%select{被显式|}1在此处捕获'
 # 'variable %0 may be uninitialized when %select{used here|captured by block}1'
-HC0A7D9F9078D: '变量%0可能在%select{此处使用时|被捕获到块中时}1时未初始化'
+HC0A7D9F9078D: '变量 %0 可能在%select{此处使用时|被捕获到块中时}1时未初始化'
 # 'variable %0 must have explicitly specified data sharing attributes'
-H9EFAEC625413: '变量%0必须显式指定数据共享属性'
+H9EFAEC625413: '变量 %0 必须显式指定数据共享属性'
 # 'variable %0 must have explicitly specified data sharing attributes, data mapping attributes, or in an is_device_ptr clause'
-H577354E45CD4: '变量%0必须显式指定数据共享属性、数据映射属性，或出现在is_device_ptr子句中'
+H577354E45CD4: '变量 %0 必须显式指定数据共享属性、数据映射属性，或出现在is_device_ptr子句中'
 # 'variable %0 set but not used'
-H9EEEA592434A: '变量%0被赋值但未使用'
+H9EEEA592434A: '变量 %0 被赋值但未使用'
 # 'variable %0 with flexible array member cannot be captured in a lambda expression'
-HEE231707A80F: '具有柔性数组成员的变量%0不能被捕获到lambda表达式中'
+HEE231707A80F: '具有柔性数组成员的变量 %0 不能被捕获到lambda表达式中'
 # 'variable %0 with type %1 has incompatible initializer of type %2'
-HECE6754B3154: '类型为%1的变量%0具有类型%2的不兼容初始值'
+HECE6754B3154: '类型为 %1 的变量 %0 具有类型 %2 的不兼容初始值'
 # 'variable %0 with unknown type cannot be given a function type'
-HBD6B0E34602F: '类型未知的变量%0不能被赋予函数类型'
+HBD6B0E34602F: '类型未知的变量 %0 不能被赋予函数类型'
 # "variable %select{|in unary expression|on right hand side of assignment|on left hand side of assignment|on left hand side of compound assignment|on left hand side of assignment}2('%3') must match variable used %select{|in unary expression|on right hand side of assignment|<not possible>|on left hand side of compound assignment|on left hand side of assignment}0('%1') from the first statement"
-H68D8E5C8B649: "在%select{|单目表达式中|赋值语句右侧|赋值语句左侧|复合赋值语句左侧|赋值语句左侧}2的变量'%3'必须与第一条语句中%select{|单目表达式使用的|赋值右侧使用的|<不可用>|复合赋值左侧使用的|赋值左侧使用的}0的变量'%1'保持一致"
+H68D8E5C8B649: "在%select{|单目表达式中|赋值语句右侧|赋值语句左侧|复合赋值语句左侧|赋值语句左侧}2的变量 '%3' 必须与第一条语句中%select{|单目表达式使用的|赋值右侧使用的|<不可用>|复合赋值左侧使用的|赋值左侧使用的}0的变量 '%1' 保持一致"
 # 'variable already marked as mapped in current construct'
 HA15930719644: '变量已在当前上下文中被标记为映射'
 # "variable appearing in '%0' clause of OpenACC 'declare' directive must be in the same scope as the directive"
-H32CD6FB44C7B: "在OpenACC 'declare'指令的'%0'子句中出现的变量必须与指令处于同一作用域"
+H32CD6FB44C7B: "在OpenACC 'declare' 指令的 '%0' 子句中出现的变量必须与指令处于同一作用域"
 # "variable can appear only once in OpenMP '%0' clause"
-H084B181F0F6F: "OpenMP '%0'子句中的变量只能出现一次"
+H084B181F0F6F: "OpenMP '%0' 子句中的变量只能出现一次"
 # "variable can appear only once in OpenMP 'target update' construct"
 H78D2AF4A7A62: "OpenMP 'target update'构造中的变量只能出现一次"
 # 'variable captured in declare target region must appear in a to clause'
@@ -28673,11 +28673,11 @@ HCED2B7B23919: '在for循环中声明的变量是C99特有功能'
 # 'variable declared constinit here'
 HBD9CCEC96BCC: '此处声明的constinit变量'
 # "variable declared with 'objc_externally_retained' cannot be modified in ARC"
-H47C52BC3E77D: "'objc_externally_retained'声明的变量在ARC中不可修改"
+H47C52BC3E77D: "'objc_externally_retained' 声明的变量在ARC中不可修改"
 # 'variable does not have a constant initializer'
 HB267A973AA07: '变量没有常量初始化器'
 # 'variable has incomplete type %0'
-HF07B48579A53: '变量具有不完整类型%0'
+HF07B48579A53: '变量具有不完整类型 %0'
 # 'variable in constant address space must be initialized'
 H66FDD0998C58: '常量地址空间中的变量必须被初始化'
 # 'variable is not assignable (missing __block type specifier)'
@@ -28685,7 +28685,7 @@ HAA0B269B98F3: '变量不可分配（缺少__block类型说明符）'
 # 'variable length array cannot be formed during template argument deduction'
 HF26A880CF088: '模板参数推导期间无法形成变量长度数组'
 # "variable length array declaration cannot have 'extern' linkage"
-H2436B28C5991: "变量长度数组声明不能具有'extern'链接"
+H2436B28C5991: "变量长度数组声明不能具有 'extern' 链接"
 # "variable length array declaration cannot have 'static' storage duration"
 H9C9D3E1402A9: "可变长数组声明不能具有 'static' 存储持续期"
 # 'variable length array declaration not allowed at file scope'
@@ -28699,7 +28699,7 @@ HFCB17814F664: '使用了可变长数组'
 # 'variable length arrays are a C99 feature'
 H82A7E9913A2F: '可变长数组是C99特性'
 # "variable length arrays are not supported %select{for the current target|in '%1'}0"
-H5707BCACEAC8: '可变长数组%select{当前目标不支持|在"%1"中不支持}0'
+H5707BCACEAC8: '可变长数组%select{当前目标不支持|在 "%1" 中不支持}0'
 # 'variable length arrays are not supported for the current target'
 H50B2A4B545B7: '当前目标不支持可变长数组'
 # 'variable length arrays are not supported in OpenCL'
@@ -28709,57 +28709,57 @@ H20FB8AB94029: '在带有"untied"子句的OpenMP任务区域中不支持可变�
 # 'variable length arrays in C++ are a Clang extension'
 HCD7C2CD01723: 'C++中的可变长数组是Clang扩展'
 # "variable length arrays in C++ are a Clang extension; did you mean to use 'static_assert'?"
-H53E1EE683577: "C++中的可变长数组是Clang扩展；是否想使用'static_assert'？"
+H53E1EE683577: "C++中的可变长数组是Clang扩展；是否想使用 'static_assert'？"
 # 'variable length arrays in a coroutine are not supported'
 HD279E72346CE: '协程中的可变长数组不被支持'
 # 'variable must be of integer or %select{pointer|random access iterator}0 type'
 H4F34EF5C94E2: '变量必须为整数或%select{指针|随机访问迭代器}0类型'
 # "variable named 'main' with external linkage has undefined behavior"
-H38BA25ED2BA1: "具有外部链接的名为'main'的变量具有未定义行为"
+H38BA25ED2BA1: "具有外部链接的名为 'main' 的变量具有未定义行为"
 # 'variable of non-literal type %1 cannot be defined in a constexpr %select{function|constructor}0 before C++23'
-H5F89C6201D7E: '非字面类型%1的变量在C++23之前不能在constexpr %select{函数|构造函数}0中定义'
+H5F89C6201D7E: '非字面类型 %1 的变量在C++23之前不能在constexpr %select{函数|构造函数}0中定义'
 # "variable of non-reference type %0 can be used only with 'val' modifier, but used with '%1'"
-HFF57CDDBE63D: '非引用类型%0的变量只能与"val"修饰符一起使用，但实际使用了"%1"'
+HFF57CDDBE63D: '非引用类型 %0 的变量只能与"val"修饰符一起使用，但实际使用了 "%1"'
 # 'variable of type %1 has %select{private|protected}2 destructor'
-H8BC8C9632B1A: '类型%1的变量具有%select{private|protected}2访问权限的析构函数'
+H8BC8C9632B1A: '类型 %1 的变量具有 %select{private|protected}2 访问权限的析构函数'
 # "variable referenced by 'link' clause not in global or namespace scope must be marked 'extern'"
-HF7968BA9CE92: "'link'子句引用的不在全局或命名空间作用域中的变量必须标记为'extern'"
+HF7968BA9CE92: "'link' 子句引用的不在全局或命名空间作用域中的变量必须标记为 'extern'"
 # "variable referenced in '%0' clause of OpenACC 'declare' directive was already referenced"
-H8FFABBD53A56: "在OpenACC 'declare'指令的'%0'子句中引用的变量已被先前引用过"
+H8FFABBD53A56: "在OpenACC 'declare' 指令的 '%0' 子句中引用的变量已被先前引用过"
 # 'variable template partial specialization %0 cannot be redefined'
-HB5621CB8D5D4: '变量模板的部分特化%0不能被重新定义'
+HB5621CB8D5D4: '变量模板的部分特化 %0 不能被重新定义'
 # 'variable templates are a C++14 extension'
 H031A6133F773: '变量模板是C++14的扩展功能'
 # 'variable templates are incompatible with C++ standards before C++14'
 HC36BFC632A54: '变量模板与C++14之前的C++标准不兼容'
 # "variable with 'loader_uninitialized' attribute cannot have an initializer"
-H9908D11CFEF9: "具有'loader_uninitialized'属性的变量不能有初始化器"
+H9908D11CFEF9: "具有 'loader_uninitialized' 属性的变量不能有初始化器"
 # "variable with 'loader_uninitialized' attribute must have a trivial default constructor"
-H30559420B01D: "具有'loader_uninitialized'属性的变量必须具有平凡的默认构造函数"
+H30559420B01D: "具有 'loader_uninitialized' 属性的变量必须具有平凡的默认构造函数"
 # 'variable with local storage in initial value of threadprivate variable'
 H06BE1F004442: '线程私有变量的初始值中包含具有局部存储的变量'
 # 'variable%select{s| %1|s %1 and %2|s %1, %2, and %3|s %1, %2, %3, and %4}0 used in loop condition not modified in loop body'
-H78CB81888F63: '变量%select{s| %1|s %1和%2|s %1、%2和%3|s %1、%2、%3和%4}0在循环条件中使用，但在循环体内未被修改'
+H78CB81888F63: '变量 %select{s| %1|s %1 和 %2|s %1、%2 和 %3|s %1、%2、%3 和 %4}0 在循环条件中使用，但在循环体内未被修改'
 # 'variable-sized object may not be initialized'
 HF22D786D9F31: '可变大小的对象不能被初始化'
 # 'variables in function scope cannot be declared static'
 H588D8DBF6957: '函数作用域内的变量不能声明为static'
 # 'variables in the %0 address space can only be declared in the outermost scope of a kernel function'
-H077534025BE2: '位于%0地址空间的变量只能在核函数的最外层作用域中声明'
+H077534025BE2: '位于 %0 地址空间的变量只能在核函数的最外层作用域中声明'
 # 'variably modified type %0 cannot be used as a template argument'
-H43ADD4446C3D: '可变修改类型%0不能用作模板参数'
+H43ADD4446C3D: '可变修改类型 %0 不能用作模板参数'
 # "variably modified type declaration cannot have 'extern' linkage"
 H31174A21A725: '可变修改类型的声明不能具有extern链接性'
 # 'variably modified type declaration not allowed at file scope'
 H0326E5892284: '不允许在文件作用域中声明可变修改类型'
 # 'variably-modified type %0 cannot be used in a constexpr %select{function|constructor}1'
-HA78DFABA86CF: '可变修改类型%0不能在constexpr %select{函数|构造函数}1中使用'
+HA78DFABA86CF: '可变修改类型 %0 不能在constexpr %select{函数|构造函数}1中使用'
 # "variadic 'friend' declarations are a C++2c extension"
 H3D2FFF66A145: '可变参数的"friend"声明是C++2c的扩展'
 # "variadic 'friend' declarations are incompatible with C++ standards before C++2c"
 H365CB532BF3E: '可变参数的"friend"声明与C++2c之前的C++标准不兼容'
 # 'variadic function cannot use %0 calling convention'
-HEC894E082768: '可变参数函数不能使用%0调用约定'
+HEC894E082768: '可变参数函数不能使用 %0 调用约定'
 # 'variadic macros are a C99 feature'
 H6AA48F3D31FE: '可变参数宏是C99的特性'
 # 'variadic macros are a Clang extension in OpenCL'
@@ -28775,33 +28775,33 @@ H82A01F59E7E3: '在#pragma omp declare variant中声明的变体函数本身也�
 # "variant in '#pragma omp declare variant' is the same as the base function"
 HEC73C56687BA: '在#pragma omp declare variant中的变体与基函数类型相同'
 # "variant in '#pragma omp declare variant' with type %0 is incompatible with type %1%select{| with appended arguments}2"
-H443E0ACFD62A: '在#pragma omp declare variant中的变体类型%0与类型%1%select{|附加参数}2不兼容'
+H443E0ACFD62A: '在#pragma omp declare variant中的变体类型 %0 与类型 %1%select{|附加参数}2不兼容'
 # 'vector component access exceeds type %0'
-HA6E77B2F0A3C: '向量组件访问超过类型%0'
+HA6E77B2F0A3C: '向量组件访问超过类型 %0'
 # 'vector component access has invalid length %0; supported lengths are: 1,2,3,4,8,16'
-HCB71F9B8CFBC: '向量组件访问具有无效长度%0；支持的长度为：1,2,3,4,8,16'
+HCB71F9B8CFBC: '向量组件访问具有无效长度 %0；支持的长度为：1,2,3,4,8,16'
 # "vector component name '%0' is a feature from OpenCL version 3.0 onwards"
-H6B53729D7A1D: "向量组件名称'%0'是OpenCL 3.0及更高版本中的特性"
+H6B53729D7A1D: "向量组件名称 '%0' 是OpenCL 3.0及更高版本中的特性"
 # 'vector condition type %0 and result type %1 do not have elements of the same size'
-H9FFA8360C1AF: '向量条件类型%0和结果类型%1的元素大小不一致'
+H9FFA8360C1AF: '向量条件类型 %0 和结果类型 %1 的元素大小不一致'
 # 'vector condition type %0 and result type %1 do not have the same number of elements'
-H48693917C57D: '向量条件类型%0和结果类型%1的元素数量不一致'
+H48693917C57D: '向量条件类型 %0 和结果类型 %1 的元素数量不一致'
 # 'vector initializers are not compatible with NEON intrinsics in big endian mode'
 H20E090504D21: '向量初始化器与大端模式下的NEON内建函数不兼容'
 # 'vector is not assignable (contains duplicate components)'
 HA13B723E09E4: '该向量不可分配（包含重复的组件）'
 # 'vector operands do not have the same elements sizes (%0 and %1)'
-H20CF2F14B1AB: '向量操作数的元素大小不一致（%0和%1）'
+H20CF2F14B1AB: '向量操作数的元素大小不一致（%0 和 %1）'
 # 'vector operands do not have the same number of elements (%0 and %1)'
-H02E2D0489C4C: '向量操作数的元素数量不一致（%0和%1）'
+H02E2D0489C4C: '向量操作数的元素数量不一致（%0 和 %1）'
 # 'vector operands to the vector conditional must be the same type %diff{($ and $)|}0,1}'
 HBD47DE4A7313: '向量条件运算符的向量操作数必须是相同类型%diff{($和$)|}0,1}'
 # 'vector size not an integral multiple of component size'
 H77E12186A8E0: '向量大小不是组件大小的整数倍'
 # "vectorize_width loop hint malformed; use vectorize_width(X, fixed) or vectorize_width(X, scalable) where X is an integer, or vectorize_width('fixed' or 'scalable')"
-H52976DB4C3C0: "向量化宽度循环提示格式错误；请使用vectorize_width(X, fixed)或vectorize_width(X, scalable)，其中X为整数，或vectorize_width('fixed'或'scalable')"
+H52976DB4C3C0: "向量化宽度循环提示格式错误；请使用vectorize_width(X, fixed)或vectorize_width(X, scalable)，其中X为整数，或vectorize_width('fixed' 或 'scalable')"
 # "vendor '%0' is not supported: '%1'"
-HEF7F8EFDE1D2: "供应商'%0'不受支持：'%1'"
+HEF7F8EFDE1D2: "供应商 '%0' 不受支持：'%1'"
 # 'verbose'
 H3F73A838273F: 'verbose'
 # 'verify structure of the log'
@@ -28811,9 +28811,9 @@ H94E54A437791: '在每次转换后验证控制流图'
 # 'verify-uselistorder Options'
 HBF754C1F763D: 'verify-uselistorder 选项'
 # "version '%0' in target triple '%1' is invalid"
-H638A2A1C27BA: "目标三元组'%1'中的版本'%0'无效"
+H638A2A1C27BA: "目标三元组 '%1' 中的版本 '%0' 无效"
 # 'version 1'
-H58A74A7AA4A0: '版本1'
+H58A74A7AA4A0: '版本 1'
 # 'version 2'
 H85DE840F8B53: '版本 2'
 # 'version 3'
@@ -28857,7 +28857,7 @@ H207695B65E04: 'HLSL中不支持虚函数'
 # 'virtual inheritance is unsupported in HLSL'
 H8C2B278220B7: 'HLSL中不支持虚继承'
 # "virtual method %0 is inside a 'final' class and can never be overridden"
-HAC30D95A1570: '虚方法%0位于"final"类中，无法被覆盖'
+HAC30D95A1570: '虚方法 %0 位于"final"类中，无法被覆盖'
 # 'visibility does not match previous declaration'
 H17040BB5EC03: '可见性与之前的声明不匹配'
 # 'void %select{function|method|block}1 %0 should not return void expression'
@@ -28899,7 +28899,7 @@ HDA1EB6DAD24A: '%0 的 weakref 声明必须处于全局上下文中'
 # 'webassembly: disables the fix  irreducible control flow optimization pass'
 HA0B81E145B1D: 'webassembly: 禁用修复不可约控制流优化pass'
 # 'when a function is considered for merging into a partition that already contains some of its callees, do the merge if at least n% of the code it can reach is already present inside the partition; e.g. 0.7 means only merge >70%'
-HB679EAE1AA06: '当考虑将函数合并到已包含其部分被调函数的分区时，如果该函数能访问的代码中至少有n%已存在于分区中，则执行合并；例如0.7表示仅合并>70%的情况'
+HB679EAE1AA06: '当考虑将函数合并到已包含其部分被调函数的分区时，如果该函数能访问的代码中至少有n%已存在于分区中，则执行合并；例如 0.7表示仅合并>70%的情况'
 # 'when applied to this declaration'
 HA6DB04448955: '当应用于该声明时'
 # 'when deciding to split a function, apply this alignment while doing the size comparison (see -split-threshold). Default value: 2.'
@@ -28911,7 +28911,7 @@ H9F7ED2DB900A: '当由类 %0 实现时'
 # "when looking up '%select{begin|end}0' function for range expression of type %1"
 HC4C870329421: '在查找类型 %1 的范围表达式对应的 `%select{begin|end}0` 函数时'
 # 'when max depth is reached and we can no longer branch out, this value determines if a function is worth merging into an already existing partition to reduce code duplication. This is a factor of the ideal partition size, e.g. 2.0 means we consider the function for merging if its cost (including its callees) is 2x the size of an ideal partition.'
-HC50D6FBB78F2: '当达到最大深度且无法继续分支时，此值决定函数是否值得合并到现有分区以减少代码重复。这是理想分区大小的倍数因子，例如2.0表示当函数的代价（包含其被调用函数）是理想分区大小的两倍时，才会考虑合并。'
+HC50D6FBB78F2: '当达到最大深度且无法继续分支时，此值决定函数是否值得合并到现有分区以减少代码重复。这是理想分区大小的倍数因子，例如 2.0表示当函数的代价（包含其被调用函数）是理想分区大小的两倍时，才会考虑合并。'
 # 'when possible, poison scoped variables at the beginning of the scope (slower, but more precise)'
 H00AA44541919: '可能的话，在作用域开头毒化作用域变量（速度较慢，但更精确）'
 # 'when repeating the instruction snippet by looping over it, duplicate the snippet until the loop body contains at least this many instruction'
@@ -28963,7 +28963,7 @@ H154EA9F3EDC1: '在将此处的 lambda 表达式代入时'
 # 'while substituting into concept arguments here; substitution failures not allowed in concept arguments'
 HAC706623FF86: '在将概念参数此处代入时；概念参数不允许替换失败'
 # 'while substituting prior template arguments into %select{non-type|template}0 template parameter%1 %2'
-HF0EDCF82D09D: '在将先前模板参数代入 %select{非类型|模板}0 模板参数%1 %2 时'
+HF0EDCF82D09D: '在将先前模板参数代入 %select{非类型|模板}0 模板参数 %1 %2 时'
 # 'while substituting template arguments into constraint expression here'
 H19C71987DC07: '在替换模板参数到此处的约束表达式时'
 # 'whitespace is not allowed in parameter passing direction'
@@ -28973,7 +28973,7 @@ H47F8347E0371: '建议在宏名后添加空白字符'
 # 'whitespace required after macro name'
 H2F43B2E26F3A: '必须在宏名后添加空白字符'
 # 'widen this field to %0 bits to store all values of %1'
-HD1698255B212: '将此字段的宽度扩展为%0位以存储%1的所有值'
+HD1698255B212: '将此字段的宽度扩展为 %0 位以存储 %1 的所有值'
 # 'width of bit-field %0 (%1 bits) exceeds the width of its type; value will be truncated to %2 bit%s2'
 H8896C13CC6D9: '位字段 %0 (%1 位) 的宽度超过其类型宽度；值将被截断至 %2 bit%s2'
 # 'width of%select{ anonymous|}0 bit-field%select{| %1}0 (%2 bits) exceeds the %select{width|size}3 of its type (%4 bit%s4)'
@@ -28981,27 +28981,27 @@ H02B50746D7D1: '位字段%select{匿名|}0 的宽度%select{| %1}0 (%2 位) 超�
 # 'with jt-footprint-reduction, only process PIC jumptables and turn off other transformations that increase code size'
 H3BB007DE5DDB: '启用jt-footprint-reduction时，仅处理PIC跳转表并关闭其他增大代码体积的转换'
 # 'within field of type %0 declared here'
-HEC6FDC220283: '在类型%0的字段中，该字段在此处声明'
+HEC6FDC220283: '在类型 %0 的字段中，该字段在此处声明'
 # 'writable atomic property %0 cannot pair a synthesized %select{getter|setter}1 with a user defined %select{getter|setter}2'
-HA65A16D8E26B: '可写原子属性%0不能将合成的%select{getter|setter}1与用户定义的%select{getter|setter}2配对'
+HA65A16D8E26B: '可写原子属性 %0 不能将合成的 %select{getter|setter}1 与用户定义的 %select{getter|setter}2 配对'
 # 'write BOLT Address Translation tables'
 H1540FEF77408: '写入BOLT地址翻译表'
 # 'write bolt info section in the output binary'
 H5BC44776C33F: '在输出二进制文件中写入bolt信息节'
 # 'wrong argument format for hlsl attribute, use %0 instead'
-H514518256D51: 'HLSL属性的参数格式错误，应使用%0'
+H514518256D51: 'HLSL属性的参数格式错误，应使用 %0'
 # 'wrong fpu width; %select{LSX|LASX}0 depends on 64-bit FPU'
-H65FC5C473561: 'FPU宽度错误；%select{LSX|LASX}0依赖于64位FPU'
+H65FC5C473561: 'FPU宽度错误；%select{LSX|LASX}0 依赖于 64 位FPU'
 # 'yaml2obj Options'
 H095AAC30EBC3: 'yaml2obj 选项'
 # "you need to include <typeinfo> before using the 'typeid' operator"
-H64B8C0D4E612: "在使用'typeid'运算符前需要包含<typeinfo>"
+H64B8C0D4E612: "在使用 'typeid' 运算符前需要包含 <typeinfo>"
 # 'z/OS target level "%0" is discontinued'
-HB5BA348592D3: 'z/OS目标级别"%0"已弃用'
+HB5BA348592D3: 'z/OS目标级别 "%0" 已弃用'
 # 'z/OS target level "%0" is invalid'
-H0080755EFA11: 'z/OS目标级别"%0"无效'
+H0080755EFA11: 'z/OS目标级别 "%0" 无效'
 # 'zero %0 size'
-HF7816CFF7955: '%0的大小为零'
+HF7816CFF7955: '%0 的大小为零'
 # 'zero as null pointer constant'
 H824A61FB1C48: '使用零作为空指针常量'
 # 'zero field width in scanf format string is unused'
@@ -29011,6 +29011,6 @@ HDA0E059C273A: '零线性步长（%0 %select{|和子句中的其他变量}1应�
 # 'zero size arrays are an extension'
 H49512BBF0CE4: '零长度数组是扩展特性'
 # "zero-length array section is not allowed in 'depend' clause"
-HC5FAF4CE6159: "在'depend'子句中不允许使用零长度数组"
+HC5FAF4CE6159: "在 'depend' 子句中不允许使用零长度数组"
 # 'zero-length arrays are not permitted in %select{C++|SYCL device code|HIP device code}0'
-H2F083F032372: '在%select{C++|SYCL device code|HIP device code}0中不允许使用零长度数组'
+H2F083F032372: '在 %select{C++|SYCL device code|HIP device code}0 中不允许使用零长度数组'

--- a/i18n/zh_TW.yml
+++ b/i18n/zh_TW.yml
@@ -225,7 +225,7 @@ H208A7E24C5FA: '%0 屬性在非定義宣告上被忽略'
 # '%0 attribute ignored on inline function'
 H96102C6ED34D: '%0 屬性在內聯函數上被忽略'
 # '%0 attribute ignored on local class%select{| member}1'
-HFF01D57072C2: '%0 屬性在本地類別%select{| 成員}1 上被忽略'
+HFF01D57072C2: '%0 屬性在本地類別 %select{| 成員}1 上被忽略'
 # '%0 attribute ignored when parsing type'
 HD37333D19CA5: '%0 屬性在解析類型時被忽略'
 # '%0 attribute is deprecated and ignored in %1'
@@ -281,7 +281,7 @@ H83B4DE3C5663: '%0 屬性僅適用於返回值為指標的返回值'
 # '%0 attribute only applies to return values that are pointers or references'
 HA603B89762A9: '%0 屬性僅適用於返回值為指標或引用的返回值'
 # '%0 attribute only applies to%select{| constant}1 pointer arguments'
-H1E90BC4B3746: '%0 屬性僅適用於%select{|常數}1指標參數'
+H1E90BC4B3746: '%0 屬性僅適用於 %select{|常數}1指標參數'
 # '%0 attribute parameter %1 is negative and will be ignored'
 HB94334A9F06D: '%0 屬性參數 %1 為負數且將被忽略'
 # '%0 attribute parameter %1 is out of bounds'
@@ -293,7 +293,7 @@ H4FBE5E81E84C: '%0 屬性參數類型不匹配：函數 %2 的第 %1 個參數�
 # '%0 attribute parameters do not match the previous declaration'
 HBB1E6D667EEA: '%0 屬性參數與先前宣告不符'
 # '%0 attribute references function %1, which %plural{0:takes no arguments|1:takes one argument|:takes exactly %2 arguments}2'
-HC6916839EF90: '%0 屬性引用函數 %1，該函數%plural{0:沒有參數|1:有一個參數|:恰好有 %2 個參數}2'
+HC6916839EF90: '%0 屬性引用函數 %1，該函數 %plural{0:沒有參數|1:有一個參數|:恰好有 %2 個參數}2'
 # '%0 attribute references parameter %1, but the function %2 has only %3 parameters'
 H95C6EBBF3D05: '%0 屬性引用參數 %1，但函數 %2 僅有 %3 個參數'
 # '%0 attribute requires %select{int or bool|an integer constant|a string|an identifier}1'
@@ -373,7 +373,7 @@ H9015777D8EDA: '%0 不可在枚舉中定義'
 # '%0 cannot be defined in the result type of a function'
 HBCF321DF1229: '%0 不可在函數的傳回類型中定義'
 # '%0 cannot be specialized%select{|: %2}1'
-H2F24480223D6: '%0 不可被特化%select{|: %2}1'
+H2F24480223D6: '%0 不可被特化 %select{|: %2}1'
 # '%0 cannot be the name of a parameter'
 H86909FCB5AFA: '%0 不可用作參數名稱'
 # '%0 cannot be the name of a variable or data member'
@@ -513,7 +513,7 @@ HC570BF566E38: '%0 非全域變數、靜態區域變數或靜態資料成員'
 # '%0 is not a global variable, static local variable or static data member; did you mean %1'
 H32A3026BA924: '%0 不是全域變數、靜態局部變數或靜態資料成員；你是否指的是 %1'
 # '%0 is not a recognized builtin%select{|; consider including <intrin.h> to access non-builtin intrinsics}1'
-HB8FF0E17F733: '%0 不是識別的內建函數%select{|；建議包含 <intrin.h> 以存取非內建內在函數}1'
+HB8FF0E17F733: '%0 不是識別的內建函數 %select{|；建議包含 <intrin.h> 以存取非內建內在函數}1'
 # '%0 is not a structural type because it has a %select{non-static data member|base class}1 of non-structural type %2'
 HF393BE38CC50: '%0 不是結構型類型，因為它有一個 %select{非靜態資料成員|基類}1 的非結構型類型 %2'
 # '%0 is not a structural type because it has a %select{non-static data member|base class}1 that is not public'
@@ -559,7 +559,7 @@ H580226EF44DA: '%0 不支援 -fembed-bitcode 選項'
 # '%0 is not virtual and cannot be declared pure'
 HFCE20933CC31: '%0 不是虛函數，因此無法宣告為純虛函數'
 # '%0 is only available %select{|in %4 environment }3on %1 %2 or newer'
-H1926B8ADA9BD: '%0 僅在 %1 %2 或更新版本%select{|的 %4 環境 }3中可用'
+H1926B8ADA9BD: '%0 僅在 %1 %2 或更新版本 %select{|的 %4 環境 }3中可用'
 # '%0 is only supported when \'-mrvv-vector-bits=<bits>\' is specified with a value of "zvl" or a power 2 in the range [64,65536]'
 H714177E08C3D: '%0 僅在指定 -mrvv-vector-bits=<bits> 的值為 "zvl" 或 64 到 65536 之間的 2 的冪次時才受支援'
 # "%0 is only supported when '-msve-vector-bits=<bits>' is specified with a value of 128, 256, 512, 1024 or 2048"
@@ -657,7 +657,7 @@ H33A930D763B0: '%0 需要超過 1 個模板參數；在此處使用時需明確�
 # '%0 returns a reference'
 H81B0F21DCC91: '%0 返回一個引用'
 # '%0 should be declared prior to the call site%select{| or in %2| or in an associated namespace of one of its arguments}1'
-H80A1DB32BBA2: '%0 應在呼叫位置%select{| 或 %2| 或其參數之一的關聯命名空間中}1 提前宣告'
+H80A1DB32BBA2: '%0 應在呼叫位置 %select{| 或 %2| 或其參數之一的關聯命名空間中}1 提前宣告'
 # "%0 should not return a null pointer unless it is declared 'throw()'%select{| or 'noexcept'}1"
 HD6330A6C968B: "%0 不應返回空指標，除非它被宣告為 'throw()'%select{| 或 'noexcept'}1"
 # '%0 size too large'
@@ -711,15 +711,15 @@ HCADF8F759262: "%0%select{| 在 'template' 關鍵字後面}1 不是模板"
 # "%0: '%1' input unused in cpp mode"
 HF14789F9D841: "%0: '%1' 輸入在cpp模式下未被使用"
 # "%0: '%1' input unused%select{ when '%3' is present|}2"
-HA6B5E8785AC8: "%0: '%1' 輸入未被使用%select{ 當存在'%3'時|}2"
+HA6B5E8785AC8: "%0: '%1' 輸入未被使用%select{ 當存在 '%3' 時|}2"
 # "%0: 'get_return_object_on_allocation_failure()' must be a static member function"
 HB26892211ABD: "%0: 'get_return_object_on_allocation_failure()' 必須是靜態成員函數"
 # "%0: previously preprocessed input%select{ unused when '%2' is present|}1"
-H1EB52EB9DA3B: "%0: 之前預處理的輸入%select{ 當存在'%2'時未被使用|}1"
+H1EB52EB9DA3B: "%0: 之前預處理的輸入%select{ 當存在 '%2' 時未被使用|}1"
 # "%0; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop or by providing the compiler option '-ffast-math'"
-H50F1AE498158: "%0; 允許重新排序可透過在迴圈前指定'#pragma clang loop vectorize(enable)' 或提供編譯器選項'-ffast-math'"
+H50F1AE498158: "%0; 允許重新排序可透過在迴圈前指定 '#pragma clang loop vectorize(enable)' 或提供編譯器選項 '-ffast-math'"
 # "%0; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop; if the arrays will always be independent, specify '#pragma clang loop vectorize(assume_safety)' before the loop or provide the '__restrict__' qualifier with the independent array arguments -- erroneous results will occur if these options are incorrectly applied"
-H696063533F0E: "%0; 允許重新排序可透過在迴圈前指定'#pragma clang loop vectorize(enable)'；若陣列始終獨立，可指定'#pragma clang loop vectorize(assume_safety)' 或在獨立陣列參數上使用 '__restrict__' 限定詞 -- 若錯誤套用這些選項將導致結果錯誤"
+H696063533F0E: "%0; 允許重新排序可透過在迴圈前指定 '#pragma clang loop vectorize(enable)'；若陣列始終獨立，可指定 '#pragma clang loop vectorize(assume_safety)' 或在獨立陣列參數上使用 '__restrict__' 限定詞 -- 若錯誤套用這些選項將導致結果錯誤"
 # '%0B (%human0B) in local locations, %1B (%human1B) in locations loaded from AST files, for a total of %2B (%human2B) (%3%% of available space)'
 H9B3C5907D274: '%0B（%human0B）在本地位置，%1B（%human1B）在從AST文件載入的位置，總共 %2B（%human2B）（佔用可用空間的 %3%%）'
 # '%1 %0 is hidden by a non-type declaration of %0 here'
@@ -735,7 +735,7 @@ HBE91EA4F0CCD: '%diff{ K&R函數參數的提升類型$與參數類型$不兼容 
 # '%diff{return type $ must match previous return type $|return type must match previous return type}0,1 when %select{block literal|lambda expression}2 has unspecified explicit return type'
 H503B0717AF47: '%diff{返回類型 $ 必須與先前的返回類型 $ 一致|返回類型必須與先前的返回類型一致}1,0 當 %select{區塊iteral|lambda運算式}2 具有未指定的明確返回類型時'
 # "%ordinal0 argument must be a %select{|scalar|vector|matrix|vector of|scalar or vector of}1%plural{[2,3]:%plural{0:|:%plural{0:|:,}2}3|:}1%plural{0:|: }1%select{|integer|signed integer|unsigned integer|'int'|pointer to a valid matrix element}2%plural{0:|: }2%plural{0:|:%plural{0:|:or }2}3%select{|floating-point}3%plural{0:|: }3%plural{[0,3]:type|:types}1 (was %4)"
-HEE73BAE75429: '%ordinal0參數必須是%select{|純量|向量|矩陣|向量的|純量或向量的}1%plural{[2,3]:%plural{0:|:%plural{0:|:,}2}3|:}1%plural{0:|: }1%select{|整數|帶符號整數|無符號整數|int類型|指向有效矩陣元素的指標}2%plural{0:|: }2%plural{0:|:%plural{0:|:或 }2}3%select{|浮點數}3%plural{0:|: }3%plural{[0,3]:類型|:類型}1（實際是 %4）'
+HEE73BAE75429: '%ordinal0參數必須是 %select{|純量|向量|矩陣|向量的|純量或向量的}1%plural{[2,3]:%plural{0:|:%plural{0:|:,}2}3|:}1%plural{0:|: }1%select{|整數|帶符號整數|無符號整數|int類型|指向有效矩陣元素的指標}2%plural{0:|: }2%plural{0:|:%plural{0:|:或 }2}3%select{|浮點數}3%plural{0:|: }3%plural{[0,3]:類型|:類型}1（實際是 %4）'
 # '%ordinal0 argument must be a WebAssembly table'
 HF0E3AF42C5DD: '%ordinal0參數必須是WebAssembly表'
 # '%ordinal0 argument must be an integer'
@@ -747,7 +747,7 @@ HE8DAC9A52D87: '%plural{1:列舉值 %1 在switch中未明確處理|2:列舉值 %
 # '%plural{1:enumeration value %1 not handled in switch|2:enumeration values %1 and %2 not handled in switch|3:enumeration values %1, %2, and %3 not handled in switch|:%0 enumeration values not handled in switch: %1, %2, %3...}0'
 H0E3F79F6C010: '%plural{1:列舉值 %1 在switch中未處理|2:列舉值 %1 和 %2 在switch中未處理|3:列舉值 %1、%2 和 %3 在switch中未處理|:%0 列舉值在switch中未處理：%1、%2、%3...}0'
 # "%plural{2:'delete' used to delete pointer to object allocated with 'std::allocator<...>::allocate'|:%select{non-array delete|array delete|'std::allocator<...>::deallocate'}0 used to delete pointer to %select{array object of type %2|non-array object of type %2|object allocated with 'new'}0}1"
-H1294E54BD6EF: "%plural{2:'delete' 用於刪除以'std::allocator<...>::allocate'分配的物件指標|:%select{非陣列delete|陣列delete|'std::allocator<...>::deallocate'}0用於刪除%select{陣列物件類型 %2|非陣列物件類型 %2|以 'new' 分配的物件}0}1"
+H1294E54BD6EF: "%plural{2:'delete' 用於刪除以 'std::allocator<...>::allocate' 分配的物件指標|:%select{非陣列delete|陣列delete|'std::allocator<...>::deallocate'}0 用於刪除%select{陣列物件類型 %2|非陣列物件類型 %2|以 'new' 分配的物件}0}1"
 # '%plural{[0,2]:must use a qualified name when declaring|3:cannot declare}0 a %select{constructor|destructor|conversion operator|deduction guide}0 as a friend'
 H180E877A4B1E: '%plural{[0,2]:宣告時必須使用合格名稱|3:無法宣告}0 %select{建構函數|解構函數|轉換運算子|推論指引}0 作為友元'
 # "%q0 %select{with definition in module '%2'|defined here}1 has different definitions in different modules; first difference is this %select{||||static assert|field|method|type alias|typedef|data member|friend declaration|function template|method|instance variable|property|unexpected decl}3"
@@ -757,11 +757,11 @@ H1F0205F4AD29: '%q0 當宣告為%q1 時不能是線程局部'
 # "%q0 from module '%1' is not present in definition of %q2%select{ in module '%4'| provided earlier}3"
 H9DF776E318FF: "%q0 來自模組 '%1' 的內容未出現在 %q2%select{ 模組 '%4' 的定義中|先前的定義中}3"
 # "%q0 has different definitions in different modules; %select{definition in module '%2' is here|defined here}1"
-HB3D6EB7685C3: "%q0 在不同模組中有不同的定義；%select{模組'%2'中的定義在此|在此處定義}1"
+HB3D6EB7685C3: "%q0 在不同模組中有不同的定義；%select{模組 '%2' 中的定義在此|在此處定義}1"
 # "%q0 has different definitions in different modules; %select{definition in module '%2'|defined here}1 first difference is %select{enum that is %select{not scoped|scoped}4|enum scoped with keyword %select{struct|class}4|enum %select{without|with}4 specified type|enum with specified type %4|enum with %4 element%s4|%ordinal4 element has name %5|%ordinal4 element %5 %select{has|does not have}6 an initializer|%ordinal4 element %5 has an initializer|}3"
-H39CEC8B6DBEB: "%q0 在不同模組中有不同的定義；%select{模組'%2'中的定義在此|在此處定義}1 第一個差異是%select{列舉%select{未指定為作用域|指定為作用域}4|列舉以關鍵字 %select{struct|class}4 指定為作用域|列舉%select{無|有}4指定類型|列舉具有指定類型 %4|列舉具有 %4 個元素|%ordinal4個元素名稱為 %5|%ordinal4個元素 %5 %select{有|沒有}6 初始值|%ordinal4個元素 %5 有初始值|}3"
+H39CEC8B6DBEB: "%q0 在不同模組中有不同的定義；%select{模組 '%2' 中的定義在此|在此處定義}1 第一個差異是%select{列舉%select{未指定為作用域|指定為作用域}4|列舉以關鍵字 %select{struct|class}4 指定為作用域|列舉%select{無|有}4指定類型|列舉具有指定類型 %4|列舉具有 %4 個元素|%ordinal4個元素名稱為 %5|%ordinal4個元素 %5 %select{有|沒有}6 初始值|%ordinal4個元素 %5 有初始值|}3"
 # "%q0 has different definitions in different modules; %select{definition in module '%2'|defined here}1 first difference is %select{return type is %4|%ordinal4 parameter with name %5|%ordinal4 parameter with type %5%select{| decayed from %7}6|%ordinal4 parameter with%select{out|}5 a default argument|%ordinal4 parameter with a default argument|function body}3"
-H68AA8A549FAA: "%q0 在不同模組中具有不同的定義；%select{模組 '%2' 中的定義|在此處定義}1 第一個差異是 %select{返回類型為 %4|%ordinal4 參數具有名稱 %5|%ordinal4 參數具有類型 %5%select{| 退化自 %7}6|%ordinal4 參數具有%select{out|}5 預設參數|%ordinal4 參數具有預設參數|函數主體}3"
+H68AA8A549FAA: "%q0 在不同模組中具有不同的定義；%select{模組 '%2' 中的定義|在此處定義}1 第一個差異是 %select{返回類型為 %4|%ordinal4 參數具有名稱 %5|%ordinal4 參數具有類型 %5%select{| 退化自 %7}6|%ordinal4 參數具有 %select{out|}5 預設參數|%ordinal4 參數具有預設參數|函數主體}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{%4 base %plural{1:class|:classes}4|%4 virtual base %plural{1:class|:classes}4|%ordinal4 base class with type %5|%ordinal4 %select{non-virtual|virtual}5 base class %6|%ordinal4 base class %5 with %select{public|protected|private|no}6 access specifier}3"
 HC4303FABC437: "%q0 在不同模組中具有不同的定義；第一個差異是 %select{模組 '%2' 中的定義|在此處定義}1 發現 %select{%4 基底 %plural{1:類別|:類別}4|%4 虛基底 %plural{1:類別|:類別}4|%ordinal4 基底類別具有類型 %5|%ordinal4 %select{非虛|虛}5 基底類別 %6|%ordinal4 基底類別 %5 具有 %select{公開|受保護|私有|無}6 存取修飾符}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{%4 referenced %plural{1:protocol|:protocols}4|%ordinal4 referenced protocol with name %5}3"
@@ -775,7 +775,7 @@ H3C6A067820A4: "%q0 在不同模組中具有不同的定義；第一個差異是
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{end of class|public access specifier|private access specifier|protected access specifier|static assert|field|method|type alias|typedef|data member|friend declaration|function template|method|instance variable|property}3"
 HC7FCD2470FA2: "%q0 在不同模組中具有不同的定義；第一個差異是 %select{模組 '%2' 中的定義|在此處定義}1 發現 %select{類別結束|公開存取修飾符|私有存取修飾符|受保護存取修飾符|static assert|資料成員|方法|類型別名|typedef|資料成員|朋友宣告|函數範本|方法|實體變數|屬性}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{field %4|field %4 with type %5|%select{non-|}5bit-field %4|bit-field %4 with one width expression|%select{non-|}5mutable field %4|field %4 with %select{no|an}5 initializer|field %4 with an initializer}3"
-H60D85DC0E685: "%q0 在不同模組中具有不同的定義；第一個差異是 %select{模組 '%2' 中的定義|在此處定義}1 發現 %select{成員 %4|成員 %4 具有類型 %5|%select{非-|}5位元域 %4|位元域 %4 具有一個寬度運算式|%select{非-|}5mutable 成員 %4|成員 %4 具有%select{無|}5 初始化式|成員 %4 具有初始化式}3"
+H60D85DC0E685: "%q0 在不同模組中具有不同的定義；第一個差異是 %select{模組 '%2' 中的定義|在此處定義}1 發現 %select{成員 %4|成員 %4 具有類型 %5|%select{非-|}5 位元域 %4|位元域 %4 具有一個寬度運算式|%select{非-|}5mutable 成員 %4|成員 %4 具有%select{無|}5 初始化式|成員 %4 具有初始化式}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{method %4 with return type %5|%select{class|instance}5 method %4|%select{no|'required'|'optional'}4 method control|method %4 with %select{no designated initializer|designated initializer}5|%select{regular|direct}5 method %4|method %4}3"
 H5AECB1226BDE: "%q0 在不同模組中有不同的定義；第一個差異在 %select{模組 '%2' 的定義中|在此處定義}1 發現 %select{返回類型為 %5 的方法 %4|%select{類別|實體}5 方法 %4|%select{未指定|'required'|'optional'}4 方法控制|具有 %select{非指定初始化程式|指定初始化程式}5 的方法 %4|%select{一般|直接}5 方法 %4|方法 %4}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{property %4|property %4 with type %5|%select{no|'required'|'optional'}4 property control|property %4 with %select{default |}6'%select{none|readonly|getter|assign|readwrite|retain|copy|nonatomic|setter|atomic|weak|strong|unsafe_unretained|nullability|null_resettable|class|direct}5' attribute}3"
@@ -783,7 +783,7 @@ H47E62251068F: "%q0 在不同模組中具有不同的定義；第一個差異是
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{static assert with condition|static assert with message|static assert with %select{|no }4message|%select{method %5|constructor|destructor}4|%select{method %5|constructor|destructor}4 is %select{not deleted|deleted}6|%select{method %5|constructor|destructor}4 is %select{not defaulted|defaulted}6|%select{method %5|constructor|destructor}4 is %select{|pure }6%select{not virtual|virtual}7|%select{method %5|constructor|destructor}4 is %select{not static|static}6|%select{method %5|constructor|destructor}4 is %select{not volatile|volatile}6|%select{method %5|constructor|destructor}4 is %select{not const|const}6|%select{method %5|constructor|destructor}4 is %select{not inline|inline}6|%select{method %5|constructor|destructor}4 with %ordinal6 parameter with%select{out|}7 a default argument|%select{method %5|constructor|destructor}4 with %ordinal6 parameter with a default argument|%select{method %5|constructor|destructor}4 with %select{no |}6template arguments|%select{method %5|constructor|destructor}4 with %6 template argument%s6|%select{method %5|constructor|destructor}4 with %6 for %ordinal7 template argument|%select{method %5|constructor|destructor}4 with %select{no body|body}6|%select{method %5|constructor|destructor}4 with body|friend %select{class|function}4|friend %4|friend function %4|function template %4 with %5 template parameter%s5|function template %4 with %ordinal5 template parameter being a %select{type|non-type|template}6 template parameter|function template %4 with %ordinal5 template parameter %select{with no name|named %7}6|function template %4 with %ordinal5 template parameter with %select{no |}6default argument|function template %4 with %ordinal5 template parameter with default argument %6|function template %4 with %ordinal5 template parameter with one type|function template %4 with %ordinal5 template parameter %select{not |}6being a template parameter pack|}3"
 HCEB41952ED68: "%q0 在不同模組中有不同的定義；第一處差異是 %select{模組 '%2' 中的定義|在此處定義}1 發現 %select{條件為的 static assert|訊息為的 static assert|條件%select{無訊息|}4 的 static assert|%select{方法 %5|建構函數|析構函數}4|%select{方法 %5|建構函數|析構函數}4 %select{未標記為 deleted|已被標記為 deleted}6|%select{方法 %5|建構函數|析構函數}4 %select{未標記為 defaulted|已被標記為 defaulted}6|%select{方法 %5|建構函數|析構函數}4 是%select{非虛|虛}6%select{非虛函數|虛函數}7|%select{方法 %5|建構函數|析構函數}4 %select{未標記為 static|已被標記為 static}6|%select{方法 %5|建構函數|析構函數}4 %select{未標記為 volatile|已被標記為 volatile}6|%select{方法 %5|建構函數|析構函數}4 %select{未標記為 const|已被標記為 const}6|%select{方法 %5|建構函數|析構函數}4 %select{未標記為 inline|已被標記為 inline}6|%select{方法 %5|建構函數|析構函數}4 具有第 %ordinal6 個參數%select{無|}7 預設值|%select{方法 %5|建構函數|析構函數}4 具有第 %ordinal6 個預設值參數|%select{方法 %5|建構函數|析構函數}4 %select{無|}6 模板參數|%select{方法 %5|建構函數|析構函數}4 具有 %6 個模板參數%s6|%select{方法 %5|建構函數|析構函數}4 具有第 %ordinal7 個模板參數 %6|%select{方法 %5|建構函數|析構函數}4 %select{無函數體|有函數體}6|%select{方法 %5|建構函數|析構函數}4 有函數體|friend %select{類別|函數}4|friend %4|friend 函數 %4|函數模板 %4 具有 %5 個模板參數%s5|函數模板 %4 的第 %ordinal5 個模板參數為 %select{類型|非類型|模板}6 參數類型|函數模板 %4 的第 %ordinal5 個模板參數%select{未命名|命名為 %7}6|函數模板 %4 的第 %ordinal5 個模板參數%select{無|}6 預設值|函數模板 %4 的第 %ordinal5 個模板參數預設值為 %6|函數模板 %4 的第 %ordinal5 個模板參數為單一類型|函數模板 %4 的第 %ordinal5 個模板參數%select{非|}6 為模板參數包|}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{unnamed template parameter|template parameter %5|template parameter with %select{no |}4default argument|template parameter with default argument}3"
-HA9E92FE31082: "%q0 在不同模組中具有不同的定義；第一個差異是 %select{模組 '%2' 中的定義|在此處定義}1 發現 %select{無名稱範本參數|範本參數 %5|範本參數具有%select{無 |}4預設參數|範本參數具有預設參數}3"
+HA9E92FE31082: "%q0 在不同模組中具有不同的定義；第一個差異是 %select{模組 '%2' 中的定義|在此處定義}1 發現 %select{無名稱範本參數|範本參數 %5|範本參數具有%select{無 |}4 預設參數|範本參數具有預設參數}3"
 # '%q0 hides overloaded virtual %select{function|functions}1'
 H2FDDD909C4BF: '%q0 隱藏了重載的虛函數 %select{函數|函數}1'
 # '%q0 is not a member of class %1'
@@ -871,9 +871,9 @@ H47225B26A402: "%select{PCH|模組|AST}0 檔案 '%1' 編譯自不同分支 (%2)�
 # "%select{PCH|module|AST}0 file '%1' contains compiler errors"
 H70FD1E0F0771: "%select{PCH|模組|AST}0 檔案 '%1' 包含編譯錯誤"
 # "%select{PCH|module|AST}0 file '%1' is out of date and needs to be rebuilt%select{|: %3}2"
-H1F11095B483F: "%select{PCH|模組|AST}0 檔案 '%1' 已過期需重新建置%select{|： %3}2"
+H1F11095B483F: "%select{PCH|模組|AST}0 檔案 '%1' 已過期需重新建置 %select{|： %3}2"
 # "%select{PCH|module|AST}0 file '%1' not found%select{|: %3}2"
-HA37A363A734E: "%select{PCH|模組|AST}0 檔案 '%1' 未找到%select{|： %3}2"
+HA37A363A734E: "%select{PCH|模組|AST}0 檔案 '%1' 未找到 %select{|： %3}2"
 # "%select{PCH|module|AST}0 file '%1' uses a newer format that cannot be read"
 H80665252BAE8: "%select{PCH|模組|AST}0 檔案 '%1' 使用較新的格式無法讀取"
 # "%select{PCH|module|AST}0 file '%1' uses an older format that is no longer supported"
@@ -891,7 +891,7 @@ HDE8352A90808: '%select{取得|引用}0 堆疊記憶體與 %select{局部變數|
 # '%select{alias|ifunc}0 definition is part of a cycle'
 H75F8799A172C: '%select{別名|ifunc}0 定義是循環的一部分'
 # '%select{alias|ifunc}0 must point to a defined %select{variable or |}1function'
-HA8FBD807C04A: '%select{別名|ifunc}0 必須指向已定義的 %select{變數或 |}1函數'
+HA8FBD807C04A: '%select{別名|ifunc}0 必須指向已定義的 %select{變數或 |}1 函數'
 # "%select{alias|ifunc}1 will not be in section '%0' but in the same section as the %select{aliasee|resolver}2"
 H14919DB80F8A: "%select{別名|ifunc}1 不會出現在區段 '%0'，而是與 %select{被引用物件|解析器}2 同區段"
 # '%select{alias|ifunc}2 will always resolve to %0 even if weak definition of %1 is overridden'
@@ -905,7 +905,7 @@ HF5A022BDF3DB: '%select{對齊值|大小}0 的成員 %1 (%2 位元) 與透明聯
 # '%select{alignment|size}0 of first field is %1 bits'
 H996CEE2D3252: '%select{對齊值|大小}0 的第一個成員是 %1 位元'
 # '%select{all|second and third}0 arguments to %1 must be of scalar or vector type with matching scalar element type%diff{: $ vs $|}2,3'
-HE09C48EB126A: '%select{所有|第二及第三}0 參數至 %1 必須為純量或向量類型，且具有相同純量元素類型%diff{: $ vs $|}2,3'
+HE09C48EB126A: '%select{所有|第二及第三}0 參數至 %1 必須為純量或向量類型，且具有相同純量元素類型 %diff{: $ vs $|}2,3'
 # '%select{an attribute specifier sequence|%0}1 in this position is a C++23 extension'
 H561F9F6DB91B: '%select{屬性指定序列|%0}1 在此位置是 C++23 的擴充功能'
 # '%select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23'
@@ -943,17 +943,17 @@ HB2E74DC62C72: '%select{之間的算術運算|之間的位元運算|比較|條�
 # '%select{assignment to readonly property|no setter method %1 for assignment to property}0'
 H7FB56A6FE5D6: '%select{將值賦予唯讀屬性|無設定器方法 %1 對屬性賦值}0'
 # '%select{base class|inherited virtual base class}0 %1 has %select{private|protected}3 %select{default |copy |move |*ERROR* |*ERROR* |*ERROR*|}2constructor'
-H3EE5604475F7: '%select{基底類別|繼承的虛基類}0 %1 具有 %select{私有|受保護}3 %select{預設 |複製 |移動 |*ERROR* |*ERROR* |*ERROR*|}2建構函式'
+H3EE5604475F7: '%select{基底類別|繼承的虛基類}0 %1 具有 %select{私有|受保護}3 %select{預設 |複製 |移動 |*ERROR* |*ERROR* |*ERROR*|}2 建構函式'
 # '%select{bit-field %1|anonymous bit-field}0 is too wide (%2 bits)'
 H4CB82469419C: '%select{位段 %1|匿名位段}0 過寬 (%2 位元)'
 # "%select{block pointer|pointer|reference}0 to function type %select{%2 |}1cannot have '%3' qualifier"
-H0BABB964A63A: "%select{函數指標|函數區塊指標|C 函數指標}0 類型 %select{%2 |}1不能具有 '%3' 限定符"
+H0BABB964A63A: "%select{函數指標|函數區塊指標|C 函數指標}0 類型 %select{%2 |}1 不能具有 '%3' 限定符"
 # '%select{call to non-static member function|use of non-static data member}0 %2 of %1 from nested type %3'
 H4DA493B4F5FF: '%select{調用非靜態成員函數|使用非靜態資料成員}0 %2 的 %1 來自嵌套類型 %3'
 # '%select{cannot assign to return value because function %1 returns a const value|cannot assign to variable %1 with const-qualified type %2|cannot assign to %select{non-|}1static data member %2 with const-qualified type %3|cannot assign to non-static data member within const member function %1|cannot assign to %select{variable %2|non-static data member %2|lvalue}1 with %select{|nested }3const-qualified data member %4|read-only variable is not assignable}0'
-H957C121C1C4E: '%select{無法對返回值進行賦值，因為函數 %1 返回了 const 值|無法對 const 限定類型 %2 的變數 %1 進行賦值|無法對 %select{非-|}1靜態資料成員 %2 具有 const 限定類型 %3 進行賦值|無法在 const 成員函數 %1 內對非靜態資料成員進行賦值|無法對 %select{變數 %2|非靜態資料成員 %2|左值}1 具有 %select{|嵌套 }3const 限定資料成員 %4 進行賦值|唯讀變數無法進行賦值}0'
+H957C121C1C4E: '%select{無法對返回值進行賦值，因為函數 %1 返回了 const 值|無法對 const 限定類型 %2 的變數 %1 進行賦值|無法對 %select{非-|}1 靜態資料成員 %2 具有 const 限定類型 %3 進行賦值|無法在 const 成員函數 %1 內對非靜態資料成員進行賦值|無法對 %select{變數 %2|非靜態資料成員 %2|左值}1 具有 %select{|嵌套 }3const 限定資料成員 %4 進行賦值|唯讀變數無法進行賦值}0'
 # "%select{case value|enumerator value|non-type template argument|non-type parameter of template template parameter|array size|explicit specifier argument|noexcept specifier argument|call to 'size()'|call to 'data()'}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1"
-HECF4733C9DA0: "%select{case值|枚舉值|非類型模板參數|匿名聯結體成員|陣列大小|顯式指定參數|noexcept指定參數|調用'size()'|調用'data()'}0 %select{不能從類型 %2 窄化為 %3|評估為 %2，這不能窄化為類型 %3}1"
+HECF4733C9DA0: "%select{case值|枚舉值|非類型模板參數|匿名聯結體成員|陣列大小|顯式指定參數|noexcept指定參數|調用 'size()'|調用 'data()'}0 %select{不能從類型 %2 窄化為 %3|評估為 %2，這不能窄化為類型 %3}1"
 # "%select{case value|enumerator value|non-type template argument|non-type parameter of template template parameter|array size|explicit specifier argument|noexcept specifier argument|call to 'size()'|call to 'data()'}0 is not a constant expression"
 HFB41B693F137: "%select{case 值|枚舉值|非類型模板參數|非類型參數的模板模板參數|陣列大小|顯示指定參數|noexcept 指定參數|調用 'size()'|調用 'data()'}0 不是常量表達式"
 # '%select{cast|implicit conversion}0 of %select{Objective-C|block|C}1 pointer type %2 to %select{Objective-C|block|C}3 pointer type %4 requires a bridged cast'
@@ -1067,7 +1067,7 @@ H2588FE2C83FF: '%select{預設|刪除}0 函數定義是C++11擴展'
 # '%select{defaulted|deleted}0 function definitions are incompatible with C++98'
 HE7CB963644EA: '%select{預設|刪除}0 函數定義與C++98不相容'
 # "%select{definition|#undef}0 of configuration macro '%1' has no effect on the import of '%2'; pass '%select{-D%1=...|-U%1}0' on the command line to configure the module"
-H20DEB068BA86: "%select{定義|#undef}0 配置巨集'%1'對'%2'的匯入無效；使用'%select{-D%1=...|-U%1}0'指令列參數進行配置"
+H20DEB068BA86: "%select{定義|#undef}0 配置巨集 '%1' 對 '%2' 的匯入無效；使用 '%select{-D%1=...|-U%1}0' 指令列參數進行配置"
 # '%select{delete|destructor}0 called on %1 that is abstract but has non-virtual destructor'
 HD3B2B405330A: '%select{delete|析構函數}0 被呼叫於具有虛基類但非虛析構函數的abstract類別 %1'
 # '%select{delete|destructor}0 called on non-final %1 that has virtual functions but non-virtual destructor'
@@ -1091,15 +1091,15 @@ H69C6598EFBD9: '%select{等同|不等|關係|三向}0 比較結果未被使用'
 # '%select{expected an expression statement|expected built-in assignment operator|expected expression of scalar type|expected lvalue expression}0'
 H7F94DE3BA105: '%select{期望表達式陳述式|期望內建賦值運算子|期望純量類型的表達式|期望左值表達式}0'
 # "%select{expected an expression statement|expected built-in binary or unary operator|expected unary decrement/increment operation|expected expression of scalar type|expected assignment expression|expected built-in binary operator|expected one of '+', '*', '-', '/', '&', '^', '%|', '<<', or '>>' built-in operations|expected in right hand side of expression}0"
-H13014A5049BE: "%select{期望表達式陳述式|期望內建一元或二元運算子|期望一元遞增/遞減運算|期望純量類型的表達式|期望賦值表達式|期望內建二元運算子|期望'+'、'*'、'-'、'/'、'&'、'^'、'%'、'|'、'<<'或'>>'運算|期望右邊的表達式}0"
+H13014A5049BE: "%select{期望表達式陳述式|期望內建一元或二元運算子|期望一元遞增/遞減運算|期望純量類型的表達式|期望賦值表達式|期望內建二元運算子|期望 '+'、'*'、'-'、'/'、'&'、'^'、'%'、'|'、'<<' 或 '>>' 運算|期望右邊的表達式}0"
 # '%select{expected assignment expression|expected compound statement|expected exactly two expression statements|expected in right hand side of the first expression}0'
 H71EE048AAB44: '%select{期望賦值表達式|期望複合陳述式|期望兩個表達式陳述式|期望第一個表達式的右邊}0'
 # "%select{expected compound statement|expected exactly one expression statement|expected assignment statement|expected conditional operator|expect result value to be at false expression|expect binary operator in conditional expression|expect '<', '>' or '==' as order operator|expect comparison in a form of 'x == e', 'e == x', 'x ordop expr', or 'expr ordop x'|expect lvalue for result value|expect scalar value|expect integer value|unexpected 'else' statement|expect '==' operator|expect an assignment statement 'v = x'|expect a 'if' statement|expect no more than two statements|expect a compound statement|expect 'else' statement|expect a form 'r = x == e; if (r) ...'}0"
-H2BEDF1CDD9ED: "%select{期望複合陳述式|期望單一表達式陳述式|期望賦值陳述式|期望條件運算子|期望false表達式有結果值|期望條件運算子中的二元運算|期望'<'、'>'或'=='為比較運算|期望'x == e'、'e == x'、'x 順序運算子 表達式'或'表達式 順序運算子 x'的比較形式|期望結果值為左值|期望純量值|期望整數值|不期望else陳述式|期望'=='運算子|期望'v = x'的賦值陳述式|期望if陳述式|期望不超過兩個陳述式|期望複合陳述式|期望else陳述式|期望形式'r = x == e; if (r) ...'}0"
+H2BEDF1CDD9ED: "%select{期望複合陳述式|期望單一表達式陳述式|期望賦值陳述式|期望條件運算子|期望false表達式有結果值|期望條件運算子中的二元運算|期望 '<'、'>' 或 '==' 為比較運算|期望 'x == e'、'e == x'、'x 順序運算子 表達式'或'表達式 順序運算子 x'的比較形式|期望結果值為左值|期望純量值|期望整數值|不期望else陳述式|期望 '==' 運算子|期望 'v = x' 的賦值陳述式|期望if陳述式|期望不超過兩個陳述式|期望複合陳述式|期望else陳述式|期望形式 'r = x == e; if (r) ...'}0"
 # '%select{explicit|friend}0 specialization cannot have a trailing requires clause unless it declares a function template'
 H4B8C1F1CA2BB: '%select{明確|友元}0 專屬化除非宣告函數模板，否則不可具有尾隨requires子句'
 # '%select{expression|base type|declaration type|data member type|bit-field size|static assertion|fixed underlying type|enumerator value|using declaration|friend declaration|qualifier|initializer|default argument|non-type template parameter type|exception type|explicit specialization|partial specialization|__if_exists name|__if_not_exists name|lambda|block|type constraint|requirement|requires clause}0 contains%plural{0: an|:}1 unexpanded parameter pack%plural{0:|1: %2|2:s %2 and %3|:s %2, %3, ...}1'
-HE9A8E0B2E8F5: '%select{表達式|基礎類型|宣告類型|資料成員類型|位段大小|static assertion|固定基礎類型|枚舉值|using 宣告|friend 宣告|限定詞|初始值設定|預設參數值|非類型模板參數類型|例外類型|明確特化|部分特化|__if_exists 名稱|__if_not_exists 名稱|lambda|block|類型約束|需求|requires 子句}0 包含%plural{0: 一個|:}1 未展開的參數包%plural{0:|1: %2|2:s %2 和 %3|:s %2, %3, ...}1'
+HE9A8E0B2E8F5: '%select{表達式|基礎類型|宣告類型|資料成員類型|位段大小|static assertion|固定基礎類型|枚舉值|using 宣告|friend 宣告|限定詞|初始值設定|預設參數值|非類型模板參數類型|例外類型|明確特化|部分特化|__if_exists 名稱|__if_not_exists 名稱|lambda|block|類型約束|需求|requires 子句}0 包含 %plural{0: 一個|:}1 未展開的參數包 %plural{0:|1: %2|2:s %2 和 %3|:s %2, %3, ...}1'
 # '%select{extension|category}0 of non-parameterized class %1 cannot have type parameters'
 H6F4F8CBFDF9B: '%select{擴充類別|類別分類}0 的非參數化類別 %1 不能具有模板參數'
 # '%select{fewer|more}0 specifiers in format string than expected'
@@ -1121,9 +1121,9 @@ HBF77ADC8F095: '%select{第一|第二}0 運算元隱式轉換為類型 %1'
 # '%select{forward class declaration|class definition|category|extension}0 has too %select{few|many}1 type parameters (expected %2, have %3)'
 HF027D432E158: '%select{類別前向宣告|類別定義|分類|擴充}0 的類型參數數目 %select{過少|過多}1（期望 %2，目前 %3）'
 # '%select{function %1 which returns const-qualified type %2 declared here|variable %1 declared const here|%select{non-|}1static data member %2 declared const here|member function %q1 is declared const here|%select{|nested }1data member %2 declared const here}0'
-HA9209A7005BD: '%select{返回const限定類型 %2 的函數 %1 宣告在此處|在此處宣告的const變數 %1|%select{非-|}1靜態資料成員 %2 在此處宣告為const|此成員函數%q1在此處宣告為const|%select{|巢狀 }1資料成員 %2 在此處宣告為const}0'
+HA9209A7005BD: '%select{返回const限定類型 %2 的函數 %1 宣告在此處|在此處宣告的const變數 %1|%select{非-|}1 靜態資料成員 %2 在此處宣告為const|此成員函數%q1在此處宣告為const|%select{|巢狀 }1資料成員 %2 在此處宣告為const}0'
 # '%select{function parameter|typedef}0 cannot be %select{<ERROR>|constexpr|consteval|constinit}1'
-H86C3A8B0C257: '%select{函數參數|typedef宣告}0 無法是%select{<ERROR>|constexpr|consteval|constinit}1'
+H86C3A8B0C257: '%select{函數參數|typedef宣告}0 無法是 %select{<ERROR>|constexpr|consteval|constinit}1'
 # '%select{function template|class template|variable template|type alias template|template template parameter}0 %1 declared here'
 H91E08CCD64B6: '%select{範型函數|範型類別|範型變數|型別別名範型|範型型別參數}0 %1 宣告在此處'
 # '%select{function with deduced return type|declaration with trailing return type}0 must be the only declaration in its group'
@@ -1171,7 +1171,7 @@ H2BE56E173B04: '%select{隱式轉換|型別轉換}0 將 %select{%2|非Objective-
 # '%select{implicit conversion|cast}0 of weak-unavailable object of type %1 to a __weak object of type %2'
 H5E0A61E4DC2C: '%select{隱式轉換|型別轉換}0 將無法存取的弱引用物件 %1 轉換為__weak物件 %2'
 # '%select{implicitly |}2captured%select{| by reference}3%select{%select{ due to use|}2 here| via initialization of lambda capture %0}1'
-H0BA3D7D599E5: '%select{隱式|}2捕獲%select{|通過引用}3%select{%select{ 由於此處的使用|}2 |通過lambda捕獲 %0 的初始化}1'
+H0BA3D7D599E5: '%select{隱式|}2 捕獲 %select{|通過引用}3%select{%select{ 由於此處的使用|}2 |通過lambda捕獲 %0 的初始化}1'
 # '%select{implicit|explicit}0 instantiation first required here'
 HB12903FE55DA: '%select{隱式|明確}0 實體化首次在此需要'
 # '%select{implicit|explicit}0 instantiation of template %1 within its own definition'
@@ -1187,17 +1187,17 @@ H113C6B0985AF: '%select{實例|類}1 方法 %0 未找到；是否指 %2？'
 # '%select{integer|integral}1 constant expression must have %select{integer|integral or unscoped enumeration}1 type, not %0'
 H07847569345A: '%select{整數|整數或無作用域列舉}1 常數運算式必須具有 %select{整數|整數或無作用域列舉}1 類型，而非 %0'
 # "%select{interrupt service routine|function with attribute 'no_caller_saved_registers'}0 should only call a function with attribute 'no_caller_saved_registers' or be compiled with '-mgeneral-regs-only'"
-HE2C243372C8E: "%select{中斷服務常式|具有 'no_caller_saved_registers' 屬性的函數}0 應僅呼叫具有 'no_caller_saved_registers' 屬性的函數，或使用'-mgeneral-regs-only'編譯"
+HE2C243372C8E: "%select{中斷服務常式|具有 'no_caller_saved_registers' 屬性的函數}0 應僅呼叫具有 'no_caller_saved_registers' 屬性的函數，或使用 '-mgeneral-regs-only' 編譯"
 # "%select{invalid use of|unknown}2 attribute subject matcher sub-rule '%0'; '%1' matcher %select{does not support sub-rules|supports the following sub-rules: %3}2"
-H8BFF482F0D6A: "%select{無效的|%s}2屬性主體匹配規則子規則'%0'；'%1'匹配器 %select{不支援子規則|支援以下子規則：%3}2"
+H8BFF482F0D6A: "%select{無效的|%s}2 屬性主體匹配規則子規則 '%0'；'%1' 匹配器 %select{不支援子規則|支援以下子規則：%3}2"
 # "%select{invalid value '%0'; must be positive|value '%0' is too large}1"
-HEC3DA4A69943: "%select{無效值'%0'；必須為正數|值'%0'過大}1"
+HEC3DA4A69943: "%select{無效值 '%0'；必須為正數|值 '%0' 過大}1"
 # "%select{invalid|missing}0 option%select{ %1|}0; expected 'contract', 'reassociate', 'reciprocal', or 'exceptions'"
 H280D64C6E2E8: "%select{無效|缺少}0 選項%select{ %1|}0; %expect 'contract', 'reassociate', 'reciprocal', 或 'exceptions'"
 # '%select{invalid|missing}0 option%select{ %1|}0; expected vectorize, vectorize_width, interleave, interleave_count, unroll, unroll_count, pipeline, pipeline_initiation_interval, vectorize_predicate, or distribute'
 HC3AB036EF44A: '%select{無效|缺少}0 選項%select{ %1|}0; %expect vectorize, vectorize_width, interleave, interleave_count, unroll, unroll_count, pipeline, pipeline_initiation_interval, vectorize_predicate, 或 distribute'
 # '%select{in|co|contra}0variant type parameter %1 conflicts with previous %select{in|co|contra}2variant type parameter %3'
-H893590D91D8F: '%select{左|右|}0邊異變型參數 %1 與先前的 %select{左|右|}2邊異變型參數 %3 冲突'
+H893590D91D8F: '%select{左|右|}0 邊異變型參數 %1 與先前的 %select{左|右|}2 邊異變型參數 %3 冲突'
 # '%select{left |right |}0operand to %select{assignment|compound assignment|increment|decrement}1 expression must be %select{an l-value|of scalar type (was %3)}2'
 H115469577E3D: '%select{左邊 |右邊 |}0 運算元至 %select{指派|複合指派|遞增|遞減}1 運算式必須為 %select{左值|純量類型（實際為 %3）}2'
 # '%select{left|right}0 side of operator converted from negative value to unsigned: %1'
@@ -1209,9 +1209,9 @@ H66CF7FCAA26B: '%select{從|寫入}指向類型 %1 的指標需要 cl_khr_fp16 �
 # '%select{local variable|parameter|typedef}0 %1 cannot be declared __module_private__'
 H1DE6DC0BF8C5: '%select{局部變數|參數|typedef}0 %1 不能宣告為__module_private__'
 # "%select{map type '%1' is not allowed|map type must be specified}0 for '#pragma omp %2'"
-HA49CE3340880: "%select{map類型'%1'不允許|必須指定map類型}0 用於'#pragma omp %2'"
+HA49CE3340880: "%select{map類型 '%1' 不允許|必須指定map類型}0 用於 '#pragma omp %2'"
 # "%select{missing '#include'|missing '#include %3'}2; %select{||default argument of |explicit specialization of |partial specialization of }0%1 must be %select{declared|defined|defined|declared|declared}0 before it is used"
-H0EC06C773CD9: "%select{缺少'#include'|缺少'#include %3'}2；%select{||預設參數的 |明確專屬化的 |部分專屬化的 }0%1 必須%select{宣告|定義|定義|宣告|宣告}0 在使用前"
+H0EC06C773CD9: "%select{缺少 '#include'|缺少 '#include %3'}2；%select{||預設參數的 |明確專屬化的 |部分專屬化的 }0%1 必須%select{宣告|定義|定義|宣告|宣告}0 在使用前"
 # '%select{no_destroy|always_destroy}0 attribute can only be applied to a variable with static or thread storage duration'
 H7D17D7EDA6B0: '%select{no_destroy|always_destroy}0 屬性只能套用於具有靜態或執行緒儲存期的變數'
 # '%select{non-constexpr|constexpr|consteval}1 declaration of %0 follows %select{non-constexpr|constexpr|consteval}2 declaration'
@@ -1225,7 +1225,7 @@ H1777D1633EE8: '%select{非const|volatile}0 左值引用 %diff{至類型$無法�
 # '%select{non-const|volatile}0 lvalue reference to type %1 cannot bind to an initializer list temporary'
 H3CF62E12AA3E: '%select{非const|volatile}0 左值引用至類型 %1 無法綁定到矩陣初始清單暫時物件'
 # '%select{non-const|volatile}0 reference cannot bind to bit-field%select{| %1}2'
-H8AF09902E67B: '%select{非const|volatile}0 參考無法綁定到成員位段%select{| %1}2'
+H8AF09902E67B: '%select{非const|volatile}0 參考無法綁定到成員位段 %select{| %1}2'
 # '%select{non-const|volatile}0 reference cannot bind to matrix element'
 HA82833F246FF: '%select{非const|volatile}0 參考無法綁定到矩陣元素'
 # '%select{non-const|volatile}0 reference cannot bind to vector element'
@@ -1235,11 +1235,11 @@ HAB3E494D65F5: '%select{非整數類型 %0|%0}1 是無效的基礎類型'
 # '%select{non-kernel function|function scope}0 variable cannot be declared in %1 address space'
 H0866366952CF: '%select{非kernel函式|函式範疇}0 變數不可在 %1 位址空間宣告'
 # "%select{non-member function|static member function|explicit object member function|deduction guide}0 %select{of type %2 |}1cannot have '%3' qualifier"
-HFB817CBCD184: "%select{非成員函式|靜態成員函式|明確物件成員函式|推論指引}0 %select{類型 %2 的|}1不可具有 '%3' 限定符"
+HFB817CBCD184: "%select{非成員函式|靜態成員函式|明確物件成員函式|推論指引}0 %select{類型 %2 的|}1 不可具有 '%3' 限定符"
 # '%select{non-member|member}0 %select{<ERROR>|equality|three-way|equality|relational}1 comparison operator must have %select{2|1}0 parameters'
 HB5C9D99264DA: '%select{非成員|成員}0 %select{<ERROR>|等式|三向|等式|關係}1 比較運算子必須有 %select{2|1}0 個參數'
 # '%select{non-member|static member|non-static member}0 function cannot perform a tail call to %select{non-member|static member|non-static member|pointer-to-member}1 function%select{| %3}2'
-HE869F55E570F: '%select{非成員|靜態成員|非靜態成員}0 函數無法對 %select{非成員|靜態成員|非靜態成員|成員指針}1 函數%select{| %3}2 進行尾調用'
+HE869F55E570F: '%select{非成員|靜態成員|非靜態成員}0 函數無法對 %select{非成員|靜態成員|非靜態成員|成員指針}1 函數 %select{| %3}2 進行尾調用'
 # "%select{non-pointer|function pointer|void pointer}0 argument to '__builtin_launder' is not allowed"
 H5F5CB4F84C85: '__builtin_launder 的 %select{非指標|函數指標|void指標}0 參數不被允許'
 # "%select{non-struct type|non-class type|non-union type|non-enum type|typedef|type alias|template|alias template|template template argument}1 %0 cannot be referenced with the '%select{struct|interface|union|class|enum}2' specifier"
@@ -1251,11 +1251,11 @@ HEC6E2A0FBA29: '__builtin_is_within_lifetime 的 %select{非指標|函數指標}
 # "%select{no|too many}0 integer expression arguments provided to OpenACC 'num_gangs' %select{|clause: '%1' directive expects maximum of %2, %3 were provided}0"
 HDF54FE517944: "%select{未提供|超出}0 整數表達式參數給 OpenACC 'num_gangs' %select{|子句: '%1' 指令最多接受 %2，但提供了 %3}0"
 # "%select{orphaned 'omp section' directives are prohibited, it|'omp section' directive}0 must be closely nested to a sections region%select{|, not a %1 region}0"
-HF07F4A64D372: "%select{孤兒 'omp section' 指令不被允許，它|'omp section' 指令}0 必須緊密巢狀在 sections 區域%select{|，而非 %1 區域}0"
+HF07F4A64D372: "%select{孤兒 'omp section' 指令不被允許，它|'omp section' 指令}0 必須緊密巢狀在 sections 區域 %select{|，而非 %1 區域}0"
 # "%select{overridden|current}0 method is explicitly declared 'instancetype'%select{| and is expected to return an instance of its class type}0"
 HB89C11914779: "%select{覆寫|目前}0 方法明確宣告為 'instancetype'%select{|，並期望返回其類別的實例}0"
 # "%select{overridden|current}0 method is part of the '%select{|alloc|copy|init|mutableCopy|new|autorelease|dealloc|finalize|release|retain|retainCount|self}1' method family%select{| and is expected to return an instance of its class type}0"
-HB76B1E081BAA: "%select{覆寫|目前}0 方法是 '%select{|alloc|copy|init|mutableCopy|new|autorelease|dealloc|finalize|release|retain|retainCount|self}1' 方法家族的成員%select{|，並期望返回其類別的實例}0"
+HB76B1E081BAA: "%select{覆寫|目前}0 方法是 '%select{|alloc|copy|init|mutableCopy|new|autorelease|dealloc|finalize|release|retain|retainCount|self}1' 方法家族的成員 %select{|，並期望返回其類別的實例}0"
 # '%select{parameters|function return value}0 cannot have __fp16 type; did you forget * ?'
 H3BDED28AD784: '%select{參數|函數傳回值}0 不可具有 __fp16 類型；是否遺漏 *？'
 # '%select{parameter|non-static data member}3 %0 %select{|of %1 }3shadows member inherited from type %2'
@@ -1293,9 +1293,9 @@ H8153C2BE3904: '%select{屬性|實體變數}0 存取不能用 %1 修飾'
 # "%select{public|private|project}1 umbrella header file not found in input: '%0'"
 HFB4B45B92460: "%select{公開|私人|專案}1 umbrella 頭文件未在輸入中找到: '%0'"
 # "%select{qualifier in |static |}0array size %select{||'[*] '}0is a C99 feature"
-H5561702CDE0D: "%select{修飾符在 |static |}0陣列大小 %select{||'[*] '}0是 C99 的功能"
+H5561702CDE0D: "%select{修飾符在 |static |}0 陣列大小 %select{||'[*] '}0 是 C99 的功能"
 # "%select{qualifier in |static |}0array size %select{||'[*] '}0is a C99 feature, not permitted in C++"
-HD9EDD0C87400: "%select{修飾符在 |static |}0陣列大小 %select{||'[*] '}0是 C99 的功能，不允許在 C++ 中使用"
+HD9EDD0C87400: "%select{修飾符在 |static |}0 陣列大小 %select{||'[*] '}0 是 C99 的功能，不允許在 C++ 中使用"
 # '%select{read of|read of|assignment to|increment of|decrement of|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>}0 volatile %select{temporary|object %2|member %2}1 is not allowed in a constant expression'
 H88BF34501395: '%select{讀取|讀取|指派給|遞增|遞減|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>}0 volatile %select{暫時物件|%2 的物件|%2 成員}1 不允許在常數運算式中使用'
 # '%select{read of|read of|assignment to|increment of|decrement of|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>|<ERROR>}0 volatile-qualified type %1 is not allowed in a constant expression'
@@ -1317,7 +1317,7 @@ H0F4326DA1EA9: '%select{讀取|讀取|賦值給|遞增|遞減|成員呼叫|dynam
 # '%select{read of|read of|assignment to|increment of|decrement of|member call on|dynamic_cast of|typeid applied to|construction of|destruction of|read of}0 mutable member %1 is not allowed in a constant expression'
 H08EBC2661AFA: '%select{讀取|讀取|賦值給|遞增|遞減|成員呼叫|dynamic_cast|對...應用typeid|建構|銷毀|讀取}0 可變更成員 %1 在常數運算式中非法'
 # "%select{read of|read of|assignment to|increment of|decrement of|member call on|dynamic_cast of|typeid applied to|construction of|destruction of|read of}0 object '%1' whose value is not known"
-H2547ED9973E0: "%select{讀取|讀取|賦值給|遞增|遞減|成員呼叫|dynamic_cast|對...應用typeid|建構|銷毀|讀取}0 值未知的物件'%1'"
+H2547ED9973E0: "%select{讀取|讀取|賦值給|遞增|遞減|成員呼叫|dynamic_cast|對...應用typeid|建構|銷毀|讀取}0 值未知的物件 '%1'"
 # '%select{read of|read of|assignment to|increment of|decrement of|member call on|dynamic_cast of|typeid applied to|construction of|destruction of|read of}0 temporary is not allowed in a constant expression outside the expression that created the temporary'
 H1A04D5C0C6D4: '%select{讀取|讀取|賦值給|遞增|遞減|成員呼叫|dynamic_cast|對...應用typeid|建構|銷毀|讀取}0 非創建運算式中的臨時物件在常數運算式中非法'
 # '%select{reading|writing}1 the value pointed to by %0 requires holding %select{any mutex|any mutex exclusively}1'
@@ -1337,7 +1337,7 @@ H8AC5A0A64CFD: '%select{參考|指標}0 成員在此處宣告'
 # '%select{reinterpret_cast|C-style cast}0 from %1 to %2 changes address space of nested pointers'
 HDAB148B74E30: '%select{reinterpret_cast|C型式轉換}0 從 %1 到 %2 改變巢狀指標的地址空間'
 # '%select{reinterpret_cast|dynamic_cast|%select{this conversion|cast that performs the conversions of a reinterpret_cast}1|cast from %1}0 is not allowed in a constant expression%select{| in C++ standards before C++20||}0'
-H1688ED0E5178: '%select{reinterpret_cast|dynamic_cast|%select{this conversion|cast that performs the conversions of a reinterpret_cast}1|cast from %1}0 不允許在常數運算式中使用%select{|在C++20之前的C++標準中||}0'
+H1688ED0E5178: '%select{reinterpret_cast|dynamic_cast|%select{this conversion|cast that performs the conversions of a reinterpret_cast}1|cast from %1}0 不允許在常數運算式中使用 %select{|在C++20之前的C++標準中||}0'
 # '%select{remainder|division}0 by zero is undefined'
 HDDF6DBF3AFB2: '%select{餘數|除法}0 除以零是未定義的行為'
 # '%select{returning|passing}0 a VL-dependent argument %select{from|to}0 a function with a different streaming-mode is undefined behaviour when the streaming and non-streaming vector lengths are different at runtime'
@@ -1363,7 +1363,7 @@ HB66515AEE2F3: '%select{有符號|無符號}0 _BitInt 的位數大於 %1 的未�
 # "%select{source|destination}2 of '%select{%select{memcpy|wmemcpy}1|%select{memmove|wmemmove}1}0' is %3"
 H752C91AB4DE4: "%select{來源|目標}2 的 '%select{%select{memcpy|wmemcpy}1|%select{memmove|wmemmove}1}0' 是 %3"
 # "%select{statement after '#pragma omp %1' must be a for loop|expected %2 for loops after '#pragma omp %1'%select{|, but found only %4}3}0"
-H5AE78EDFB051: "%select{在'#pragma omp %1'之後的語句必須是for迴圈|期望在'#pragma omp %1'之後有 %2 個for迴圈%select{|，但僅找到 %4}3}0"
+H5AE78EDFB051: "%select{在 '#pragma omp %1' 之後的語句必須是for迴圈|期望在 '#pragma omp %1' 之後有 %2 個for迴圈 %select{|，但僅找到 %4}3}0"
 # '%select{statement|directive}0 outside teams construct here'
 HCEC20E30EFC9: '%select{語句|指令}0 在這裡的 teams 結構外部'
 # "%select{static data member is predetermined as shared|variable with static storage duration is predetermined as shared|loop iteration variable is predetermined as private|loop iteration variable is predetermined as linear|loop iteration variable is predetermined as lastprivate|constant variable is predetermined as shared|global variable is predetermined as shared|non-shared variable in a task construct is predetermined as firstprivate|variable with automatic storage duration is predetermined as private}0%select{|; perhaps you forget to enclose 'omp %2' directive into a parallel or another task region?}1"
@@ -1385,25 +1385,25 @@ HBECD0A183C46: '%select{struct|union}0 若沒有命名成員則是GNU擴充'
 # '%select{subtraction|addition}0 of address-of-label expressions is not supported with ptrauth indirect gotos'
 H131327EB0D0D: '%select{減法|加法}0 的地址標籤運算式不支援 ptrauth 間接 goto'
 # '%select{template type|non-type template|template template}0 parameter%select{| pack}1 conflicts with previous %select{template type|non-type template|template template}0 parameter%select{ pack|}1'
-HACD51B91D6D5: '%select{template type|non-type template|template template}0 參數%select{| pack}1 與先前的 %select{template type|non-type template|template template}0 參數%select{ pack|}1 產生衝突'
+HACD51B91D6D5: '%select{template type|non-type template|template template}0 參數 %select{| pack}1 與先前的 %select{template type|non-type template|template template}0 參數%select{ pack|}1 產生衝突'
 # '%select{template type|non-type template|template template}0 parameter%select{| pack}1 does not match %select{template type|non-type template|template template}0 parameter%select{ pack|}1 in template argument'
-H42D8D01F5E06: '%select{template type|non-type template|template template}0 參數%select{| pack}1 在模板參數中與 %select{template type|non-type template|template template}0 參數%select{ pack|}1 不符合'
+H42D8D01F5E06: '%select{template type|non-type template|template template}0 參數 %select{| pack}1 在模板參數中與 %select{template type|non-type template|template template}0 參數%select{ pack|}1 不符合'
 # '%select{template|partial|member}0 specialization cannot be declared __module_private__'
 H0A90D5264D30: '%select{template|partial|member}0 專門化不能宣告為__module_private__'
 # '%select{temporary %select{whose address is used as value of|%select{|implicitly }2bound to}4 %select{%select{|reference }4member of local variable|local %select{variable|reference}4}1|array backing %select{initializer list subobject of local variable|local initializer list}1}0 %select{%3 |}2will be destroyed at the end of the full-expression'
-H1685FEE7827D: '%select{臨時物件 %select{其地址被用作值|%select{ | 隱含 }2綁定到}4 %select{%select{ | 參考 }4的成員是局部變數|局部 %select{變數|參考}4}1 |陣列後備 %select{局部變數的初始清單子物件|局部初始清單}1}0 %select{%3 |}2將在完整表達式的結尾被銷毀'
+H1685FEE7827D: '%select{臨時物件 %select{其地址被用作值|%select{ | 隱含 }2綁定到}4 %select{%select{ | 參考 }4的成員是局部變數|局部 %select{變數|參考}4}1 |陣列後備 %select{局部變數的初始清單子物件|局部初始清單}1}0 %select{%3 |}2 將在完整表達式的結尾被銷毀'
 # "%select{the message|the expression}0 in %select{a static assertion|this asm operand}0 must be a string literal or an object with 'data()' and 'size()' member functions"
-H320EEB9B1530: "%select{訊息|運算式}0 在 %select{static assertion|這個asm運算元}0 中必須是字串常數或具有'data()'和'size()'成員函數的物件"
+H320EEB9B1530: "%select{訊息|運算式}0 在 %select{static assertion|這個asm運算元}0 中必須是字串常數或具有 'data()' 和 'size()' 成員函數的物件"
 # '%select{the message|the expression}0 in %select{a static assertion|this asm operand}0 must be produced by a constant expression'
 H9571480E2335: '%select{訊息|運算式}0 在 %select{static assertion|這個asm運算元}0 中必須由常數運算式產生'
 # "%select{the message|the expression}0 in %select{a static assertion|this asm operand}0 must have a '%select{size|data}1()' member function returning an object convertible to '%select{std::size_t|const char *}1'"
-HE077A8EBD022: "%select{訊息|運算式}0 在 %select{static assertion|這個asm運算元}0 中必須具有回傳可轉換為'%select{std::size_t|const char *}1'的'%select{size|data}1()'成員函數"
+HE077A8EBD022: "%select{訊息|運算式}0 在 %select{static assertion|這個asm運算元}0 中必須具有回傳可轉換為 '%select{std::size_t|const char *}1' 的 '%select{size|data}1()' 成員函數"
 # '%select{the message|the expression}0 in %select{this static assertion|this asm operand}0 is not a constant expression'
 H1136016D414E: '%select{訊息|運算式}0 在 %select{此static assertion|這個asm運算元}0 中不是常數運算式'
 # '%select{too few|too many}0 template arguments for %select{class template|function template|variable template|alias template|template template parameter|concept|template}1 %2'
 HA3BFC0466346: '%select{模板參數過少|模板參數過多}0 對於%select{類別模板|函式模板|變數模板|別名模板|模板模板參數|概念|模板}1 %2'
 # '%select{too few|too many}0 template parameters in template %select{|template parameter }1redeclaration'
-H2FC8E4427754: '%select{模板參數過少|模板參數過多}0 在模板%select{|模板參數 }1重宣告中'
+H2FC8E4427754: '%select{模板參數過少|模板參數過多}0 在模板 %select{|模板參數 }1重宣告中'
 # '%select{too few|too many}0 template parameters in template template argument'
 HEDDF73011D6C: '%select{模板參數過少|模板參數過多}0 在模板模板參數中'
 # '%select{too many|too few}0 elements in vector %select{initialization|operand}3 (expected %1 elements, have %2)'
@@ -1431,9 +1431,9 @@ HF8F02B43BB62: '%select{值|類型}0依賴的運算式被傳遞給除錯命令�
 # '%select{variable|static data member}0 instantiated with function type %1'
 HE6193A7D74C4: '%select{變數|靜態資料成員}0以函式類型 %1 實體化'
 # '%select{via initialization of|binding reference}0 variable %select{%2 |}1here'
-HB0440A5001E5: '%select{透過初始化|綁定參考}0 變數%select{%2 |}1在此處'
+HB0440A5001E5: '%select{透過初始化|綁定參考}0 變數 %select{%2 |}1 在此處'
 # "%select{virtual method|function pointer}0 cannot be inferred '%1'"
-H57712FD11644: "%select{虛方法|函式指標}0無法推斷'%1'"
+H57712FD11644: "%select{虛方法|函式指標}0無法推斷 '%1'"
 # '%select{void function|void method|constructor|destructor}1 %0 must not return a value'
 HE90DDC8579B5: '%select{void函式|void方法|建構子|析構子}1 %0 必須不可傳回值'
 # '%select{void function|void method|constructor|destructor}1 %0 should not return a value'
@@ -1443,9 +1443,9 @@ HEBA1B65B6166: '%select{wide|Unicode}0 字元字面值不能包含多個字元'
 # "%select{x86|x86-64}0 'interrupt' attribute only applies to functions that have %select{a 'void' return type|only a pointer parameter optionally followed by an integer parameter|a pointer as the first parameter|a %2 type as the second parameter}1"
 H6EAE552C7EA8: "%select{x86|x86-64}0 'interrupt' 屬性僅適用於返回類型%select{為 'void'|具有可選後跟整數參數的指標參數|以指標作為第一個參數|%2 類型作為第二個參數}1的函數"
 # "%select{|'%1-%2' }0diagnostics %select{with '%2' severity |}0%select{expected|seen}3 but not %select{seen|expected}3: %4"
-H6E1DC1644300: "%select{|'%1-%2' }0診斷%select{具有'%2'嚴重性 |}0%select{期望|檢測到}3 但未%select{檢測到|期望}3：%4"
+H6E1DC1644300: "%select{|'%1-%2' }0診斷%select{具有 '%2' 嚴重性 |}0%select{期望|檢測到}3 但未%select{檢測到|期望}3：%4"
 # '%select{|a template declaration|an explicit template specialization|an explicit template instantiation}0 can only %select{|declare|declare|instantiate}0 a single entity'
-HCEE3630F178B: '%select{|模板宣告|明確模板特化|明確模板實體化}0 只能%select{|宣告|宣告|實體化}0 單一實體'
+HCEE3630F178B: '%select{|模板宣告|明確模板特化|明確模板實體化}0 只能 %select{|宣告|宣告|實體化}0 單一實體'
 # "%select{|captured }1%0 parameter marked 'called_once' is never called"
 H5EDD8753404F: "%select{|捕獲的 }1%0 標記為 'called_once' 的參數從未被調用"
 # '%select{|captured }1completion handler is never called'
@@ -1453,7 +1453,7 @@ H31A1FA39F285: '%select{|被捕獲的 }1完成處理器從未被呼叫'
 # "%select{|change to 'snprintf' for explicit bounds checking | buffer pointer and size may not match|string argument is not guaranteed to be null-terminated|'va_list' is unsafe}0"
 H071DEF637982: "%select{|改為使用 'snprintf' 進行明確邊界檢查 |緩衝區指標和大小可能不匹配|字串參數不保證以空終結|'va_list' 是不安全}0"
 # '%select{|direct }0%select{method|property}1 declaration conflicts with previous %select{|direct }2declaration of %select{method|property}1 %3'
-H1D02391D3A58: '%select{|直接 }0%select{方法|屬性}1 宣告與先前%select{|直接 }2宣告的%select{方法|屬性}1 %3 冲突'
+H1D02391D3A58: '%select{|直接 }0%select{方法|屬性}1 宣告與先前 %select{|直接 }2宣告的%select{方法|屬性}1 %3 冲突'
 # '%select{|empty }0%select{struct|union}1 has size 0 in C, %select{size 1|non-zero size}2 in C++'
 HEA8D8C4B49F9: '%select{|空的 }0%select{struct|union}1 在C中大小為 0，在C++中%select{大小為 1|非零大小}2'
 # "%select{|implicit }0use of 'this' pointer is only allowed within the evaluation of a call to a 'constexpr' member function"
@@ -1471,7 +1471,7 @@ H03EFD19ED92A: '%select{|成員}0 使用宣告 %1 實例化為空包'
 # '%select{|non-aggregate }0type %1 cannot be initialized with an initializer list'
 H94A9DAA06E2F: '%select{|非聚合 }0類型 %1 不能用初始值列表初始化'
 # '%select{|overriding }1method cannot be unavailable on %0 when %select{the protocol method it implements|its overridden method}1 is available'
-H11BFB9C90008: '%select{|覆寫 }1方法當實作協定的方法%select{|或被覆寫的方法}1 在 %0 可用時不可標示為不可用'
+H11BFB9C90008: '%select{|覆寫 }1方法當實作協定的方法 %select{|或被覆寫的方法}1 在 %0 可用時不可標示為不可用'
 # '%select{|overriding }4method %select{introduced after|deprecated before|obsoleted before}0 %select{the protocol method it implements|overridden method}4 on %1 (%2 vs. %3)'
 H3102E4185799: '%select{|覆寫 }4方法 %select{在...後引入|在...前已棄用|在...前已廢止}0 %select{它實作的協定方法|覆寫的方法}4 在 %1 上 (%2 對 %3)'
 # '%select{|pointer to |reference to }0incomplete type %1 is not allowed in exception specification'
@@ -1489,7 +1489,7 @@ H3E89611A15B6: '%select{|引用 }0無大小類型 %1 不允許出現在例外規
 # '%select{|second }0%1 token is here'
 H00E98F1D44F7: '%select{|第二個 }0%1 令牌在此處'
 # '%select{|static_cast|reinterpret_cast|dynamic_cast|C-style cast|functional-style cast|}0 from %1 to %2 uses deleted function%select{|: %4}3'
-HD806C936F5D9: '%select{|static_cast|reinterpret_cast|dynamic_cast|C-style cast|函式樣式 cast|}0 從 %1 轉換到 %2 使用了已被刪除的函數%select{|: %4}3'
+HD806C936F5D9: '%select{|static_cast|reinterpret_cast|dynamic_cast|C-style cast|函式樣式 cast|}0 從 %1 轉換到 %2 使用了已被刪除的函數 %select{|: %4}3'
 # '%select{|success |failure }0memory order argument to atomic operation is invalid'
 HFAC869D2863E: '%select{|成功 |失敗 }0原子運算的記憶體順序參數無效'
 # "%select{|umbrella }0header '%1' not found"
@@ -1503,7 +1503,7 @@ H4BC2B3E593E1: '%select{||reinterpret_cast||C型式轉換||}0 從向量 %1 到�
 # '%select{||reinterpret_cast||C-style cast||}0 from vector %1 to vector %2 of different size'
 H855233AE0D42: '%select{||reinterpret_cast||C型式轉換||}0 從向量 %1 到不同大小的向量 %2 的轉換'
 # "%select{|||||virtual function called on|dynamic_cast applied to|typeid applied to|construction of|destruction of}0 object '%1' whose dynamic type is not constant"
-H292A692F3948: "%select{|||||呼叫虛函數於|dynamic_cast套用於|typeid套用於|建立|銷毀}0物件'%1'，其動態類型並非固定"
+H292A692F3948: "%select{|||||呼叫虛函數於|dynamic_cast套用於|typeid套用於|建立|銷毀}0物件 '%1'，其動態類型並非固定"
 # "'##' cannot appear at end of __VA_OPT__ argument"
 H2B78B6D67ACA: "'##' 無法出現在 __VA_OPT__ 參數的結尾處"
 # "'##' cannot appear at end of macro expansion"
@@ -1529,15 +1529,15 @@ H8053A181B977: "'#pragma alloc_text' 只適用於具有C連結的函數"
 # "'#pragma clang arc_cf_code_audited' was not ended within this file"
 H3175433AA2FB: "'#pragma clang assume_nonnull' 在此檔案中未結束"
 # "'#pragma clang assume_nonnull' was not ended within this file"
-H344021929D5B: "'#pragma clang assume_nonnull'未在此檔案中結束"
+H344021929D5B: "'#pragma clang assume_nonnull' 未在此檔案中結束"
 # "'#pragma clang attribute %select{%1.|}0pop' with no matching '#pragma clang attribute %select{%1.|}0push'"
-H170B16ACF46E: "'#pragma clang attribute %select{%1.|}0pop'沒有對應的'#pragma clang attribute %select{%1.|}0push'"
+H170B16ACF46E: "'#pragma clang attribute %select{%1.|}0pop' 沒有對應的 '#pragma clang attribute %select{%1.|}0push'"
 # "'#pragma clang attribute push' regions ends here"
-HF6A5F5655AB0: "'#pragma clang attribute push'區塊在此結束"
+HF6A5F5655AB0: "'#pragma clang attribute push' 區塊在此結束"
 # "'#pragma clang attribute' attribute with no matching '#pragma clang attribute push'"
-HAAE6327E2566: "'#pragma clang attribute'屬性沒有對應的'#pragma clang attribute push'"
+HAAE6327E2566: "'#pragma clang attribute' 屬性沒有對應的 '#pragma clang attribute push'"
 # "'#pragma comment %0' ignored"
-HEB14674C1594: "'#pragma comment %0'被忽略"
+HEB14674C1594: "'#pragma comment %0' 被忽略"
 # "'#pragma float_control push/pop' can only appear at file or namespace scope or within a language linkage specification"
 H053264F8F924: "'#pragma float_control(except, on)' 在 precise 關閉時非法"
 # "'#pragma float_control(except, on)' is illegal when precise is disabled"
@@ -1547,31 +1547,31 @@ H922887ACFECE: "'#pragma float_control(precise, off)' 在 fenv_access 啟用時�
 # "'#pragma float_control(precise, off)' is illegal when fenv_access is enabled"
 HAFA440F76585: "'#pragma init_seg' 只在目標為 Microsoft 環境時支援"
 # "'#pragma init_seg' is only supported when targeting a Microsoft environment"
-H4E91F2EF3757: "'#pragma init_seg'僅在針對Microsoft環境時支援"
+H4E91F2EF3757: "'#pragma init_seg' 僅在針對Microsoft環境時支援"
 # "'#pragma omp %0' %select{|with '%2' clause }1cannot be an immediate substatement"
-HA805BCE4C312: "'#pragma omp %0' %select{|帶有'%2'子句 }1不能是立即子語句"
+HA805BCE4C312: "'#pragma omp %0' %select{|帶有 '%2' 子句 }1不能是立即子語句"
 # "'#pragma omp %0' directive must appear only in file scope"
-H3C04CBDE708E: "'#pragma omp %0'指令必須出現在檔案作用域"
+H3C04CBDE708E: "'#pragma omp %0' 指令必須出現在檔案作用域"
 # "'#pragma omp %0' must appear in the scope of the %q1 variable declaration"
 HCD521713958F: "'#pragma omp %0' 必須在 %q1 變數的所有引用前出現"
 # "'#pragma omp %0' must precede all references to variable %q1"
-HA982E769431D: "'#pragma omp %0'必須出現在變數%q1的所有引用之前"
+HA982E769431D: "'#pragma omp %0' 必須出現在變數%q1的所有引用之前"
 # "'#pragma omp declare %select{simd|variant}0' can only be applied to functions"
 HC2DB961C6B39: "'#pragma omp declare %select{simd|variant}0' 只能套用於函數"
 # "'#pragma omp declare variant' cannot be applied for function after first usage; the original function might be used"
-H504957D176C7: "'#pragma omp declare variant'無法套用在函數首次使用後；原函數可能已被使用"
+H504957D176C7: "'#pragma omp declare variant' 無法套用在函數首次使用後；原函數可能已被使用"
 # "'#pragma omp declare variant' cannot be applied to the function that was defined already; the original function might be used"
-HB5A7CD5EEB6F: "'#pragma omp declare variant'無法套用在已定義的函數；原函數可能已被使用"
+HB5A7CD5EEB6F: "'#pragma omp declare variant' 無法套用在已定義的函數；原函數可能已被使用"
 # "'#pragma omp declare variant' does not support %select{function templates|virtual functions|deduced return types|constructors|destructors|deleted functions|defaulted functions|constexpr functions|consteval function}0"
-H240B964685D1: "'#pragma omp declare variant'不支援%select{函數範型|虛函數|推論傳回類型|建構函數|解構函數|已刪除函數|預設函數|constexpr函數|consteval函數}0"
+H240B964685D1: "'#pragma omp declare variant' 不支援%select{函數範型|虛函數|推論傳回類型|建構函數|解構函數|已刪除函數|預設函數|constexpr函數|consteval函數}0"
 # "'#pragma omp declare variant' is not compatible with any target-specific attributes"
-HDFFC2CD6FA69: "'#pragma omp declare variant'與任何目標特定屬性不相容"
+HDFFC2CD6FA69: "'#pragma omp declare variant' 與任何目標特定屬性不相容"
 # "'#pragma omp end assumes' with no matching '#pragma omp begin assumes'"
-HAF63C041427E: "'#pragma omp end assumes'沒有對應的'#pragma omp begin assumes'"
+HAF63C041427E: "'#pragma omp end assumes' 沒有對應的 '#pragma omp begin assumes'"
 # "'#pragma omp end declare variant' with no matching '#pragma omp begin declare variant'"
-HD60959180819: "'#pragma omp end declare variant'沒有對應的'#pragma omp begin declare variant'"
+HD60959180819: "'#pragma omp end declare variant' 沒有對應的 '#pragma omp begin declare variant'"
 # "'#pragma unsafe_buffer_usage' was not ended"
-H8FB2F039CC57: "'#pragma unsafe_buffer_usage'未結束"
+H8FB2F039CC57: "'#pragma unsafe_buffer_usage' 未結束"
 # "'$' in identifier"
 HB5654708DC14: "'$' 在識別符中"
 # "'%%n' specifier not supported on this platform"
@@ -1585,9 +1585,9 @@ H140C3ABC4AE4: "'%0' 參數被忽略；之前已指定 '%1' 參數"
 # "'%0' and '%1' clause are mutually exclusive and may not appear on the same directive"
 H124967FEEE58: "'%0' 與 '%1' 子句互斥，不可在同一指令中同時出現"
 # "'%0' argument on '%1' clause is not permitted on a%select{|n orphaned}2 '%3' construct%select{| associated with a '%5' compute construct}4"
-H43AC213E21A0: "'%0' 參數不可用於%select{|孤兒}2 '%3' 結構%select{|與 '%5' 計算構造相關聯}4 的 '%1' 子句上"
+H43AC213E21A0: "'%0' 參數不可用於 %select{|孤兒}2 '%3' 結構 %select{|與 '%5' 計算構造相關聯}4 的 '%1' 子句上"
 # "'%0' argument to '%1' clause not allowed on a '%2' construct%select{| associated with a '%4' construct}3 that has a '%5' clause"
-H08457CF75CEB: "'%0' 子句的'%1'參數在與具有 '%5' 子句的'%2'%select{|與 '%4' 結構相關}3 結構不被允許"
+H08457CF75CEB: "'%0' 子句的 '%1' 參數在與具有 '%5' 子句的 '%2'%select{|與 '%4' 結構相關}3 結構不被允許"
 # "'%0' as a module map name is deprecated, rename it to %select{module.modulemap|module.private.modulemap}1%select{| in the 'Modules' directory of the framework}2"
 H871445ACDF0B: "'%0' 模組映射名稱已棄用，請重新命名為 %select{module.modulemap|module.private.modulemap}1%select{|在框架的 'Modules' 資料夾中}2"
 # "'%0' attribute cannot be specified on a definition"
@@ -1615,7 +1615,7 @@ H0985DFE3C8AA: "'%0' 的轉換在未使用 ARC 時無效"
 # "'%0' clause is specified here"
 H573F42F97FF4: "'%0' 子句在此處指定"
 # "'%0' clause not allowed on a 'kernels loop' construct that has a '%1' clause with a%select{n| 'num'}2 argument"
-HA63B4E6AC69A: "具有%select{n| 'num'}2 參數的 '%1' 子句的 'kernels loop' 構造不可指定 '%0' 子句"
+HA63B4E6AC69A: "具有 %select{n| 'num'}2 參數的 '%1' 子句的 'kernels loop' 構造不可指定 '%0' 子句"
 # "'%0' clause requires 'dispatch' context selector"
 H94FAB67C930A: "'%0' 子句需要 'dispatch' 環境選擇器"
 # "'%0' clause specifies a loop count greater than the number of available loops"
@@ -1641,15 +1641,15 @@ HF167BCD9180C: "'%0' 被宣告為型別 %1 的函數陣列"
 # "'%0' declared as array of references of type %1"
 H07B7977DE9AC: "'%0' 被宣告為型別 %1 的參考陣列"
 # "'%0' directive cannot follow %select{'%2' directive|other expected directives}1"
-H81459AA5C045: "'%0' 指令不能跟隨%select{'%2' 指令|其他期望指令}1"
+H81459AA5C045: "'%0' 指令不能跟隨 %select{'%2' 指令|其他期望指令}1"
 # "'%0' directive found here"
 H689CAA47B15F: "'%0' 指令在此處發現"
 # "'%0' does not contain a GCC installation"
 H5EA2B901E3DD: "'%0' 不包含GCC安裝"
 # "'%0' does not support '-%1'; flag ignored"
-H5F193B6442A3: "'%0' 不支援'-%1'；旗標被忽略"
+H5F193B6442A3: "'%0' 不支援 '-%1'；旗標被忽略"
 # "'%0' does not support '-moutline'; flag ignored"
-H8FCF49E8EFFE: "'%0' 不支援'-moutline'；旗標被忽略"
+H8FCF49E8EFFE: "'%0' 不支援 '-moutline'；旗標被忽略"
 # "'%0' evaluates to a null function pointer"
 HC166C9B46BC9: "'%0' 評估為空函數指標"
 # "'%0' file not found"
@@ -1657,7 +1657,7 @@ HE40852833202: "'%0' 檔案未找到"
 # '\'%0\' file not found with <angled> %select{include|import}1; use "quotes" instead'
 HB65E7D8C29D0: "'%0' 檔案未使用<尖括號> %select{包含|匯入}1找到；請改用「雙引號」"
 # "'%0' file not found, did you mean '%1'?"
-HA3BAEA90173D: "'%0' 檔案未找到，是否意指'%1'？"
+HA3BAEA90173D: "'%0' 檔案未找到，是否意指 '%1'？"
 # "'%0' function must have a prototype"
 H161348B5A00F: "'%0' 函數必須具有原型"
 # "'%0' ignored on this declaration"
@@ -1665,7 +1665,7 @@ H3A73EC6937F0: "'%0' 在此宣告中被忽略"
 # "'%0' included multiple times, additional include site here"
 H67346CC37DF8: "'%0' 被多次包含，額外包含位置在此處"
 # "'%0' included multiple times, additional include site in header from module '%1'"
-HC2226976DFB3: "'%0' 被多次包含，額外包含位置在模組'%1'的標頭檔中"
+HC2226976DFB3: "'%0' 被多次包含，額外包含位置在模組 '%1' 的標頭檔中"
 # "'%0' invalid for input of type %1"
 H0F254F5D0DEC: "'%0' 無法轉換為類型 %1 的輸入"
 # "'%0' is a C11 extension"
@@ -1733,9 +1733,9 @@ H76B771A1DA3E: "'%0' 只適用於%select{函數|指標|Objective-C物件或區�
 # "'%0' only applies to medium and large code models"
 H2B43B16BADDB: "'%0' 選項僅適用於中等與大型程式碼模型"
 # "'%0' option requires target HLSL Version >= 2018%select{| and shader model >= 6.2}1, but HLSL Version is '%2'%select{| and shader model is '%3'}1"
-H73FD169C1664: "'%0' 選項需要HLSL版本≥2018%select{|且著色器模型≥6.2}1，但目前HLSL版本為'%2'%select{|且著色器模型為'%3'}1"
+H73FD169C1664: "'%0' 選項需要HLSL版本≥2018%select{|且著色器模型≥6.2}1，但目前HLSL版本為 '%2'%select{|且著色器模型為 '%3'}1"
 # "'%0' parameter can only be used with swiftcall%select{ or swiftasynccall|}1 calling convention%select{|s}1"
-H7F6C0A7A9011: "'%0' 參數只能與swiftcall%select{或swiftasynccall|}1呼叫約定%select{搭配使用|}1"
+H7F6C0A7A9011: "'%0' 參數只能與swiftcall%select{或swiftasynccall|}1 呼叫約定%select{搭配使用|}1"
 # "'%0' parameter must have pointer%select{| to unqualified pointer}1 type; type here is %2"
 HA49C073BB7A8: "'%0' 參數必須是%select{未限定指標|指標}1類型；目前類型為 %2"
 # "'%0' previously encountered here"
@@ -1745,35 +1745,35 @@ HD3C37F48AA10: "'%0' 修飾詞不得用於建構子"
 # "'%0' qualifier is not allowed on a destructor"
 H63A821EC7A98: "'%0' 修飾詞不得用於解構子"
 # "'%0' qualifier may not appear after the virtual specifier '%1'"
-HC82C66448381: "'%0' 限定詞不能出現在虛函數指定符'%1'之後"
+HC82C66448381: "'%0' 限定詞不能出現在虛函數指定符 '%1' 之後"
 # "'%0' qualifier may not be applied to a reference"
 H39DF4A724F57: "'%0' 限定詞不能應用在參考類型上"
 # "'%0' qualifier on function type %1 has no effect"
-HCA4F5C288E32: "函式類型 %1 上的'%0' 限定詞無效"
+HCA4F5C288E32: "函式類型 %1 上的 '%0' 限定詞無效"
 # "'%0' qualifier on function type %1 has no effect and is a Clang extension"
-HA82B1E90695B: "函式類型 %1 上的'%0' 限定詞無效（此為Clang擴充功能）"
+HA82B1E90695B: "函式類型 %1 上的 '%0' 限定詞無效（此為Clang擴充功能）"
 # "'%0' qualifier on omitted return type %1 has no effect"
-H226C520C0A5C: "省略的返回類型 %1 上的'%0' 限定詞無效"
+H226C520C0A5C: "省略的返回類型 %1 上的 '%0' 限定詞無效"
 # "'%0' qualifier on reference type %1 has no effect"
-H9D5F7EA85F79: "參考類型 %1 上的'%0' 限定詞無效"
+H9D5F7EA85F79: "參考類型 %1 上的 '%0' 限定詞無效"
 # "'%0' qualifier%s1 on base class type %2 %plural{1:has|:have}1 no effect"
-HB4BF74C2E9A3: "基底類別類型 %2 上的'%0' 限定詞%s1%plural{1:無效|:無效}1"
+HB4BF74C2E9A3: "基底類別類型 %2 上的 '%0' 限定詞%s1%plural{1:無效|:無效}1"
 # "'%0' region encountered before requires directive with '%1' clause"
 HAC48A5EE380D: "'%0' 區塊在具有 '%1' 子句的requires指令之前出現"
 # "'%0' required by '%1'"
-H149191A7D780: "'%0' 被'%1'所要求"
+H149191A7D780: "'%0' 被 '%1' 所要求"
 # "'%0' required for precompiled header not found"
-HBDA853057C16: "所需的'%0' 預編譯標頭未找到"
+HBDA853057C16: "所需的 '%0' 預編譯標頭未找到"
 # "'%0' size argument is too large; destination buffer has size %1, but size argument is %2"
 H1B04445BBECB: "'%0' 長度參數過大；目標緩衝區大小為 %1，但指定長度為 %2"
 # "'%0' specifier is not allowed outside a class definition"
 H496E8612120E: "'%0' 限定詞不能出現在類別定義之外"
 # "'%0' statement cannot be used in OpenMP for loop"
-HB1E296AE95BC: "OpenMP for 迴圈中不能使用'%0' 語句"
+HB1E296AE95BC: "OpenMP for 迴圈中不能使用 '%0' 語句"
 # "'%0' statement cannot be used in OpenMP simd region"
-H1C587C7353B1: "OpenMP simd 區塊中不能使用'%0' 語句"
+H1C587C7353B1: "OpenMP simd 區塊中不能使用 '%0' 語句"
 # "'%0' type not found; include <omp.h>"
-H4CF50F4E769F: "未找到'%0' 類型；請包含<omp.h>"
+H4CF50F4E769F: "未找到 '%0' 類型；請包含 <omp.h>"
 # "'%0' type qualifier%s1 on return type %plural{1:has|:have}1 no effect"
 H065A9C128711: "'%0' 在回傳類型上的類型修飾符%s1%plural{1:對回傳類型無效|:對回傳類型無效}1"
 # "'%0' type specifier is incompatible with C++98"
@@ -1803,11 +1803,11 @@ HEA339F2E046F: "'%0': 無法在此工具中使用AST檔案"
 # "'%0': unable to use module files with this tool"
 H25C074B573CF: "'%0': 無法在此工具中使用模組檔案"
 # "'%0(%select{source|sink:vec}1)' clause%select{|s}1 cannot be mixed with '%0(%select{sink:vec|source}1)' clause%select{s|}1"
-H081C849E3FF9: "'%0(%select{source|sink:vec}1)' 子句%select{|s}1 無法與 '%0(%select{sink:vec|source}1)' 子句%select{s|}1 混合使用"
+H081C849E3FF9: "'%0(%select{source|sink:vec}1)' 子句 %select{|s}1 無法與 '%0(%select{sink:vec|source}1)' 子句 %select{s|}1 混合使用"
 # "'%1' attribute on property %0 does not match the property inherited from %2"
 H0392738DA622: "'%1' 屬性在屬性 %0 與從 %2 繼承的屬性不相符"
 # "'%1' cannot be used in %select{a constructor|a destructor|the 'main' function|a constexpr function|a function with a deduced return type|a varargs function|a consteval function}0"
-HB2DCA2D92D0E: "'%select{建構函數|析構函數|'main' 函數|constexpr函數|具有推論回傳類型的函數|可變參數函數|consteval函數}0'中不能使用'%1'"
+HB2DCA2D92D0E: "'%select{建構函數|析構函數|'main' 函數|constexpr函數|具有推論回傳類型的函數|可變參數函數|consteval函數}0'中不能使用 '%1'"
 # "'%select{#|#@}0' is not followed by a macro parameter"
 HFFC615C42B6A: "'%select{#|#@}0' 後未跟隨宏參數"
 # "'%select{%select{memcpy|wmemcpy}1|%select{memmove|wmemmove}1}0' not supported: %select{size to copy (%4) is not a multiple of size of element type %3 (%5)|source is not a contiguous array of at least %4 elements of type %3|destination is not a contiguous array of at least %4 elements of type %3}2"
@@ -1817,41 +1817,41 @@ H0D1F0E4F63B2: "'%select{*|.*}0' 指定的欄位%select{寬度|精確度}0 缺�
 # "'%select{--|++}0' on an object of complex type is a C2y extension"
 HDA93C21904C8: "'%select{--|++}0' 運算子作用於複數類型物件是C2y擴展"
 # "'%select{--|++}0' on an object of complex type is incompatible with C standards before C2y"
-H20E81B85B020: "'%select{--|++}0'運算子作用於複雜類型物件與C2y之前C標準不相容"
+H20E81B85B020: "'%select{--|++}0' 運算子作用於複雜類型物件與C2y之前C標準不相容"
 # "'%select{\\|@}0%1' command does not terminate a verbatim text block"
-H42F81A2BAA36: "'%select{\\|@}0%1'指令未結束直譯文字區塊"
+H42F81A2BAA36: "'%select{\\|@}0%1' 指令未結束直譯文字區塊"
 # "'%select{\\|@}0%1' command has %plural{0:no|:%2}2 word argument%s2, expected %3"
 HBEDC67E6720C: "'%select{\\|@}0%1' 命令具有 %plural{0:無|:%2}2 個單字參數，期望 %3"
 # "'%select{\\|@}0%1' command used in a comment that is attached to a %select{function returning void|constructor|destructor|method returning void}2"
-HFBFA65D15A47: "'%select{\\|@}0%1'指令用於附加至%select{回傳void類型的函數|建構函數|析構函數|回傳void類型的方法}2的註解中"
+HFBFA65D15A47: "'%select{\\|@}0%1' 指令用於附加至%select{回傳void類型的函數|建構函數|析構函數|回傳void類型的方法}2的註解中"
 # "'%select{\\|@}0%1' command used in a comment that is not attached to a function or method declaration"
-H9A9CB5F0CECC: "'%select{\\|@}0%1'指令用於未附加至函數或方法宣告的註解中"
+H9A9CB5F0CECC: "'%select{\\|@}0%1' 指令用於未附加至函數或方法宣告的註解中"
 # "'%select{\\|@}0%select{classdesign|coclass|dependency|helper|helperclass|helps|instancesize|ownership|performance|security|superclass}1' command should not be used in a comment attached to a non-container declaration"
-H63CA64568B3F: "'%select{\\|@}0%select{classdesign|coclass|dependency|helper|helperclass|helps|instancesize|ownership|performance|security|superclass}1'指令不應用於附加至非容器宣告的註解中"
+H63CA64568B3F: "'%select{\\|@}0%select{classdesign|coclass|dependency|helper|helperclass|helps|instancesize|ownership|performance|security|superclass}1' 指令不應用於附加至非容器宣告的註解中"
 # "'%select{\\|@}0%select{class|interface|protocol|struct|union}1' command should not be used in a comment attached to a non-%select{class|interface|protocol|struct|union}2 declaration"
-H2B2D23C85C31: "'%select{\\|@}0%select{class|interface|protocol|struct|union}1'指令不應用於附加至非 %select{class|interface|protocol|struct|union}2 宣告的註解中"
+H2B2D23C85C31: "'%select{\\|@}0%select{class|interface|protocol|struct|union}1' 指令不應用於附加至非 %select{class|interface|protocol|struct|union}2 宣告的註解中"
 # "'%select{\\|@}0%select{function|functiongroup|method|methodgroup|callback}1' command should be used in a comment attached to %select{a function|a function|an Objective-C method|an Objective-C method|a pointer to function}2 declaration"
-H30965075CCD3: "'%select{\\|@}0%select{function|functiongroup|method|methodgroup|callback}1'指令應用於附加至%select{函數|函數|Objective-C方法|Objective-C方法|函數指標}2宣告的註解中"
+H30965075CCD3: "'%select{\\|@}0%select{function|functiongroup|method|methodgroup|callback}1' 指令應用於附加至%select{函數|函數|Objective-C方法|Objective-C方法|函數指標}2宣告的註解中"
 # "'%select{\\|@}0param' command used in a comment that is not attached to a function declaration"
-HA6D99227D713: "'%select{\\|@}0param'指令用於未附加至函數宣告的註解中"
+HA6D99227D713: "'%select{\\|@}0param' 指令用於未附加至函數宣告的註解中"
 # "'%select{\\|@}0tparam' command used in a comment that is not attached to a template declaration"
-H78D96F6B0A65: "'%select{\\|@}0tparam'指令用於未附加至範型宣告的註解中"
+H78D96F6B0A65: "'%select{\\|@}0tparam' 指令用於未附加至範型宣告的註解中"
 # "'%select{auto|decltype(auto)}0' in return type deduced as %1 here but deduced as %2 in earlier return statement"
-HDFEF08FDDF8E: "'%select{auto|decltype(auto)}0'在回傳類型中 %1 在此處被推論，但與先前的return語句中推論為 %2 產生衝突"
+HDFEF08FDDF8E: "'%select{auto|decltype(auto)}0' 在回傳類型中 %1 在此處被推論，但與先前的return語句中推論為 %2 產生衝突"
 # "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' argument cannot refer to a union member"
-HF50BCD9CECE6: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0'參數不能引用共用體成員"
+HF50BCD9CECE6: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' 參數不能引用共用體成員"
 # "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' argument must be a simple declaration reference"
-HF6AC15305460: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0'參數必須是簡單宣告引用"
+HF6AC15305460: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' 參數必須是簡單宣告引用"
 # "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' cannot be applied to a union member"
-H01022C27C2BB: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0'不能應用於共用體成員"
+H01022C27C2BB: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' 不能應用於共用體成員"
 # "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' only applies to pointers%select{ or C99 flexible array members|||}0%select{|; did you mean to use 'counted_by'?}1"
-H077E0A5BF4C4: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0'只能用於指標%select{或C99彈性陣列成員|||}0%select{; 是否應使用 'counted_by'?|}1"
+H077E0A5BF4C4: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' 只能用於指標%select{或C99彈性陣列成員|||}0%select{; 是否應使用 'counted_by'?|}1"
 # "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' requires a non-boolean integer type argument"
-H69D52A4DAF87: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0'需要非布林整數類型參數"
+H69D52A4DAF87: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' 需要非布林整數類型參數"
 # "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}1' field %0 isn't within the same struct as the annotated %select{pointer|flexible array}2"
-HBD3F5637D173: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}1'標記的 %0 欄位與被註解的%select{指標|彈性陣列}2不在同一結構體中"
+HBD3F5637D173: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}1' 標記的 %0 欄位與被註解的%select{指標|彈性陣列}2不在同一結構體中"
 # "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}4' %select{cannot|should not}3 be applied to %select{a pointer with pointee|an array with element}0 of unknown size because %1 is %select{an incomplete type|a sizeless type|a function type|a struct type with a flexible array member%select{|. This will be an error in a future compiler version}3}2"
-HEFA740A9E276: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}4' %select{不能|不應}3 應用於 %select{指標所指向的|陣列元素}0 無法確定大小的類型，因為 %1 是 %select{不完整類型|無大小類型|函數類型|包含可調節長度陣列的結構類型%select{|。此處將在未來版本編譯器中成為錯誤}3}2"
+HEFA740A9E276: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}4' %select{不能|不應}3 應用於 %select{指標所指向的|陣列元素}0 無法確定大小的類型，因為 %1 是 %select{不完整類型|無大小類型|函數類型|包含可調節長度陣列的結構類型 %select{|。此處將在未來版本編譯器中成為錯誤}3}2"
 # "'%select{if|switch}0' initialization statements are a C++17 extension"
 HBFF569602D2E: "'%select{if|switch}0' 初始化語句是 C++17 擴充"
 # "'%select{make_unsigned|make_signed}0' is only compatible with non-%select{bool|_BitInt(1)}1 integers and enum types, but was given %2%select{| whose underlying type is %4}3"
@@ -1925,7 +1925,7 @@ HF4121BB98E1E: "帶有訊息的 '= delete' 與 C++2c 之前的標準不相容"
 # "'@encode' of incomplete type %0"
 H26BBB8B07598: "'@encode' 的不完整類型 %0"
 # "'@end' appears where closing brace '}' is expected"
-H0D104C2A47DE: "'@end' 出現在期望有閉合大括號'}' 的位置"
+H0D104C2A47DE: "'@end' 出現在期望有閉合大括號 '}' 的位置"
 # "'@end' must appear in an Objective-C context"
 H53F73799BBFE: "'@end' 必須出現在 Objective-C 環境中"
 # "'NSObject' attribute is for pointer types only"
@@ -2177,7 +2177,7 @@ H021467CD0886: "C++ 中未指定 'extern' 的 'gnu_inline' 屬性會被視為外
 # "'hybrid_patchable' is ignored on functions without external linkage"
 H0ADF7398ED3A: "'hybrid_patchable' 會被忽略於無外部連結性的函數"
 # "'inline' can only appear on functions%select{| and non-local variables}0"
-H89E78E1738F9: "'inline' 只能出現在函數%select{| 和非局部變數}0 上"
+H89E78E1738F9: "'inline' 只能出現在函數 %select{| 和非局部變數}0 上"
 # "'inscan' modifier can be used only in 'omp for', 'omp simd', 'omp for simd', 'omp parallel for', or 'omp parallel for simd' directive"
 HD994FA838907: "'inscan' 修飾詞只能用在 'omp for'、'omp simd'、'omp for simd'、'omp parallel for' 或 'omp parallel for simd' 指令中"
 # "'internal_linkage' attribute on a non-static local variable is ignored"
@@ -2261,7 +2261,7 @@ H01CEEA4215DD: "'new' 不能分配一個不具顯式所有權的 %0 類型陣列
 # "'new' cannot allocate object of variably modified type %0"
 HB68377C1CB34: "'new' 不能分配變數長度類型 %0 的物件"
 # "'new' cannot allocate objects of type %0 in address space '%1'"
-H8F2EE8209986: "'new' 無法分配地址空間'%1'中的類型 %0"
+H8F2EE8209986: "'new' 無法分配地址空間 '%1' 中的類型 %0"
 # "'new' expression with placement arguments refers to non-placement 'operator delete'"
 H9A938FDFCB36: '帶有置位參數的new運算式引用了非置位的operator delete'
 # "'nocf_check' attribute ignored; use -fcf-protection to enable the attribute"
@@ -2311,7 +2311,7 @@ HC1D7E6DA4A9D: "在此處宣告的 'operator->' 會產生類型為 %0 的物件"
 # "'ordered' clause with a parameter cannot be specified in '#pragma omp %0' directive"
 HE291A06801DB: "在 '#pragma omp %0' 指令中，不能指定帶有參數的 'ordered' 子句"
 # "'ordered' clause%select{| with specified parameter}0"
-H337028DA61A4: "'ordered' 子句%select{| 帶有指定參數}0"
+H337028DA61A4: "'ordered' 子句 %select{| 帶有指定參數}0"
 # "'ordered' directive %select{without any clauses|with 'threads' clause}0 cannot be closely nested inside ordered region with specified parameter"
 HB16FD1003ED0: "'ordered' 指令 %select{未指定任何子句|具有 'threads' 子句}0 不能緊密嵌套在帶有指定參數的 ordered 區域內"
 # "'ordered' directive with '%0' clause cannot be closely nested inside ordered region without specified parameter"
@@ -2375,7 +2375,7 @@ H01C26A9D5D7B: "'size_t' 字面值的後綴與C++23之前的標準不相容"
 # "'static' can only be specified inside the class definition"
 HC2C3574A2AC5: "'static' 只能在類定義內部指定"
 # "'static' function %0 declared in header file should be declared 'static inline'"
-HAC6B8325923D: "在標頭檔中宣告的靜態函數 %0 應宣告為'static inline'"
+HAC6B8325923D: "在標頭檔中宣告的靜態函數 %0 應宣告為 'static inline'"
 # "'static' may not be used with an unspecified variable length array size"
 H8C886B8B17D3: "未指定的可變長度陣列大小不能與 'static' 一起使用"
 # "'static' may not be used without an array size"
@@ -2393,11 +2393,11 @@ H89070CD2F991: "無訊息的 'static_assert' 是C++17的擴充功能"
 # "'static_assert' with no message is incompatible with C++ standards before C++17"
 HFE8F37E6AE5C: "無訊息的 'static_assert' 與C++17之前的標準不相容"
 # "'std::allocator<...>::deallocate' used to delete a null pointer"
-HF2B279909DBC: "使用'std::allocator<...>::deallocate'刪除空指標"
+HF2B279909DBC: "使用 'std::allocator<...>::deallocate' 刪除空指標"
 # "'std::source_location::__impl' must be standard-layout and have only two 'const char *' fields '_M_file_name' and '_M_function_name', and two integral fields '_M_line' and '_M_column'"
-HCA27D3915F0B: "'std::source_location::__impl'必須是標準佈局類別，且僅有兩個'const char *'型別的欄位 '_M_file_name' 和 '_M_function_name'，以及兩個整數型別的欄位 '_M_line' 和 '_M_column'"
+HCA27D3915F0B: "'std::source_location::__impl' 必須是標準佈局類別，且僅有兩個 'const char *' 型別的欄位 '_M_file_name' 和 '_M_function_name'，以及兩個整數型別的欄位 '_M_line' 和 '_M_column'"
 # "'std::source_location::__impl' was not found; it must be defined before '__builtin_source_location' is called"
-HD0F806FB73A8: "未找到'std::source_location::__impl'；它必須在呼叫 '__builtin_source_location' 之前被定義"
+HD0F806FB73A8: "未找到 'std::source_location::__impl'；它必須在呼叫 '__builtin_source_location' 之前被定義"
 # "'super' is only valid in a method body"
 HB06D73D4C0E7: "'super' 只能在方法主體中使用"
 # "'swift_async' completion handler parameter must have block type returning 'void', type here is %0"
@@ -2443,11 +2443,11 @@ HB5D291C13072: "成員函數 %0 的 'this' 參數類型為 %1，但該函數未�
 # "'this' argument to member function %0 is an %select{lvalue|rvalue}1, but function has %select{non-const lvalue|rvalue}2 ref-qualifier"
 H0AF4BFFD004C: "成員函數 %0 的 'this' 參數是 %select{lvalue|rvalue}1，但函數具有%select{非 const lvalue|rvalue}2 型別限定符"
 # "'this' cannot be %select{implicitly |}0captured in this context"
-H0697D44E3441: "'this' 在此語境中無法%select{隱式 |}0被捕獲"
+H0697D44E3441: "'this' 在此語境中無法%select{隱式 |}0 被捕獲"
 # "'this' cannot be captured by reference"
 H13B6762030CD: "'this' 不能以引用形式被捕獲"
 # "'this' cannot be%select{| implicitly}0 used in a static member function declaration"
-H4C9AC15A6831: "'this' 指標不能在靜態成員函數宣告中%select{| 隱式}0使用"
+H4C9AC15A6831: "'this' 指標不能在靜態成員函數宣告中 %select{| 隱式}0使用"
 # "'this' pointer cannot be null in well-defined C++ code; comparison may be assumed to always evaluate to %select{true|false}0"
 HC979F6DEC864: "'this' 指標在符合C++語法的程式中不能為空；比較可能被假設始終評估為 %select{true|false}0"
 # "'this' pointer cannot be null in well-defined C++ code; pointer may be assumed to always convert to true"
@@ -2505,7 +2505,7 @@ H7DDAB71DFE28: "'void' 指定時必須是第一個也是唯一的參數"
 # "'||' of a value and its negation always evaluates to true"
 H067D990351EF: "'||' 運算子的值與其反運算結果總為true"
 # "'~' in destructor name should be after nested name specifier"
-H85ED3FE9838A: "析構函數名稱中的'~' 應位於嵌套名稱限定符之後"
+H85ED3FE9838A: "析構函數名稱中的 '~' 應位於嵌套名稱限定符之後"
 # "(Deprecated) Controls whether '-Winvalid-gnu-asm-cast' defaults to an error or a warning"
 HBE7A04BC29B9: "(已棄用) 控制 '-Winvalid-gnu-asm-cast' 預設是否為錯誤或警告"
 # "(For new pass manager) 'per-pass': one report for each pass; 'per-pass-run': one report for each pass invocation"
@@ -3761,7 +3761,7 @@ H66ADFA49B9E1: '套用反覆的後處理以推斷正確的BFI計數。'
 # 'Apply edits to analyzed source files'
 HFDE3C74EED4D: '套用修改至已分析的原始檔。'
 # 'Apply first slot optimization for stack tagging (eliminate ADDG Rt, Rn, 0, 0).'
-H2ADE0B593B04: '套用首槽優化於堆疊標記（消除ADDG Rt, Rn, 0, 0指令）。'
+H2ADE0B593B04: '套用首槽優化於堆疊標記（消除ADDG Rt, Rn, 0, 0 指令）。'
 # 'Apply fix-it advice creating a file with the given suffix'
 H2BD66E062CA1: '套用修正建議以建立具有指定副檔名的檔案。'
 # 'Apply fix-it advice even in the presence of unfixable errors'
@@ -4241,7 +4241,7 @@ H505EEFB93C8E: 'CL.EXE相容選項'
 # 'COFF Symbol RVAs (DEBUG_S_COFF_SYMBOL_RVA subsection)'
 HFE26A86E5CFD: 'COFF符號RVAs（DEBUG_S_COFF_SYMBOL_RVA子區段）'
 # "CPU '%0' does not support '%1' execution mode"
-H489FB3B6F514: "CPU '%0'不支援'%1'執行模式"
+H489FB3B6F514: "CPU '%0' 不支援 '%1' 執行模式"
 # 'CPU list contains duplicate entries; attribute ignored'
 H40F374760829: 'CPU清單包含重複項目；屬性被忽略'
 # 'CSKY DAG->DAG Pattern Instruction Selection'
@@ -4267,7 +4267,7 @@ H4386F29D7C1C: "CUDA 特殊函數 '%0' 必須具有純量返回類型"
 # 'CUDA version %0 is only partially supported'
 HABB5F3AD45B9: 'CUDA 版本 %0 僅部分支援'
 # 'CUDA version%0 is newer than the latest%select{| partially}1 supported version %2'
-HC8470F3A3C10: 'CUDA 版本 %0 比最新%select{| 部分}1支援的版本 %2 更新'
+HC8470F3A3C10: 'CUDA 版本 %0 比最新 %select{| 部分}1支援的版本 %2 更新'
 # 'CXX Dump Options'
 HEC70FF6EBB76: 'CXX 輸出選項'
 # 'CXX Map Options'
@@ -4523,7 +4523,7 @@ H089CBD249A00: '用於過濾日誌中動作的來源位置的逗號分隔清單�
 # "Comma-separated list of comment prefixes to use from check file\n(defaults to 'COM,RUN'). Please avoid using this feature in\nLLVM's LIT-based test suites, which should be easier to\nmaintain if they all follow a consistent comment style. This\nfeature is meant for non-LIT test suites using FileCheck."
 H40AA0BE08629: '從檢查檔案使用的註解前綴的逗號分隔清單（預設為「COM,RUN」）。\n請避免在LLVM的LIT基礎測試套件中使用此功能，若所有套件均遵循一致的註解風格，將更易於維護。\n此功能主要針對使用FileCheck而非LIT的測試套件。'
 # "Comma-separated list of globs describing the list of callbacks to output. Globs are processed in order of appearance. Globs with the '-' prefix remove callbacks from the set. e.g. '*,-Macro*'."
-HB2EA0F3C4C38: "以逗號分隔的通配模式清單，描述要輸出的回呼。通配模式按出現順序處理。以'-'前綴的通配模式將從集合中移除回呼。例如：'*,-Macro*'。"
+HB2EA0F3C4C38: "以逗號分隔的通配模式清單，描述要輸出的回呼。通配模式按出現順序處理。以 '-' 前綴的通配模式將從集合中移除回呼。例如：'*,-Macro*'。"
 # 'Comma-separated list of vectorizer passes. If not set we run the predefined pipeline.'
 H5F9267E8F02A: '向量化器pass的列表。若未設定則執行預定義的管線。'
 # 'Command line options to pass to the downstream compiler.'
@@ -4541,7 +4541,7 @@ H10812CD37717: '比較選項'
 # 'Compare all elements.'
 HD1160DBAE7C6: '比較所有元素。'
 # 'Compare bits 62 and 61 of address (TBI should be disabled)'
-HC1881DEFBF5A: '比較地址的第 62 和 61位元（TBI應被禁用）'
+HC1881DEFBF5A: '比較地址的第 62 和 61 位元（TBI應被禁用）'
 # 'Compare with the result of XPAC (requires Armv8.3-a)'
 HBA5A269FECBF: '與XPAC的結果進行比較（需要Armv8.3-a）'
 # 'Compare with the result of XPACLRI'
@@ -4673,7 +4673,7 @@ HE1318392829D: '控制vtordisp的放置位置'
 # 'Control vtordisp placement on win32 targets'
 H1B28D470DA9E: '控制win32目標的vtordisp放置位置'
 # "Control where files for distributed backends are created. Expects 'oldprefix;newprefix' and if path prefix of output file is oldprefix it will be replaced with newprefix."
-HC0263D605A37: "控制分散後端的檔案建立位置。期望值為'oldprefix;newprefix'，如果輸出檔案的路徑前綴為oldprefix，則會被替換為newprefix。"
+HC0263D605A37: "控制分散後端的檔案建立位置。期望值為 'oldprefix;newprefix'，如果輸出檔案的路徑前綴為oldprefix，則會被替換為newprefix。"
 # 'Control whether the compiler can use scalable vectors to vectorize a loop'
 H6A90BC2050A3: '控制編譯器是否可以使用可擴展向量來向量化一個迴圈'
 # 'Control whether unstable and experimental library features are enabled. This option enables various library features that are either experimental (also known as TSes), or have been but are not stable yet in the selected Standard Library implementation. It is not recommended to use this option in production code, since neither ABI nor API stability are guaranteed. This is intended to provide a preview of features that will ship in the future for experimentation purposes'
@@ -5551,7 +5551,7 @@ H9F6E8121BA35: '停用不可分配的物理寄存器複製優化'
 # 'Disable odd single-precision floating point registers'
 HC69012E33908: '停用奇數單精準度浮點寄存器'
 # "Disable omitting 'dls lr, lr' instructions"
-HBB8A633ECC4C: "停用省略'dls lr, lr'指令"
+HBB8A633ECC4C: "停用省略 'dls lr, lr' 指令"
 # 'Disable on-demand initialization of thread-local variables'
 HD53AA5AC4AC6: '停用按需初始化的執行緒局部變數'
 # 'Disable one or more combiner rules temporarily in '
@@ -6357,7 +6357,7 @@ H2C209A90E709: '不要發出以下參數的未使用參數警告'
 # "Don't error out if the detected version of the CUDA install is too low for the requested CUDA gpu architecture."
 H16AC4195802C: '如果偵測到的CUDA安裝版本低於請求的CUDA GPU架構要求，則不顯示錯誤'
 # "Don't expand conditional move related pseudos for Mips 16"
-H68A3ACC276BC: '不展開Mips 16相關的條件移動偽指令'
+H68A3ACC276BC: '不展開Mips 16 相關的條件移動偽指令'
 # "Don't export branch data (LCOV)"
 H15B1E91EF10C: '不匯出分支資料（LCOV）'
 # "Don't export expanded source regions"
@@ -7007,7 +7007,7 @@ H2EC78B18E661: '在 Global ISel 中啟用 / 禁用可擴展向量（SVE）'
 # 'Enable / disable promotion of unnamed_addr constants into constant pools'
 HFAE28EE53BD3: '啟用 / 禁用將無名址常量提升至常量池'
 # 'Enable 16-bit types and disable min precision types.Available in HLSL 2018 and shader model 6.2.'
-HAAC77E9561C2: '啟用 16 位元類型並禁用最小精度類型。適用於HLSL 2018和著色器模型 6.2。'
+HAAC77E9561C2: '啟用 16 位元類型並禁用最小精度類型。適用於HLSL 2018 和著色器模型 6.2。'
 # 'Enable <feature> in module map requires declarations'
 H5C8DA92AFFD8: '在 module map 的 requires 宣告中啟用 <feature>'
 # 'Enable AArch64 SME memory operations to lower to librt functions'
@@ -8497,7 +8497,7 @@ HE1AD57EFF1BD: '用於視圖分割的合併器名稱'
 # 'Folds all regular instructions (including pre-outputs)'
 HB765A3FB1AB5: '合併所有常規指令（包括預輸出）'
 # 'Follow Fortran 2003 rules for (re)allocating the LHS of the intrinsic assignment'
-H1CD29CD7E654: '遵循Fortran 2003規則來（重新）分配內建賦值的左操作數（LHS）'
+H1CD29CD7E654: '遵循Fortran 2003 規則來（重新）分配內建賦值的左操作數（LHS）'
 # 'Follow the AAPCS standard requirement stating that volatile bit-field width is dictated by the field container type. (ARM only).'
 H318AB39D2C02: '遵循AAPCS標準要求，即volatile位段的寬度由該位段的容器類型決定。（僅限ARM）'
 # 'Follows the AAPCS standard that all volatile bit-field write generates at least one load. (ARM only).'
@@ -8517,9 +8517,9 @@ HFC5FF11ED2AC: '對MachO，禁用基於atexit()的全域析構函數降級處理
 # 'For a large interval, if it is coalesced with other live intervals many times more than the threshold, stop its coalescing to control the compile time. '
 H31454C2664AA: '若某大區間與其他活躍區間的合併次數超過閾值多倍，則停止其合併以控制編譯時間'
 # "For a list of available CPUs for the target use '-mcpu=help'"
-HFB257544DEA1: "如需列出目標支援的CPU清單，請使用'-mcpu=help'"
+HFB257544DEA1: "如需列出目標支援的CPU清單，請使用 '-mcpu=help'"
 # "For a list of available architectures for the target use '-mcpu=help'"
-HCFFD910F1E45: "如需列出目標支援的架構清單，請使用'-mcpu=help'"
+HCFFD910F1E45: "如需列出目標支援的架構清單，請使用 '-mcpu=help'"
 # 'For all options that iterate over modules, ignore modules from system libraries'
 HF30AFF2F9F8C: '對所有需遍歷模組的選項，忽略系統函式庫的模組'
 # 'For all options that iterate over modules, limit to the specified module'
@@ -9215,7 +9215,7 @@ H5EEF255AAE70: '通用選項'
 # 'Generic memory optimizations'
 H800F1622EB9A: '通用記憶體最佳化'
 # 'Get the symbol definition from <line> <start-column> <end-column>'
-H9C96E5C80114: '從 <line> <start-column> <end-column>取得符號定義'
+H9C96E5C80114: '從 <line> <start-column> <end-column> 取得符號定義'
 # 'Give each function an independent TBAA tree (default)'
 H7A952E99A7FC: '為每個函數提供獨立的TBAA樹（預設值）'
 # 'Give global C++ operator new and delete declarations hidden visibility'
@@ -9641,7 +9641,7 @@ H2050B14C1C4D: '忽略RecMII'
 # 'Ignore TTI attributes compatibility check between callee/caller during inline cost calculation'
 H6DBD3A9D0CF3: '在內聯成本計算期間忽略呼叫者與被呼叫者之間的TTI屬性相容性檢查'
 # "Ignore all DWARF data. This relaxes the requirements for all statically linked libraries to have been compiled with '-g', but will result in false positives for 'CFI unprotected' instructions."
-H39BB8E06FB84: "忽略所有DWARF資料。這會鬆弛所有靜態連結函式庫必須使用'-g'編譯的要求，但會導致'CFI未受保護'指令出現誤判。"
+H39BB8E06FB84: "忽略所有DWARF資料。這會鬆弛所有靜態連結函式庫必須使用 '-g' 編譯的要求，但會導致'CFI未受保護'指令出現誤判。"
 # 'Ignore attribute objc_direct so that direct methods can be tested'
 HCF66187C2621: '忽略objc_direct屬性以測試直接方法'
 # 'Ignore balance information, always return (1: Even, 2: Odd).'
@@ -9781,9 +9781,9 @@ HC64F11374476: '將CUDA裝置端二進位碼整合至主物件文件中。'
 # 'Increase alignment of LDS if it is not on align boundary'
 H6B6D9E0BE911: '若未對齊，則增加LDS的對齊值'
 # "Increases 'x86-br-merging-base-cost' in cases that it is likely that all conditionals will be executed. For example for merging the conditionals (a == b && c > d), if its known that a == b is likely, then it is likely that if the conditionals are split both sides will be executed, so it may be desirable to increase the instruction cost threshold. Set to -1 to never merge likely branches."
-H9238554A10FA: "在所有條件式可能都會執行的情況下，增加'x86-br-merging-base-cost'的值。例如在合併條件式 (a == b && c > d) 時，若已知 a == b 是高機率執行，則條件式若被分割成兩邊執行時，可能需要提高指令成本閾值。設為-1將永遠不合併高機率分支。"
+H9238554A10FA: "在所有條件式可能都會執行的情況下，增加 'x86-br-merging-base-cost' 的值。例如在合併條件式 (a == b && c > d) 時，若已知 a == b 是高機率執行，則條件式若被分割成兩邊執行時，可能需要提高指令成本閾值。設為-1將永遠不合併高機率分支。"
 # "Increases 'x86-br-merging-base-cost' in cases that the target supports conditional compare instructions."
-H0EFC5555FAAB: "在目標支援條件式比較指令時，增加'x86-br-merging-base-cost'的值。"
+H0EFC5555FAAB: "在目標支援條件式比較指令時，增加 'x86-br-merging-base-cost' 的值。"
 # 'Incremental depth computation will be used for basic blocks with more instructions.'
 HE1566572AE0C: '對指令數量較多的基本區塊，使用遞增深度計算。'
 # 'Index of module to extract'
@@ -10031,7 +10031,7 @@ HD3F623D56EDC: '保留所有基準測試（預設）'
 # 'Keep all non-cold contexts (increases cloning overheads)'
 H4544ED3678BF: '保留所有非冷卻的上下文（會增加複製開銷）'
 # 'Keep aside the last <num-test-traces> traces in the profile when computing the function order and instead use them to evaluate that order'
-H77D85A9D26A6: '在計算函數順序時，將分析中的最後<num-test-traces>個追蹤資料保留一旁，並改用它們來評估該順序'
+H77D85A9D26A6: '在計算函數順序時，將分析中的最後 <num-test-traces> 個追蹤資料保留一旁，並改用它們來評估該順序'
 # 'Keep copies of symbols in LTO indexing'
 HB94AF3670BCE: '在 LTO 索引中保留符號的複本'
 # 'Keep going on errors encountered'
@@ -10233,7 +10233,7 @@ HEAF5A10A6293: '每區塊限制 SLP 排程區域的大小'
 # 'Limit the size of the seed bundle to cap compilation time.'
 H4DFB40A73CC1: '限制種子包的大小以限制編譯時間。'
 # 'Limits the range of tokens in -check file on which various features are tested. Example --check-lines=3-7 restricts testing to lines 3 to 7 (inclusive) or --check-lines=5 to restrict to one line. Default is testing entire file.'
-H2A6188976AA0: '限制在-check文件中測試各項功能的token範圍。例如--check-lines=3-7將測試範圍限制在第 3 到 7行（包含），或--check-lines=5限制到單一行。預設是測試整個檔案。'
+H2A6188976AA0: '限制在-check文件中測試各項功能的token範圍。例如--check-lines=3-7將測試範圍限制在第 3 到 7 行（包含），或--check-lines=5限制到單一行。預設是測試整個檔案。'
 # 'Linalg ODS Gen from YAML'
 H78D204B7569D: '從YAML生成Linalg ODS'
 # 'Line kind to use when printing lines.'
@@ -10367,7 +10367,7 @@ HAAA0526E734E: '位置與變數'
 # 'Locations only'
 H997812E5B96A: '僅位置'
 # "Log action execution to a file, or stderr if  '-' is passed"
-H7DDDF7706229: "將動作執行記錄到檔案中，若傳入'-'則輸出到標準錯誤"
+H7DDDF7706229: "將動作執行記錄到檔案中，若傳入 '-' 則輸出到標準錯誤"
 # 'Look up implicit modules in the prebuilt module path'
 H7389FC31B294: '在預建模組路徑中查找隱含模組'
 # 'LoongArch DAG->DAG Pattern Instruction Selection'
@@ -11595,7 +11595,7 @@ H18CDEE7EFD75: "OpenACC 'routine' 指令若指定函數名稱，將指向與下�
 # "OpenACC 'tile' clause size expression must be %select{an asterisk or a constant expression|positive integer value, evaluated to %1}0"
 HA638C30812B2: "OpenACC 'tile' 子句尺寸運算式必須是%select{星號或常量運算式|評估為 %1 的正整數值}0"
 # "OpenACC 'update' construct may not appear in place of the statement following a%select{n if statement| while statement| do statement| switch statement| label statement}0"
-H3E931AFE1E4E: "OpenACC 'update' 建構不能出現在%select{if 陳述式|while 陳述式|do 陳述式|switch 陳述式|label 陳述式}0 之後的陳述式位置"
+H3E931AFE1E4E: "OpenACC 'update' 建構不能出現在 %select{if 陳述式|while 陳述式|do 陳述式|switch 陳述式|label 陳述式}0 之後的陳述式位置"
 # "OpenACC clause '%0' may not appear on the same construct as a '%1' clause on a '%2' construct"
 HFD5E5BF152EC: "OpenACC '%2' 建構中不可同時出現 '%0' 與 '%1' 子句"
 # "OpenACC clause '%0' may not follow a '%1' clause in a '%2' construct"
@@ -11637,7 +11637,7 @@ H5FFA8811F2EF: "OpenACC 變數 %select{在 'use_device' 子句中|在 'declare' 
 # 'OpenACC variable in cache directive is not a valid sub-array or array element'
 H0DEC3018E66D: 'OpenACC cache 指令中的變數不是有效的子陣列或陣列元素'
 # 'OpenACC variable is not a valid variable name, sub-array, array element,%select{| member of a composite variable,}0 or composite variable member'
-HA8B26141C7C6: 'OpenACC變數不是有效的變數名稱、子陣列、陣列元素%select{|合成變數的成員，}0，或是合成變數的成員'
+HA8B26141C7C6: 'OpenACC變數不是有效的變數名稱、子陣列、陣列元素 %select{|合成變數的成員，}0，或是合成變數的成員'
 # 'OpenCL extension %0 is core feature or supported optional core feature - ignoring'
 H1E2DAA7C8DD9: 'OpenCL 擴展 %0 是核心功能或支援的選擇性核心功能 - 無視'
 # 'OpenCL extension %0 unknown or does not require pragma - ignoring'
@@ -11679,7 +11679,7 @@ HBFAEB31DF5F3: 'OpenMP 捕獲區域尚未支援 %select{流式函數|具有 ZA �
 # "OpenMP clause '%0' is only available as extension, use '-fopenmp-extensions'"
 H7D732B734761: "OpenMP 子句 '%0' 是擴展功能，請使用 '-fopenmp-extensions'"
 # 'OpenMP constructs may not be nested inside a simd region%select{| except for ordered simd, simd, scan, or atomic directive}0'
-HC65424272817: 'OpenMP 結構不得嵌套在 simd 區域內%select{|，但 ordered simd、simd、scan 或 atomic 指令除外}0'
+HC65424272817: 'OpenMP 結構不得嵌套在 simd 區域內 %select{|，但 ordered simd、simd、scan 或 atomic 指令除外}0'
 # 'OpenMP constructs may not be nested inside an atomic region'
 HE2C47884F9E6: 'OpenMP 結構不得嵌套在 atomic 區域內'
 # "OpenMP extension clause '%0' only allowed with '#pragma omp %1'"
@@ -11703,13 +11703,13 @@ H6461D2D7A8F6: "OpenMP 目標無效: '%0'"
 # 'Optimise without changing ABI'
 H19D2D13E9ED7: '在不改變ABI的情況下進行優化'
 # 'Optimization level 0. Similar to clang -O0. Same as -passes="default<O0>"'
-H809F6417B5CD: '優化級別 0。與clang -O0類似。與-passes="default<O0>"相同'
+H809F6417B5CD: '優化級別 0。與clang -O0類似。與-passes="default<O0>" 相同'
 # 'Optimization level 1. Similar to clang -O1. Same as -passes="default<O1>"'
-H563E0780E60E: '優化級別 1。與clang -O1類似。與-passes="default<O1>"相同'
+H563E0780E60E: '優化級別 1。與clang -O1類似。與-passes="default<O1>" 相同'
 # 'Optimization level 2. Similar to clang -O2. Same as -passes="default<O2>"'
-H71099B09BC66: '優化級別 2。與clang -O2類似。與-passes="default<O2>"相同'
+H71099B09BC66: '優化級別 2。與clang -O2類似。與-passes="default<O2>" 相同'
 # 'Optimization level 3. Similar to clang -O3. Same as -passes="default<O3>"'
-H73EA61C4E41D: '優化級別 3。與clang -O3類似。與-passes="default<O3>"相同'
+H73EA61C4E41D: '優化級別 3。與clang -O3類似。與-passes="default<O3>" 相同'
 # 'Optimization level for NVVM compilation'
 HA23F3D2204EA: 'NVVM編譯的優化級別'
 # "Optimization level. [-O0, -O1, -O2, or -O3] (default = '-O2')"
@@ -11719,7 +11719,7 @@ HEFDDA07D8CA1: '包含由cgscc內聯重播的內聯註解的優化註解文件�
 # 'Optimization remarks file containing inline remarks to be replayed by inlining from sample profile loader.'
 H7FC66DD3A1D4: '包含由樣本剖面載入器的內聯進行重播的內聯註解的優化註解文件。'
 # 'Optimizations available (use "-passes=" for the new pass manager)'
-H61E922DB15A6: '可用的優化（使用"-passes="以使用新的pass管理器）'
+H61E922DB15A6: '可用的優化（使用 "-passes=" 以使用新的pass管理器）'
 # 'Optimize AArch64 selected instructions'
 HC4CE467B7223: '優化AArch64選取的指令'
 # 'Optimize LiveIntervals for WebAssembly'
@@ -11905,7 +11905,7 @@ H76E82EB3BAF1: '輸出啟動核心的資源使用情況'
 # 'Output the total number corresponding to the count for the provided input file.'
 H8049C03B1803: '輸出與提供的輸入檔案計數對應的總數。'
 # "Output trace to the given file name or '-' for stdout."
-H8DCBEA863061: "將追蹤輸出到指定的檔案名稱或使用'-'表示標準輸出。"
+H8DCBEA863061: "將追蹤輸出到指定的檔案名稱或使用 '-' 表示標準輸出。"
 # 'Outputs for view.'
 H377C2CC892EF: '用於顯示的輸出。'
 # 'Overapproximation of dependences'
@@ -13073,13 +13073,13 @@ H3692DAF330DE: 'RISC-V原子假指令展開pass'
 # 'RISC-V gather/scatter lowering pass'
 H05AC68772FF6: 'RISC-V gather/scatter降階pass'
 # "RISC-V interrupt attribute '%0' requires extension '%1'"
-H6CFF2777C071: "RISC-V中斷屬性'%0'需要擴展'%1'"
+H6CFF2777C071: "RISC-V中斷屬性 '%0' 需要擴展 '%1'"
 # 'RISC-V post-regalloc pseudo instruction expansion pass'
 H7D576AB43EFF: 'RISC-V寄存器分配後假指令展開pass'
 # 'RISC-V pseudo instruction expansion pass'
 H0A43861EEE99: 'RISC-V虛指令展開Pass'
 # "RISC-V type %0 requires the '%1' extension"
-HD2DE400562E4: "RISC-V類型 %0 需要'%1'擴展"
+HD2DE400562E4: "RISC-V類型 %0 需要 '%1' 擴展"
 # 'ROCm device library path. Alternative to rocm-path.'
 H671F96D79AC7: 'ROCm裝置庫路徑。rocm-path的替代選項。'
 # 'ROCm installation path, used for finding and automatically linking required bitcode libraries.'
@@ -13283,7 +13283,7 @@ H16B0416B17A1: '重新打包所有在任何維度上非連續的陣列。若設�
 # 'Repeat compilation N times for timing'
 HD8053595EBB4: '重複編譯N次以測量時間'
 # "Replace 'mul x, Const' with more effective instructions like SHIFT, LEA, etc."
-HC54A5626311D: "將'mul x, Const'替換為更有效的指令，如SHIFT、LEA等"
+HC54A5626311D: "將 'mul x, Const' 替換為更有效的指令，如SHIFT、LEA等"
 # 'Replace ARM non-local ADR instructions with ADRP'
 H4558533FD5F3: '將ARM的非局部ADR指令替換為ADRP'
 # 'Replace PHIs by their incoming values'
@@ -13975,7 +13975,7 @@ HA1F9E472551C: '選擇教程版本'
 # 'Select underlying type for wchar_t'
 H871CFB3D3DBF: '設定wchar_t的底層類型'
 # "Select which XRay instrumentation points to emit. Options: all, none, function-entry, function-exit, function, custom. Default is 'all'.  'function' includes both 'function-entry' and 'function-exit'."
-HF1CF9325D610: "選擇要發射的XRay插樁點類型。選項：all、none、function-entry、function-exit、function、custom。預設為 'all'。 'function' 包含 'function-entry'和'function-exit'。"
+HF1CF9325D610: "選擇要發射的XRay插樁點類型。選項：all、none、function-entry、function-exit、function、custom。預設為 'all'。 'function' 包含 'function-entry' 和 'function-exit'。"
 # 'Select which denormal numbers the code is permitted to require'
 H2AC882EF26F4: '設定程式允許要求的非規格化數值類型'
 # 'Select which denormal numbers the code is permitted to require for float'
@@ -14223,9 +14223,9 @@ H7736F9C56939: '設定WebAssembly載入和儲存的p2align操作數'
 # 'Set the parallelization strategy'
 HF0A794612D46: '設定並行化策略'
 # "Set the profile instrumentation burst duration, which can range from 1 to the value of 'sampled-instr-period' (0 is invalid). This number of samples will be recorded for each 'sampled-instr-period' count update. Setting to 1 enables simple sampling, in which case it is recommended to set 'sampled-instr-period' to a prime number."
-H5CA10C80C24A: "設定配置文件插樁的突发持續時間，其範圍從 1 到'sampled-instr-period'的值（0無效）。每個'sampled-instr-period'計數更新將記錄此數量的樣本。設置為 1 可啟用簡易採樣，此時建議將'sampled-instr-period'設置為質數。"
+H5CA10C80C24A: "設定配置文件插樁的突发持續時間，其範圍從 1 到 'sampled-instr-period' 的值（0無效）。每個 'sampled-instr-period' 計數更新將記錄此數量的樣本。設置為 1 可啟用簡易採樣，此時建議將 'sampled-instr-period' 設置為質數。"
 # "Set the profile instrumentation sample period. A sample period of 0 is invalid. For each sample period, a fixed number of consecutive samples will be recorded. The number is controlled by 'sampled-instr-burst-duration' flag. The default sample period of 65536 is optimized for generating efficient code that leverages unsigned short integer wrapping in overflow, but this is disabled under simple sampling (burst duration = 1)."
-HC029DE20A3E1: "設定配置文件插樸的採樣週期。0的採樣週期無效。每個採樣週期將記錄固定數量的連續樣本。此數量由'sampled-instr-burst-duration'旗標控制。預設的 65536 採樣週期經過最佳化，可生成有效使用無符號短整數溢位的程式碼，但在簡易採樣（burst duration=1）時此功能被禁用。"
+HC029DE20A3E1: "設定配置文件插樸的採樣週期。0的採樣週期無效。每個採樣週期將記錄固定數量的連續樣本。此數量由 'sampled-instr-burst-duration' 旗標控制。預設的 65536 採樣週期經過最佳化，可生成有效使用無符號短整數溢位的程式碼，但在簡易採樣（burst duration=1）時此功能被禁用。"
 # "Set the rsp quoting to either 'posix', or 'windows'"
 HFF7A11383873: "設定rsp引號格式為 'posix' 或 'windows'"
 # 'Set the stack alignment'
@@ -14831,9 +14831,9 @@ H8693C7688390: '指定要對齊的分支類型'
 # 'Specify types of branches to align (plus separated list of types):\njcc      indicates conditional jumps\nfused    indicates fused conditional jumps\njmp      indicates direct unconditional jumps\ncall     indicates direct and indirect calls\nret      indicates rets\nindirect indicates indirect unconditional jumps'
 H3D330EC77559: '指定要對齊的分支類型（以+號分隔的類型列表）:\njcc      指示條件式跳轉\nfused    指示融合式條件式跳轉\njmp      指示直接無條件跳轉\ncall     指示直接和間接呼叫\nret      指示rets\nindirect 指示間接無條件跳轉'
 # 'Specify wavefront size 32 mode (AMDGPU only)'
-HA9AC5ACEB8A1: '指定wavefront size 32模式（僅AMDGPU）'
+HA9AC5ACEB8A1: '指定wavefront size 32 模式（僅AMDGPU）'
 # 'Specify wavefront size 64 mode (AMDGPU only)'
-H33E655B3FFCB: '指定wavefront size 64模式（僅AMDGPU）'
+H33E655B3FFCB: '指定wavefront size 64 模式（僅AMDGPU）'
 # 'Specify where to find the compiled intrinsic modules'
 H60F443A1A2B8: '指定搜尋編譯後的內置模組的路徑'
 # 'Specify which frame pointers to retain.'
@@ -16127,7 +16127,7 @@ HCD3F9F572B30: '使用GlobalISel所需的合法性規則，而非嘗試使用與
 # 'Use HLFIR lowering (experimental)'
 HBF33CE828D70: '使用HLFIR降階（實驗性）'
 # 'Use IEEE 754 quadruple-precision for long double'
-H52864CA1A557: '使用IEEE 754四重精確度表示long double'
+H52864CA1A557: '使用IEEE 754 四重精確度表示long double'
 # 'Use INTEGER(KIND=8) for the result type in size-related intrinsics'
 H31BCF654D576: '在與大小相關的內建函數中使用INTEGER(KIND=8)作為結果類型'
 # 'Use InstrItineraryData for latency lookup'
@@ -16221,7 +16221,7 @@ HE1A472AB0CD6: '對函數中的第一個計數器（通常是入口計數器）�
 # 'Use base address specifiers in debug_ranges'
 H16F9B262870C: '在debug_ranges中使用基址指定符'
 # 'Use base and pass 1 discriminators'
-HFD9F1E3E9AB6: '使用基址和pass 1判別值'
+HFD9F1E3E9AB6: '使用基址和pass 1 判別值'
 # 'Use base and pass 1-2 discriminators'
 H8235CCC718A7: '使用基址和pass 1-2判別值'
 # 'Use base and pass 1-3 discriminators'
@@ -16381,7 +16381,7 @@ H609A25655FBA: '僅使用Doxygen樣式註解來生成文件。'
 # 'Use only register numbers when writing assembly output'
 H3A4857A621C3: '在寫入組裝輸出時僅使用寄存器編號'
 # "Use optimistic attributes describing 'as-if' properties of runtime calls."
-H4E943E97F387: "使用描述執行時間調用'as-if'屬性的樂觀屬性。"
+H4E943E97F387: "使用描述執行時間調用 'as-if' 屬性的樂觀屬性。"
 # 'Use packed stack layout (SystemZ only).'
 HD83EA715FFB0: '使用緊湊堆疊佈局（僅SystemZ）。'
 # 'Use page aliasing in HWASan'
@@ -17237,7 +17237,7 @@ HC15AE9021482: '__weak 屬性在未啟用 ARC 時不能用在自動變數上'
 # '`#pragma const_seg` for section %1 will not apply to %0 due to the presence of a %select{mutable field||non-trivial constructor|non-trivial destructor}2'
 H8811D5F6122A: '`#pragma const_seg` 對區段 %1 將不會套用到 %0，因為存在 %select{可變更的成員||非平凡建構函數|非平凡析構函數}2'
 # 'a %select{function|block}0 declaration without a prototype is deprecated %select{in all versions of C|}0'
-HA427D7F1B8D9: '一個沒有原型的%select{函數|區塊}0宣告在C的各個版本中已棄用%select{|}0'
+HA427D7F1B8D9: '一個沒有原型的%select{函數|區塊}0宣告在C的各個版本中已棄用 %select{|}0'
 # "a %select{pack indexing|'decltype'}0 specifier cannot be used in a declarative nested name specifier"
 H505B17716528: "%select{封包索引|'decltype'}0 指定項不能用在宣告式巢狀名稱指定項中"
 # 'a concept definition cannot refer to itself'
@@ -17307,7 +17307,7 @@ H878607247E5C: 'typedef不能是模板'
 # 'absolute value function %0 given an argument of type %1 but has parameter of type %2 which may cause truncation of value'
 H2B4AC1EEC989: '絕對值函數 %0 被傳遞了一個類型為 %1 的參數，但其參數類型為 %2，這可能會導致值被截斷'
 # "abstract class is marked '%select{final|sealed}0'"
-H9546D737D23E: '抽象類被標記為"%select{final|sealed}0"'
+H9546D737D23E: '抽象類被標記為 "%select{final|sealed}0"'
 # 'access declarations are deprecated; use using declarations instead'
 H3431BA5113E5: '訪問宣告已被棄用；請改用using宣告'
 # 'access qualifier %0 cannot be used for %1 %select{|prior to OpenCL C version 2.0 or in version 3.0 and without __opencl_c_read_write_images feature}2'
@@ -17387,7 +17387,7 @@ H540EC7EBFA01: '重新宣告時添加預設參數將使此建構函式成為%sel
 # 'address argument to atomic builtin cannot be const-qualified (%0 invalid)'
 H05DD72B70C0D: '原子內建函數的地址參數不能是const限定 (%0 錯誤)'
 # 'address argument to atomic builtin must be a pointer %select{|to a non-zero-sized object }1(%0 invalid)'
-H25FC8322E786: '原子內建函數的地址參數必須是%select{|指向非零大小物件的 }1指標 (%0 錯誤)'
+H25FC8322E786: '原子內建函數的地址參數必須是 %select{|指向非零大小物件的 }1指標 (%0 錯誤)'
 # 'address argument to atomic builtin must be a pointer to 1,2,4,8 or 16 byte type (%0 invalid)'
 H8F0926664FBC: '原子內建函數的地址參數必須是指向 1、2、4、8或 16 位元組型別的指標 (%0 錯誤)'
 # 'address argument to atomic builtin must be a pointer to integer or pointer (%0 invalid)'
@@ -17395,13 +17395,13 @@ H05518FC9E223: '原子內建函數的地址參數必須是指向整數或指標�
 # 'address argument to atomic builtin must be a pointer to integer, floating-point or pointer (%0 invalid)'
 H4BE1CF542714: '原子內建函數的地址參數必須是指向整數、浮點數或指標型別的指標 (%0 錯誤)'
 # 'address argument to atomic operation must be a pointer to %select{|atomic }0integer (%1 invalid)'
-H45F0D7833F1F: '原子運算的地址參數必須是指向%select{|原子 }0整數型別的指標 (%1 錯誤)'
+H45F0D7833F1F: '原子運算的地址參數必須是指向 %select{|原子 }0整數型別的指標 (%1 錯誤)'
 # 'address argument to atomic operation must be a pointer to %select{|atomic }0integer or pointer (%1 invalid)'
-HD792403A7931: '原子運算的地址參數必須是指向%select{|原子 }0整數或指標型別的指標 (%1 錯誤)'
+HD792403A7931: '原子運算的地址參數必須是指向 %select{|原子 }0整數或指標型別的指標 (%1 錯誤)'
 # 'address argument to atomic operation must be a pointer to %select{|atomic }0integer or supported floating point type (%1 invalid)'
-H645D002EEC1B: '原子運算的地址參數必須是指向%select{|原子 }0整數或支援的浮點數型別的指標 (%1 錯誤)'
+H645D002EEC1B: '原子運算的地址參數必須是指向 %select{|原子 }0整數或支援的浮點數型別的指標 (%1 錯誤)'
 # 'address argument to atomic operation must be a pointer to %select{|atomic }0integer, pointer or supported floating point type (%1 invalid)'
-HF8B6B0144FE9: '原子運算的地址參數必須是指向%select{|原子 }0整數、指標或支援的浮點數型別的指標 (%1 錯誤)'
+HF8B6B0144FE9: '原子運算的地址參數必須是指向 %select{|原子 }0整數、指標或支援的浮點數型別的指標 (%1 錯誤)'
 # 'address argument to atomic operation must be a pointer to _Atomic type (%0 invalid)'
 HED971913A5AB: '原子運算的地址參數必須是指向 _Atomic 類型的指標（%0 適用）'
 # 'address argument to atomic operation must be a pointer to a trivially-copyable type (%0 invalid)'
@@ -17523,21 +17523,21 @@ H5F21C338A420: 'alignof 表達式與 C++98 不相容'
 # 'all paths through this function will call itself'
 H40E0BDFB048F: '此函數的所有路徑都會調用自身'
 # "allocate directive specifies %select{default|'%1'}0 allocator while previously used %select{default|'%3'}2"
-HC639234B285B: "allocate指令指定%select{預設|'%1'}0配置器，而之前使用的是%select{預設|'%3'}2"
+HC639234B285B: "allocate指令指定%select{預設|'%1'}0 配置器，而之前使用的是%select{預設|'%3'}2"
 # 'allocated size %0 is not a multiple of size %1 of element type %2'
 H279696362CDE: '分配的大小 %0 不是元素類型 %2 大小 %1 的倍數'
 # "allocated with 'new%select{[]|}0' here"
-H1AA44259E5AA: "在此處使用'new%select{[]|}0'分配"
+H1AA44259E5AA: "在此處使用 'new%select{[]|}0' 分配"
 # 'allocating an object of abstract class type %0'
 H07CDBA71F9A5: '分配抽象類別類型 %0 的物件'
 # 'allocation of %select{incomplete|sizeless}0 type %1'
 HD40A80B2E772: '分配%select{不完整|無大小}0類型 %1'
 # 'allocation performed here was not deallocated%plural{0:|: (along with %0 other memory leak%s0)}0'
-H04A2F923450C: '此處的分配未被釋放%plural{0:|:（連同 %0 其他記憶體泄漏%s0）}0'
+H04A2F923450C: '此處的分配未被釋放 %plural{0:|:（連同 %0 其他記憶體泄漏%s0）}0'
 # "allocator must be specified in the 'uses_allocators' clause"
 H6A6EDC2E2834: "'uses_allocators' 子句必須指定配置器"
 # "allocator with the 'thread' trait access has unspecified behavior on '%0' directive"
-HDC686C65C1AA: "具有 'thread' 特性的配置器在'%0'指令上的存取行為未定義"
+HDC686C65C1AA: "具有 'thread' 特性的配置器在 '%0' 指令上的存取行為未定義"
 # "allocators used in 'uses_allocators' clause cannot appear in other data-sharing or data-mapping attribute clauses"
 H3D9F65EE1204: "'uses_allocators' 子句中的配置器不得出現在其他資料共享或資料映射屬性子句中"
 # 'allow processing of stripped binaries'
@@ -17547,13 +17547,13 @@ H8A45202314E0: '允許片段產生器產生最多該數量的配置'
 # "allowable client missing from %0: '%1'"
 H1792F22F4481: '%0 缺少允許的客戶端："%1"'
 # "allowable clients do not match: '%0' (provided) vs '%1' (found)"
-H73C7C1046F8D: '允許的客戶端不匹配："提供的 %0" vs "找到的 %1"'
+H73C7C1046F8D: '允許的客戶端不匹配："提供的 %0" vs " 找到的 %1"'
 # "already inside '#pragma clang arc_cf_code_audited'"
-H490BE327E34C: "已經在'#pragma clang arc_cf_code_audited'範圍內"
+H490BE327E34C: "已經在 '#pragma clang arc_cf_code_audited' 範圍內"
 # "already inside '#pragma clang assume_nonnull'"
-H59F0A861C85D: "已經在'#pragma clang assume_nonnull'範圍內"
+H59F0A861C85D: "已經在 '#pragma clang assume_nonnull' 範圍內"
 # "already inside '#pragma unsafe_buffer_usage'"
-H94EE60235FE3: "已經在'#pragma unsafe_buffer_usage'範圍內"
+H94EE60235FE3: "已經在 '#pragma unsafe_buffer_usage' 範圍內"
 # 'also accessed here'
 H4EBEB7641C26: '在此處也被存取'
 # 'also found'
@@ -17625,13 +17625,13 @@ H3AB5357520EE: '附加到結構化綁定宣告的屬性規範序列與C++2c之�
 # 'an explicit object parameter can only appear as the first parameter of a member function'
 HB251EBFE2CF5: '顯式物件參數只能出現在成員函數的第一個參數'
 # 'an explicit object parameter can only appear as the first parameter of the %select{function|lambda}0'
-H7FA58E3ABF3F: '顯式物件參數只能出現在%select{函數|lambda}0的第一個參數'
+H7FA58E3ABF3F: '顯式物件參數只能出現在%select{函數|lambda}0 的第一個參數'
 # 'an explicit object parameter cannot appear in a %select{constructor|destructor}0'
 H75A07B3C23F5: '顯式物件參數不能出現在%select{構造函數|析構函數}0中'
 # 'an explicit object parameter cannot appear in a %select{static|virtual|non-member}0 %select{function|lambda}1'
-HF679F4DDA00F: '顯式物件參數不能出現在%select{靜態|虛函數|非成員}0 %select{函數|lambda}1中'
+HF679F4DDA00F: '顯式物件參數不能出現在%select{靜態|虛函數|非成員}0 %select{函數|lambda}1 中'
 # "an explicitly-defaulted %select{copy|move}0 assignment operator may not have 'const'%select{, 'constexpr'|}1 or 'volatile' qualifiers"
-HC61798127DDC: "明確預設的%select{複製|移動}0指定運算子不可具有 'const'%select{, 'constexpr'|}1或 'volatile' 限定符"
+HC61798127DDC: "明確預設的%select{複製|移動}0指定運算子不可具有 'const'%select{, 'constexpr'|}1 或 'volatile' 限定符"
 # 'an explicitly-defaulted %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}0 cannot be variadic'
 HE8693CE23671: '明確預設的%select{預設構造函數|複製構造函數|移動構造函數|複製指定運算子|移動指定運算子|析構函數}0不能是可變參'
 # 'an explicitly-defaulted %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}0 cannot have default arguments'
@@ -17655,7 +17655,7 @@ H6C951E1E776A: '尖括號同時包含了一個%select{類型|協定}0 (%1)和一
 # 'angle-bracketed include <%0> cannot be aliased to double-quoted include "%1"'
 H6DC7B4C3CA94: '尖括號包含 <%0> 無法別名為雙引號包含 "%1"'
 # 'annotate %select{%1|anonymous %1}0 with an availability attribute to silence this warning'
-H1B283AC48C5C: '用可用性屬性註解%select{%1|匿名 %1}0 以消除此警告'
+H1B283AC48C5C: '用可用性屬性註解 %select{%1|匿名 %1}0 以消除此警告'
 # "annotating the 'if %select{constexpr|consteval}0' statement here"
 HE2CC6E318B60: '在此處註解「if %select{constexpr|consteval}0」陳述式'
 # 'annotating the infinite loop here'
@@ -17685,9 +17685,9 @@ H131F22F8B917: '匿名命名空間在此處開始'
 # 'anonymous namespaces cannot be exported'
 HD9CECEFAA4C6: '匿名命名空間無法導出'
 # 'anonymous non-C-compatible type given name for linkage purposes by %select{typedef|alias}0 declaration after its linkage was computed; add a tag name here to establish linkage prior to definition'
-H4E07DEF6B927: '不相容C的匿名類型由%select{typedef|別名}0宣告在計算其連結性之後命名以供連結用途；請在此添加標記名稱以在定義前建立連結性'
+H4E07DEF6B927: '不相容C的匿名類型由 %select{typedef|別名}0宣告在計算其連結性之後命名以供連結用途；請在此添加標記名稱以在定義前建立連結性'
 # 'anonymous non-C-compatible type given name for linkage purposes by %select{typedef|alias}0 declaration; add a tag name here'
-H5233EEEB5041: '不相容C的匿名類型由%select{typedef|別名}0宣告命名以供連結用途；請在此添加標記名稱'
+H5233EEEB5041: '不相容C的匿名類型由 %select{typedef|別名}0宣告命名以供連結用途；請在此添加標記名稱'
 # 'anonymous property is not supported'
 HBEA1F99304A4: '匿名屬性不受支援'
 # 'anonymous structs are a C11 extension'
@@ -17705,7 +17705,7 @@ H3FE1C37A16FD: "命名空間或全域作用域中的匿名共用體必須宣告�
 # 'append PID to saved profile file name (default: false)'
 HFDE8729E14B7: '將PID附加到儲存的剖析檔檔名（預設：false）'
 # "application of '%select{alignof|sizeof}1' to interface %0 is not supported on this architecture and platform"
-H7F7758BA5771: "對介面 %0 應用'%select{alignof|sizeof}1'在此架構和平台上不受支援"
+H7F7758BA5771: "對介面 %0 應用 '%select{alignof|sizeof}1' 在此架構和平台上不受支援"
 # 'apply additional analysis to remove stores (experimental)'
 H0FDD6748AD67: '套用額外分析以移除存儲（實驗性）'
 # 'apply unchecked-ld-st when the target is definitely within range'
@@ -17713,9 +17713,9 @@ H75826487B47E: '當目標絕對在範圍內時套用未檢查的ld-st'
 # 'applying attribute %0 to a declaration is deprecated; apply it to the type instead'
 H1F568760A093: '將屬性 %0 套用到宣告是已棄用的；請改為套用到類型'
 # "architecture '%0' does not support '%1' execution mode"
-H341F2DD78603: "架構'%0'不支援'%1'執行模式"
+H341F2DD78603: "架構 '%0' 不支援 '%1' 執行模式"
 # "architectures do not match: '%0' (provided) vs '%1' (found)"
-H1E0CF63FB0D6: "架構不符：'%0'（提供的）與'%1'（找到的）"
+H1E0CF63FB0D6: "架構不符：'%0'（提供的）與 '%1'（找到的）"
 # 'architectures of the coverage mapping binaries'
 HC4DF8B556ACB: '涵蓋映射二進位檔的架構'
 # 'argument %0 is not an unqualified class type'
@@ -17731,7 +17731,7 @@ H873B3444BA19: "'preferred_name' 屬性的參數 %0 不是 %1 的特化類型的
 # 'argument %0 value should represent a contiguous bit field'
 H004B84FF9E91: '參數 %0 的值應表示連續的位段'
 # "argument '%0' is deprecated%select{|, use '%2' instead}1"
-H549CE16A2419: "參數 '%0' 已棄用%select{|，請改用 '%2'}1"
+H549CE16A2419: "參數 '%0' 已棄用 %select{|，請改用 '%2'}1"
 # "argument '%0' is deprecated, %1"
 HFF8BB35E32E8: "參數 '%0' 已棄用，%1"
 # "argument '%0' requires profile-guided optimization information"
@@ -17747,7 +17747,7 @@ HC935448BE70B: "參數不得具有 'void' 類型"
 # 'argument must be a function'
 H4B920E91F120: '參數必須是函數'
 # 'argument must be a string literal%select{| of char type}0'
-HE9E2C9450B76: '參數必須是字串文字%select{|的 char 類型}0'
+HE9E2C9450B76: '參數必須是字串文字 %select{|的 char 類型}0'
 # "argument not in expected state; expected '%0', observed '%1'"
 H081944E631B6: "參數未處於期望狀態；期望 '%0'，但觀察到 '%1'"
 # "argument of OpenMP clause '%0' must reference the same object in all threads"
@@ -17837,13 +17837,13 @@ H84236342B8A2: '對可能重疊字面值的位址進行算術運算的結果未�
 # 'arithmetic on pointer to interface %0, which is not a constant size for this architecture and platform'
 H9C9B045DAD4E: '在無法為此架構和平台提供固定大小的介面 %0 的指標進行算術運算'
 # 'arithmetic on%select{ a|}0 pointer%select{|s}0 to void'
-H58D09A5B5E7F: '在%select{ a|}0指標%select{|s}0到void類型進行算術運算'
+H58D09A5B5E7F: '在%select{ a|}0 指標 %select{|s}0 到void類型進行算術運算'
 # 'arithmetic on%select{ a|}0 pointer%select{|s}0 to void is a GNU extension'
-HB4BACD25A732: '在%select{ a|}0指標%select{|s}0到void類型進行算術運算是GNU擴展'
+HB4BACD25A732: '在%select{ a|}0 指標 %select{|s}0 到void類型進行算術運算是GNU擴展'
 # 'arithmetic on%select{ a|}0 pointer%select{|s}0 to%select{ the|}2 function type%select{|s}2 %1%select{| and %3}2'
-H1FD9A476B84E: '在%select{ a|}0指標%select{|s}0到%select{ the|}2函數類型%select{|s}2 %1%select{|和 %3}2進行算術運算'
+H1FD9A476B84E: '在%select{ a|}0 指標 %select{|s}0 到%select{ the|}2 函數類型 %select{|s}2 %1%select{|和 %3}2 進行算術運算'
 # 'arithmetic on%select{ a|}0 pointer%select{|s}0 to%select{ the|}2 function type%select{|s}2 %1%select{| and %3}2 is a GNU extension'
-H94DE585BA344: '在%select{ a|}0指標%select{|s}0到%select{ the|}2函數類型%select{|s}2 %1%select{|和 %3}2進行算術運算是GNU擴展'
+H94DE585BA344: '在%select{ a|}0 指標 %select{|s}0 到%select{ the|}2 函數類型 %select{|s}2 %1%select{|和 %3}2 進行算術運算是GNU擴展'
 # 'array %0 declared here'
 HD94D934376D0: '在此處宣告的陣列 %0'
 # "array 'new' cannot have initialization arguments"
@@ -17861,7 +17861,7 @@ HF8952A3F237D: '陣列指定項索引(%0)超出陣列邊界(%1)'
 # 'array designator range [%0, %1] is empty'
 HFAC24EA6FC3D: '陣列指定項範圍[%0, %1]為空'
 # "array designator value '%0' is negative"
-H02A61A71BE5A: "陣列指定項值'%0'為負數"
+H02A61A71BE5A: "陣列指定項值 '%0' 為負數"
 # 'array designators are a C99 extension'
 H09604E6E8FF6: '陣列指定項是C99擴展'
 # 'array has %select{incomplete|sizeless}0 element type %1'
@@ -17873,7 +17873,7 @@ HB32CD52AC2F7: '陣列索引 %0 超出陣列末端（該陣列類型為 %1%selec
 # 'array index %0 refers past the last possible element for an array in %1-bit address space containing %2-bit (%3-byte) elements (max possible %4 element%s5)'
 H8C89DC3E13D9: '陣列索引 %0 指向超過 %1-bit 位址空間中包含 %2-bit (%3-byte) 元素 (最大可能 %4 元素%s5) 的陣列末尾元素'
 # 'array initializer must be an initializer list%select{| or string literal| or wide string literal}0'
-H4C9486DBC430: '陣列初始值設定必須是初始化列表%select{|或字串文字|或寬字元字串文字}0'
+H4C9486DBC430: '陣列初始值設定必須是初始化列表 %select{|或字串文字|或寬字元字串文字}0'
 # 'array is too large (%0 elements)'
 H898DDC47DE13: '陣列過大 (%0 個元素)'
 # 'array of %0 type is invalid in OpenCL'
@@ -17901,7 +17901,7 @@ H521C171EF9F9: '陣列形狀運算的維度非整數'
 # 'array size expression has incomplete class type %0'
 H48253C816CFD: '陣列大小運算式具有不完整類別類型 %0'
 # 'array size expression must have integral or %select{|unscoped }0enumeration type, not %1'
-H46181D36F61E: '陣列大小運算式必須為整數或%select{|未指定作用域 }0枚舉型別，而非 %1'
+H46181D36F61E: '陣列大小運算式必須為整數或 %select{|未指定作用域 }0枚舉型別，而非 %1'
 # 'array size expression of type %0 requires explicit conversion to type %1'
 H08A74EE986A3: '陣列大小運算式型別 %0 需明確轉換為 %1 型別'
 # 'array size is negative'
@@ -17919,7 +17919,7 @@ HA2673E710254: '陣列類型無法進行值初始化'
 # 'array-to-pointer decay of array member without known bound is not supported'
 HAB3F18D32404: '無已知邊界的陣列成員的陣列指標衰減未被支援'
 # "as specified in %select{'collapse'|'ordered'|'collapse' and 'ordered'}0 clause%select{||s}0"
-H1ABDD2AD30EB: '如在 %select{Collapse|Ordered|Collapse 和 Ordered}0 子句%select{||s}0 中指定'
+H1ABDD2AD30EB: '如在 %select{Collapse|Ordered|Collapse 和 Ordered}0 子句 %select{||s}0 中指定'
 # 'ascending'
 HF393CC9965C7: '遞增'
 # 'asm constraint has an unexpected number of alternatives: %0 vs %1'
@@ -17983,7 +17983,7 @@ H6E5B5738458E: '嘗試在非堆疊%select{物件 %2|物件：區塊運算式|物
 # 'attempt to specialize declaration here'
 HF06CAF52936D: '嘗試在此處專門化宣告'
 # 'attempt to use a deleted function%select{|: %1}0'
-HA9C947D267C4: '嘗試使用已刪除的函數%select{|: %1}0'
+HA9C947D267C4: '嘗試使用已刪除的函數 %select{|: %1}0'
 # 'attempt to use a poisoned identifier'
 H3643F70789A4: '嘗試使用被毒化的識別符'
 # 'attempting to use the forward class %0 as superclass of %1'
@@ -18091,9 +18091,9 @@ HA0C341D1A812: '自動屬性合成不會合成在協定 %1 中宣告的屬性 %0
 # 'auto property synthesis will not synthesize property %0; it will be implemented by its superclass, use @dynamic to acknowledge intention'
 H0457D53851AF: '自動屬性合成不會合成屬性 %0，因其將由超類實作，請使用 @dynamic 以明確表示意圖'
 # 'automatic variable qualified with an%select{| invalid}0 address space'
-H122ACAE25198: '帶有%select{|無效}0地址空間的自動變數'
+H122ACAE25198: '帶有 %select{|無效}0地址空間的自動變數'
 # 'autosynthesized property %0 will use %select{|synthesized}1 instance variable %2, not existing instance variable %3'
-H4495EA68D322: '自動合成的屬性 %0 將使用%select{|合成的}1實例變數 %2，而非現有的實例變數 %3'
+H4495EA68D322: '自動合成的屬性 %0 將使用 %select{|合成的}1實例變數 %2，而非現有的實例變數 %3'
 # 'availability does not match previous declaration'
 H583F2A1BC062: '可用性宣告與先前宣告不一致'
 # 'available multilibs are:%0'
@@ -18121,7 +18121,7 @@ H4B76670DCEA2: '基類具有不完整類型'
 # 'base class initializer %0 names both a direct base class and an inherited virtual base class'
 HAE21C251743B: '基類初始化器 %0 同時指定直接基類和繼承的虛基類'
 # 'base of member reference is a function; perhaps you meant to call it%select{| with no arguments}0?'
-H224FA72A413F: '成員引用的基類是函數；可能您想呼叫它%select{|不帶引數}0？'
+H224FA72A413F: '成員引用的基類是函數；可能您想呼叫它 %select{|不帶引數}0？'
 # 'base specifier must name a class'
 HBDBF7667EBAE: '基類規格必須指定一個類別'
 # 'basic register allocator'
@@ -18129,9 +18129,9 @@ HFEA9765B5A50: '基本寄存器分配器'
 # 'basic statistics'
 HAA78894D50F2: '基本統計資訊'
 # 'because %select{base class of |field of |}0type %1 has a user-provided %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}2'
-HA75BA84DF85B: '因為 %select{類別的基類 |類別的成員 |}0型別 %1 具有使用者提供的 %select{預設建構函數|複製建構函數|移動建構函數|複製賦值運算子|移動賦值運算子|析構函數}2'
+HA75BA84DF85B: '因為 %select{類別的基類 |類別的成員 |}0 型別 %1 具有使用者提供的 %select{預設建構函數|複製建構函數|移動建構函數|複製賦值運算子|移動賦值運算子|析構函數}2'
 # 'because %select{base class of |field of |}0type %1 has no default constructor'
-HC07ABEF26326: '因為 %select{類別的基類 |類別的成員 |}0型別 %1 沒有預設建構函數'
+HC07ABEF26326: '因為 %select{類別的基類 |類別的成員 |}0 型別 %1 沒有預設建構函數'
 # 'because field %0 has an initializer'
 H7DB53EF856A5: '因為成員 %0 具有初始值設定式'
 # 'because it has a default argument'
@@ -18183,7 +18183,7 @@ H672061929029: '綁定 %0 不得出現在其自身分解宣告的初始值設定
 # 'binding dereferenced null pointer to reference has undefined behavior'
 H95EC0F6A8A66: '將解引用空指標綁定至引用具有未定義行為'
 # 'binding reference %diff{of type $ to value of type $|to value}0,1 %select{drops %3 qualifier%plural{1:|2:|4:|:s}4|changes address space|not permitted due to incompatible qualifiers}2'
-H55C0D80172E9: 'binding reference %diff{類型為 $ 的引用綁定到類型為 $ 的值 | 綁定到值}0,1 %select{丟失 %3 修飾符%plural{1:|2:|4:|:s}4|改變位元組空間|因不相容修飾符而禁止}2'
+H55C0D80172E9: 'binding reference %diff{類型為 $ 的引用綁定到類型為 $ 的值 | 綁定到值}0,1 %select{丟失 %3 修飾符 %plural{1:|2:|4:|:s}4|改變位元組空間|因不相容修飾符而禁止}2'
 # 'binding reference member %0 to stack allocated %select{variable|parameter}2 %1'
 H6CEDF6C3E571: '將引用成員 %0 綁定至堆疊分配的 %select{變數|參數}2 %1'
 # "binding type '%0' is invalid"
@@ -18223,7 +18223,7 @@ H7CE8DAA0A6CB: '對Objective-C物件指標進行內部檢查的位遮罩操作�
 # 'bitwise comparison always evaluates to %select{false|true}0'
 H8A4398170F46: '位元比較始終評估為 %select{false|true}0'
 # "bitwise negation of a boolean expression%select{;| always evaluates to 'true';}0 did you mean logical negation?"
-HE532D6128324: "布林運算式的位元非運算%select{;| 始終評估為 'true';}0 你是否想要邏輯非運算？"
+HE532D6128324: "布林運算式的位元非運算 %select{;| 始終評估為 'true';}0 你是否想要邏輯非運算？"
 # 'bitwise or with non-zero value always evaluates to true'
 H6F8F36ACC41B: '與非零值的位元或運算始終評估為 true'
 # 'block cannot return %select{array|function}0 type %1'
@@ -18259,7 +18259,7 @@ H8D491EEC35CA: '用於基本區塊對齊的邊界值'
 # 'brace elision for designated initializer is a C99 extension'
 H98B26CB02BEA: '為指定初始化器省略大括號是 C99 的擴充功能'
 # 'braces around %select{scalar |}0initializer'
-H5FA1CA5D46EC: '%select{純量 |}0初始化式周圍的大括號'
+H5FA1CA5D46EC: '%select{純量 |}0 初始化式周圍的大括號'
 # 'bracket nesting level exceeded maximum of %0'
 HAE0DB07D013C: '括號嵌套層級超過最大值 %0'
 # 'brackets are not allowed here; to declare an array, place the brackets after the %select{identifier|name}0'
@@ -18293,7 +18293,7 @@ HFC2F5B50372D: '內建標頭屬於系統模組，且_Builtin_ 模組會被忽略
 # 'builtin is not supported on this target'
 H6C31A7E5443F: '此目標不支援此內建功能'
 # 'builtin requires%select{| at least one of the following extensions}0: %1'
-HBE3E35E72C33: '內建功能需要%select{|至少開啟下列其中一個擴充功能}0: %1'
+HBE3E35E72C33: '內建功能需要 %select{|至少開啟下列其中一個擴充功能}0: %1'
 # "but in %select{'%1'|definition here}0 found %select{%3 referenced %plural{1:protocol|:protocols}3|%ordinal3 referenced protocol with different name %4}2"
 HD3683C05282A: "但在 %select{'%1'|定義在此處}0 發現 %select{%3 參考 %plural{1:協定|:協定}3|%ordinal3 參考名稱不同的協定 %4}2"
 # "but in %select{'%1'|definition here}0 found %select{%select{method %4|constructor|destructor}3 that has %5 parameter%s5|%select{method %4|constructor|destructor}3 with %ordinal5 parameter of type %6%select{| decayed from %8}7|%select{method %4|constructor|destructor}3 with %ordinal5 parameter named %6}2"
@@ -18321,7 +18321,7 @@ H926097C3EBA4: "但在 '%0' 中找到 %select{不同的返回類型 %2|%ordinal2
 # "but in '%0' found %select{enum that is %select{not scoped|scoped}2|enum scoped with keyword %select{struct|class}2|enum %select{without|with}2 specified type|enum with specified type %2|enum with %2 element%s2|%ordinal2 element has name %3|%ordinal2 element %3 %select{has|does not have}4 an initializer|%ordinal2 element %3 has different initializer|}1"
 H44D066860BB7: "但在 '%0' 中找到 %select{類型%select{非命名空間|命名空間}2 的 enum|enum 命名空間使用關鍵字 %select{struct|class}2|enum%select{未指定|指定}2 類型|enum 具有指定類型 %2|enum 具有 %2 成員%s2|%ordinal2 成員具有名稱 %3|%ordinal2 成員 %3 %select{具有|未指定}4 初始化式|%ordinal2 成員 %3 具有不同初始化式|}1"
 # "but in '%0' found %select{static assert with different condition|static assert with different message|static assert with %select{|no }2message|%select{method %3|constructor|destructor}2|%select{method %3|constructor|destructor}2 is %select{not deleted|deleted}4|%select{method %3|constructor|destructor}2 is %select{not defaulted|defaulted}4|%select{method %3|constructor|destructor}2 is %select{|pure }4%select{not virtual|virtual}5|%select{method %3|constructor|destructor}2 is %select{not static|static}4|%select{method %3|constructor|destructor}2 is %select{not volatile|volatile}4|%select{method %3|constructor|destructor}2 is %select{not const|const}4|%select{method %3|constructor|destructor}2 is %select{not inline|inline}4|%select{method %3|constructor|destructor}2 with %ordinal4 parameter with%select{out|}5 a default argument|%select{method %3|constructor|destructor}2 with %ordinal4 parameter with a different default argument|%select{method %3|constructor|destructor}2 with %select{no |}4template arguments|%select{method %3|constructor|destructor}2 with %4 template argument%s4|%select{method %3|constructor|destructor}2 with %4 for %ordinal5 template argument|%select{method %3|constructor|destructor}2 with %select{no body|body}4|%select{method %3|constructor|destructor}2 with different body|friend %select{class|function}2|friend %2|friend function %2|function template %2 with %3 template parameter%s3|function template %2 with %ordinal3 template paramter being a %select{type|non-type|template}4 template parameter|function template %2 with %ordinal3 template parameter %select{with no name|named %5}4|function template %2 with %ordinal3 template parameter with %select{no |}4default argument|function template %2 with %ordinal3 template parameter with default argument %4|function template %2 with %ordinal3 template parameter with different type|function template %2 with %ordinal3 template parameter %select{not |}4being a template parameter pack|}1"
-H650FCD73F7BC: "但在 '%0' 中發現 %select{具有不同條件的 static assert|具有不同訊息的 static assert|static assert 無%select{|}2訊息|%select{方法 %3|建構函式|析構函式}2|%select{方法 %3|建構函式|析構函式}2 是%select{未刪除|已刪除}4|%select{方法 %3|建構函式|析構函式}2 是%select{未預設|已預設}4|%select{方法 %3|建構函式|析構函式}2 是%select{|純 }4%select{非虛|虛}5|%select{方法 %3|建構函式|析構函式}2 是%select{非靜態|靜態}4|%select{方法 %3|建構函式|析構函式}2 是%select{非揮發|揮發}4|%select{方法 %3|建構函式|析構函式}2 是%select{非常數|常數}4|%select{方法 %3|建構函式|析構函式}2 是%select{非內嵌|內嵌}4|%select{方法 %3|建構函式|析構函式}2 的第 %ordinal4 個參數%select{有|}5 預設參數|%select{方法 %3|建構函式|析構函式}2 的第 %ordinal4 個參數具有不同預設參數|%select{方法 %3|建構函式|析構函式}2%select{無|}4 模板參數|%select{方法 %3|建構函式|析構函式}2 具有 %4 個模板參數|%select{方法 %3|建構函式|析構函式}2 的第 %ordinal5 個模板參數為 %4|%select{方法 %3|建構函式|析構函式}2%select{無|}4 函式主體|%select{方法 %3|建構函式|析構函式}2 具有不同函式主體|友元%select{類別|函式}2|友元 %2|友元函式 %2|函式模板 %2 具有 %3 個模板參數|函式模板 %2 的第 %ordinal3 個模板參數為 %select{類型|非類型|模板}4 模板參數|函式模板 %2 的第 %ordinal3 個模板參數%select{無名稱|稱為 %5}4|函式模板 %2 的第 %ordinal3 個模板參數%select{無|}4 預設參數|函式模板 %2 的第 %ordinal3 個模板參數具有預設參數 %4|函式模板 %2 的第 %ordinal3 個模板參數具有不同類型|函式模板 %2 的第 %ordinal3 個模板參數%select{非|}4 為模板參數包|}1"
+H650FCD73F7BC: "但在 '%0' 中發現 %select{具有不同條件的 static assert|具有不同訊息的 static assert|static assert 無 %select{|}2 訊息|%select{方法 %3|建構函式|析構函式}2|%select{方法 %3|建構函式|析構函式}2 是%select{未刪除|已刪除}4|%select{方法 %3|建構函式|析構函式}2 是%select{未預設|已預設}4|%select{方法 %3|建構函式|析構函式}2 是 %select{|純 }4%select{非虛|虛}5|%select{方法 %3|建構函式|析構函式}2 是%select{非靜態|靜態}4|%select{方法 %3|建構函式|析構函式}2 是%select{非揮發|揮發}4|%select{方法 %3|建構函式|析構函式}2 是%select{非常數|常數}4|%select{方法 %3|建構函式|析構函式}2 是%select{非內嵌|內嵌}4|%select{方法 %3|建構函式|析構函式}2 的第 %ordinal4 個參數%select{有|}5 預設參數|%select{方法 %3|建構函式|析構函式}2 的第 %ordinal4 個參數具有不同預設參數|%select{方法 %3|建構函式|析構函式}2%select{無|}4 模板參數|%select{方法 %3|建構函式|析構函式}2 具有 %4 個模板參數|%select{方法 %3|建構函式|析構函式}2 的第 %ordinal5 個模板參數為 %4|%select{方法 %3|建構函式|析構函式}2%select{無|}4 函式主體|%select{方法 %3|建構函式|析構函式}2 具有不同函式主體|友元%select{類別|函式}2|友元 %2|友元函式 %2|函式模板 %2 具有 %3 個模板參數|函式模板 %2 的第 %ordinal3 個模板參數為 %select{類型|非類型|模板}4 模板參數|函式模板 %2 的第 %ordinal3 個模板參數%select{無名稱|稱為 %5}4|函式模板 %2 的第 %ordinal3 個模板參數%select{無|}4 預設參數|函式模板 %2 的第 %ordinal3 個模板參數具有預設參數 %4|函式模板 %2 的第 %ordinal3 個模板參數具有不同類型|函式模板 %2 的第 %ordinal3 個模板參數%select{非|}4 為模板參數包|}1"
 # "but in '%0' found %select{unnamed template parameter %2|template parameter %3|template parameter with %select{no |}2default argument|template parameter with different default argument}1"
 HA18966A0FC1B: "但在 '%0' 中找到 %select{未命名的第 %2 個模板參數|模板參數 %3|模板參數%select{未指定|}2 預設參數|模板參數具有不同預設參數}1"
 # "by value capture of '*this' is incompatible with C++ standards before C++17"
@@ -18365,11 +18365,11 @@ H41309CFB27F8: "呼叫串流函數需要 'sme'"
 # 'call to constructor of %0 is ambiguous'
 H00A38B0315FF: '對 %0 的建構函數呼叫存在歧義'
 # 'call to deleted constructor of %0%select{|: %2}1'
-HAA8E5FBCBA79: '呼叫已刪除的 %0 建構函數%select{|: %2}1'
+HAA8E5FBCBA79: '呼叫已刪除的 %0 建構函數 %select{|: %2}1'
 # 'call to deleted function call operator in type %0%select{|: %2}1'
-H8F857BEAC26F: '呼叫類別 %0 中已刪除的呼叫運算子%select{|: %2}1'
+H8F857BEAC26F: '呼叫類別 %0 中已刪除的呼叫運算子 %select{|: %2}1'
 # 'call to deleted%select{| member}0 function %1%select{|: %3}2'
-H6B002A51A7D4: '呼叫已刪除%select{| 成員}0 函數 %1%select{|: %3}2'
+H6B002A51A7D4: '呼叫已刪除 %select{| 成員}0 函數 %1%select{|: %3}2'
 # 'call to function %0 that is neither visible in the template definition nor found by argument-dependent lookup'
 H225588528963: '呼叫在模板定義中不可見且未經引數依賴查找找到的全域函數 %0'
 # 'call to global function %0 not configured'
@@ -18413,7 +18413,7 @@ H2870B0B82BD7: '呼叫類別 %0 的%select{私有|受保護的}1 析構函數'
 # "calling function %0 requires negative capability '%1'"
 HB81388BC5C94: "呼叫函數 %0 需要負向能力 '%1'"
 # "calling function %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
-HF6312AC18647: "呼叫函數 %1 需要持有 %0%select{'%2'|'排他性 %2'}3"
+HF6312AC18647: "呼叫函數 %1 需要持有 %0%select{'%2'|' 排他性 %2'}3"
 # 'calling function with incomplete return type %0'
 H47066D05EDB3: '呼叫具有不完整返回類型 %0 的函式'
 # 'calls the given entry-point on a new thread (jit-kind=orc-lazy only)'
@@ -18433,17 +18433,17 @@ HA2E8E747932F: '候選%select{建構函數|範本}0被忽略：繼承而來的�
 # 'candidate %select{constructor|template}0 ignored: instantiation %select{takes|would take}0 its own class type by value'
 H5F81F51806D8: '候選%select{建構函數|範本}0被忽略：實例化%select{需要|將需要}0以值形式接受自身類別型態'
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 has been %select{explicitly made unavailable|explicitly deleted|implicitly deleted}3"
-HDF3920A3A1F2: "候選%select{函數|函數|函數（參數順序反轉）|建構函數|預設建構函數（隱式）|複製建構函數（隱式）|移動建構函數（隱式）|複製指定運算子（隱式）|移動指定運算子（隱式）|為此'operator<=>'隱式產生的'operator=='|繼承而來的建構函數}0%select{|範本| %2}1已被%select{明確標記不可用|明確刪除|隱式刪除}3"
+HDF3920A3A1F2: "候選%select{函數|函數|函數（參數順序反轉）|建構函數|預設建構函數（隱式）|複製建構函數（隱式）|移動建構函數（隱式）|複製指定運算子（隱式）|移動指定運算子（隱式）|為此 'operator<=>' 隱式產生的 'operator=='|繼承而來的建構函數}0%select{|範本| %2}1 已被%select{明確標記不可用|明確刪除|隱式刪除}3"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: %ordinal5 argument (%3) would lose %select{const|restrict|const and restrict|volatile|const and volatile|volatile and restrict|const, volatile, and restrict}4 qualifier%select{||s||s|s|s}4"
-H95E4AEB3B23E: "候選%select{函數|函數|函數（參數順序反轉）|建構函數|預設建構函數（隱式）|複製建構函數（隱式）|移動建構函數（隱式）|複製指定運算子（隱式）|移動指定運算子（隱式）|為此'operator<=>'隱式產生的'operator=='|繼承而來的建構函數}0%select{|範本| %2}1不可行：%ordinal5個參數（%3）將失去 %select{const|restrict|const和restrict|volatile|const和volatile|volatile和restrict|const、volatile和restrict}4 資格%select{||s||s|s|s}4"
+H95E4AEB3B23E: "候選%select{函數|函數|函數（參數順序反轉）|建構函數|預設建構函數（隱式）|複製建構函數（隱式）|移動建構函數（隱式）|複製指定運算子（隱式）|移動指定運算子（隱式）|為此 'operator<=>' 隱式產生的 'operator=='|繼承而來的建構函數}0%select{|範本| %2}1 不可行：%ordinal5個參數（%3）將失去 %select{const|restrict|const和restrict|volatile|const和volatile|volatile和restrict|const、volatile和restrict}4 資格 %select{||s||s|s|s}4"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: %select{%ordinal7|'this'}6 argument (%3) has %select{no|__unsafe_unretained|__strong|__weak|__autoreleasing}4 ownership, but parameter has %select{no|__unsafe_unretained|__strong|__weak|__autoreleasing}5 ownership"
-H8D414CDC2F4E: "候選%select{函數|函數|函數（參數順序反轉）|建構函數|預設建構函數（隱式）|複製建構函數（隱式）|移動建構函數（隱式）|複製指定運算子（隱式）|移動指定運算子（隱式）|為此'operator<=>'隱式產生的'operator=='|繼承而來的建構函數}0%select{|範本| %2}1不可行：%select{%ordinal7|'this'}6個參數（%3）具有%select{無|__unsafe_unretained|__strong|__weak|__autoreleasing}4所有權，但參數需要%select{無|__unsafe_unretained|__strong|__weak|__autoreleasing}5所有權"
+H8D414CDC2F4E: "候選%select{函數|函數|函數（參數順序反轉）|建構函數|預設建構函數（隱式）|複製建構函數（隱式）|移動建構函數（隱式）|複製指定運算子（隱式）|移動指定運算子（隱式）|為此 'operator<=>' 隱式產生的 'operator=='|繼承而來的建構函數}0%select{|範本| %2}1 不可行：%select{%ordinal7|'this'}6 個參數（%3）具有%select{無|__unsafe_unretained|__strong|__weak|__autoreleasing}4 所有權，但參數需要%select{無|__unsafe_unretained|__strong|__weak|__autoreleasing}5 所有權"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: %select{%ordinal7|'this'}6 argument (%3) has %select{no|__weak|__strong}4 ownership, but parameter has %select{no|__weak|__strong}5 ownership"
-HFD1E148AC849: "候選%select{函數|函數|函數（參數順序反轉）|建構函數|預設建構函數（隱式）|複製建構函數（隱式）|移動建構函數（隱式）|複製指定運算子（隱式）|移動指定運算子（隱式）|為此'operator<=>'隱式產生的'operator=='|繼承而來的建構函數}0%select{|範本| %2}1不可行：%select{%ordinal7|'this'}6個參數（%3）具有%select{無|__weak|__strong}4所有權，但參數需要%select{無|__weak|__strong}5所有權"
+HFD1E148AC849: "候選%select{函數|函數|函數（參數順序反轉）|建構函數|預設建構函數（隱式）|複製建構函數（隱式）|移動建構函數（隱式）|複製指定運算子（隱式）|移動指定運算子（隱式）|為此 'operator<=>' 隱式產生的 'operator=='|繼承而來的建構函數}0%select{|範本| %2}1 不可行：%select{%ordinal7|'this'}6 個參數（%3）具有%select{無|__weak|__strong}4 所有權，但參數需要%select{無|__weak|__strong}5 所有權"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: %select{cannot convert initializer list|too few initializers in list|too many initializers in list}7 argument to %4"
-H4C57102C9323: "候選%select{函數|函數|函數（參數順序反轉）|建構函數|預設建構函數（隱式）|複製建構函數（隱式）|移動建構函數（隱式）|複製指定運算子（隱式）|移動指定運算子（隱式）|為此'operator<=>'隱式產生的'operator=='|繼承而來的建構函數}0%select{|範本| %2}1不可行：%select{初始化清單無法轉換|初始化清單項目過少|初始化清單項目過多}7個參數轉換至 %4"
+H4C57102C9323: "候選%select{函數|函數|函數（參數順序反轉）|建構函數|預設建構函數（隱式）|複製建構函數（隱式）|移動建構函數（隱式）|複製指定運算子（隱式）|移動指定運算子（隱式）|為此 'operator<=>' 隱式產生的 'operator=='|繼承而來的建構函數}0%select{|範本| %2}1 不可行：%select{初始化清單無法轉換|初始化清單項目過少|初始化清單項目過多}7個參數轉換至 %4"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: %select{requires at least|allows at most single|requires single}3 %select{|non-object }6argument %4, but %plural{0:no|:%5}5 arguments were provided"
-H8AD4B8B6097C: "候選%select{函數|函數|函數（參數順序反轉）|建構函數|預設建構函數（隱式）|複製建構函數（隱式）|移動建構函數（隱式）|複製指定運算子（隱式）|移動指定運算子（隱式）|為此'operator<=>'隱式產生的'operator=='|繼承而來的建構函數}0%select{|範本| %2}1不可行：%select{至少需要|最多僅允許單一|需要單一}3 %select{|非物件 }6參數 %4，但%plural{0:無|:%5}5個參數被提供"
+H8AD4B8B6097C: "候選%select{函數|函數|函數（參數順序反轉）|建構函數|預設建構函數（隱式）|複製建構函數（隱式）|移動建構函數（隱式）|複製指定運算子（隱式）|移動指定運算子（隱式）|為此 'operator<=>' 隱式產生的 'operator=='|繼承而來的建構函數}0%select{|範本| %2}1 不可行：%select{至少需要|最多僅允許單一|需要單一}3 %select{|非物件 }6參數 %4，但 %plural{0:無|:%5}5 個參數被提供"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: 'this' argument has type %3, but method is not marked %select{const|restrict|const or restrict|volatile|const or volatile|volatile or restrict|const, volatile, or restrict}4"
 HE6BBB39EEE68: "候選%select{函數|函數|參數順序相反的函數|建構函數|預設隱含建構函數|複製隱含建構函數|移動隱含建構函數|複製隱含指定運算子函數|移動隱含指定運算子函數|此 'operator<=>' 的隱含 'operator==' 函數|繼承建構函數}0%select{| 範型| %2}1 不適用：'this' 參數的類型為 %3，但方法未標記 %select{const|restrict|const 或 restrict|volatile|const 或 volatile|volatile 或 restrict|const、volatile 或 restrict}4"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: 'this' object is in %3, but method expects object in %4"
@@ -18469,7 +18469,7 @@ H327F9AFBF1B4: "候選%select{函數|函數|參數順序相反的函數|建構�
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: requires%select{ at least| at most|}3 %4 %select{|non-object }6argument%s4, but %5 %plural{1:was|:were}5 provided"
 HE70B20B055FA: "候選%select{函數|函數|參數順序相反的函數|建構函數|預設隱含建構函數|複製隱含建構函數|移動隱含建構函數|複製隱含指定運算子函數|移動隱含指定運算子函數|此 'operator<=>' 的隱含 'operator==' 函數|繼承建構函數}0%select{| 範型| %2}1 不適用：需要%select{至少| 最多|}3 %4 %select{|非物件 }6參數%s4，但 %5 %plural{1:有|:有}5 被提供"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %3}1%select{| has different class%diff{ (expected $ but has $)|}5,6| has different number of parameters (expected %5 but has %6)| has type mismatch at %ordinal5 parameter%diff{ (expected $ but has $)|}6,7| has different return type%diff{ ($ expected but has $)|}5,6| has different qualifiers (expected %5 but found %6)| has different exception specification}4"
-H8C85DA7348D1: "候選%select{函數|函數|參數順序反轉的函數|建構函數|隱含預設建構函數|隱含複製建構函數|隱含移動建構函數|隱含複製賦值運算子|隱含移動賦值運算子|隱含'operator=='的三向比較運算子)|繼承建構函數}0%select{|函式模板| %3}1%select{| 具有不同的類別%diff{（期望$但具有$）|}5,6| 參數數量不同（期望 %5 但具有 %6）| 第%ordinal5個參數類型不匹配%diff{（期望$但具有$）|}6,7| 回傳類型不同%diff{（期望$但具有$）|}5,6| 具有不同的修飾詞（期望 %5 但發現 %6）| 具有不同的例外規格}4"
+H8C85DA7348D1: "候選%select{函數|函數|參數順序反轉的函數|建構函數|隱含預設建構函數|隱含複製建構函數|隱含移動建構函數|隱含複製賦值運算子|隱含移動賦值運算子|隱含 'operator==' 的三向比較運算子)|繼承建構函數}0%select{|函式模板| %3}1%select{| 具有不同的類別%diff{（期望$但具有$）|}5,6| 參數數量不同（期望 %5 但具有 %6）| 第%ordinal5個參數類型不匹配%diff{（期望$但具有$）|}6,7| 回傳類型不同%diff{（期望$但具有$）|}5,6| 具有不同的修飾詞（期望 %5 但發現 %6）| 具有不同的例外規格}4"
 # 'candidate address cannot be taken because parameter %0 has pass_object_size attribute'
 H9C284929AC5A: '無法取得候選地址，因為參數 %0 具有 pass_object_size 屬性'
 # 'candidate constructor ignored: cannot be used to construct an object in address space %0'
@@ -18543,7 +18543,7 @@ H40A5A6DFAC87: "無法%select{使用內建運算子 '<=>'|預設 'operator<=>' }
 # 'cannot %select{use type %1 for a function/method parameter|use type %1 for function/method return|default-initialize an object of type %1|declare an automatic variable of type %1|copy-initialize an object of type %1|assign to a variable of type %1|construct an automatic compound literal of type %1|capture a variable of type %1|cannot use volatile type %1 where it causes an lvalue-to-rvalue conversion}3 since it %select{contains|is}2 a union that is non-trivial to %select{default-initialize|destruct|copy}0'
 H72F7777296D1: '無法 %select{使用類型 %1 做為函數/方法參數|使用類型 %1 做為函數/方法回傳類型|預設初始化類型 %1 的物件|宣告類型 %1 的自動變數|複製初始化類型 %1 的物件|指派給類型 %1 的變數|宣告類型 %1 的自動複合字面值|捕獲類型 %1 的變數|在需要 lvalue-to-rvalue 轉換時使用類型 %1}3，因為它 %select{包含|是}2 一個在 %select{預設初始化|析構|複製}0 時非平凡的聯合類型'
 # 'cannot %select{||reinterpret_cast||C-style cast||}0 from member pointer type %1 to member pointer type %2 of different size'
-H4DC29F600065: '無法%select{||reinterpret_cast||C-style cast||}0 從成員指標類型 %1 轉換為不同大小的成員指標類型 %2'
+H4DC29F600065: '無法 %select{||reinterpret_cast||C-style cast||}0 從成員指標類型 %1 轉換為不同大小的成員指標類型 %2'
 # "cannot add 'abi_tag' attribute in a redeclaration"
 H48F70104AB1E: "無法在重新宣告中新增 'abi_tag' 屬性"
 # 'cannot add a default template argument to the definition of a member of a class template'
@@ -18783,11 +18783,11 @@ H483DC86F4594: "無法找到 CUDA 安裝路徑；請透過 '--cuda-path' 提供�
 # "cannot find HIP Standard Parallelism Acceleration library; provide it via '--hipstdpar-path'"
 H20ABDE201926: "無法找到 HIP 並行加速函式庫；請透過 '--hipstdpar-path' 提供路徑"
 # "cannot find HIP device library%select{| for %1}0; provide its path via '--hip-path' or '--hip-device-lib-path', or pass '-nogpulib' to build without HIP device library"
-H74B6BE24033A: "無法找到HIP裝置函式庫%select{| 的 %1}0；透過 '--hip-path' 或 '--hip-device-lib-path' 提供其路徑，或傳遞 '-nogpulib' 以不使用HIP裝置函式庫進行建置"
+H74B6BE24033A: "無法找到HIP裝置函式庫 %select{| 的 %1}0；透過 '--hip-path' 或 '--hip-device-lib-path' 提供其路徑，或傳遞 '-nogpulib' 以不使用HIP裝置函式庫進行建置"
 # "cannot find HIP runtime; provide its path via '--rocm-path', or pass '-nogpuinc' to build without HIP runtime"
 H11EBFA045BE3: "無法找到 HIP 執行時間；請透過 '--rocm-path' 提供路徑，或透過 '-nogpuinc' 參數跳過 HIP 執行時間"
 # "cannot find ROCm device library%select{| for %1| for ABI version %1}0; provide its path via '--rocm-path' or '--rocm-device-lib-path', or pass '-nogpulib' to build without ROCm device library"
-H7B7F4A357272: "無法找到 ROCm 裝置函式庫%select{| %1 的| ABI 版本 %1 的}0；請透過 '--rocm-path' 或 '--rocm-device-lib-path' 提供路徑，或透過 '-nogpulib' 參數跳過 ROCm 裝置函式庫"
+H7B7F4A357272: "無法找到 ROCm 裝置函式庫 %select{| %1 的| ABI 版本 %1 的}0；請透過 '--rocm-path' 或 '--rocm-device-lib-path' 提供路徑，或透過 '-nogpulib' 參數跳過 ROCm 裝置函式庫"
 # 'cannot find a valid user-defined mapper for type %0 with name %1'
 H0907A5973C27: '無法為類型 %0 找到名稱 %1 的有效使用者定義映射器'
 # "cannot find end ('%1') of expected %0"
@@ -18925,17 +18925,17 @@ H92D6BE5E0D10: '無法對%select{從|到}0%select{建構函數|解構函數}1執
 # 'cannot perform a tail call from this return statement'
 HD566EFBB0F10: '無法從這個return語句執行尾調用'
 # 'cannot perform a tail call to function%select{| %1}0 because it uses an incompatible calling convention'
-H32E425482ACE: '無法對函數%select{| %1}0執行尾調用，因為它使用了不相容的呼叫約定'
+H32E425482ACE: '無法對函數 %select{| %1}0 執行尾調用，因為它使用了不相容的呼叫約定'
 # 'cannot perform a tail call to function%select{| %1}0 because its signature is incompatible with the calling function'
-HB6791E3481C6: '無法對函數%select{| %1}0執行尾調用，因為其簽章與呼叫函數不相容'
+HB6791E3481C6: '無法對函數 %select{| %1}0 執行尾調用，因為其簽章與呼叫函數不相容'
 # 'cannot perform atomic operation on a pointer to type %0: type has non-trivial ownership'
 H33A9E57472E9: '無法對具有非平凡擁有權的 %0 類型指標執行原子操作'
 # "cannot read configuration file '%0': %1"
-H0AF7279B0969: "無法讀取配置文件'%0'： %1"
+H0AF7279B0969: "無法讀取配置文件 '%0'： %1"
 # "cannot read randomize layout seed file '%0'"
-H97BBD89360BC: "無法讀取隨機化佈局種子文件'%0'"
+H97BBD89360BC: "無法讀取隨機化佈局種子文件 '%0'"
 # "cannot rebuild module '%0' as it is already finalized"
-H80C2AA3A79E5: "無法重建已最終化的模組'%0'"
+H80C2AA3A79E5: "無法重建已最終化的模組 '%0'"
 # 'cannot redeclare builtin function %0'
 HC3E811B65243: '無法重新宣告內建函數 %0'
 # 'cannot refer to a block inside block'
@@ -18949,7 +18949,7 @@ H3ACCC42BDE35: '無法在區塊內引用具有可變長度類型的宣告'
 # 'cannot refer to declaration with an array type inside block'
 HBA9381EF3C23: '無法在區塊內引用具有陣列型別的宣告'
 # 'cannot refer to element %0 of %select{array of %2 element%plural{1:|:s}2|non-array object}1 in a constant expression'
-H97B7B294ED7C: '無法在常數運算式中引用%select{具有 %2 個元素的陣列%plural{1:|s}2|非陣列物件}1的第 %0 項'
+H97B7B294ED7C: '無法在常數運算式中引用%select{具有 %2 個元素的陣列 %plural{1:|s}2|非陣列物件}1的第 %0 項'
 # "cannot refer to member %0 in %1 with '%select{.|->}2'"
 HF25CD96D4723: "無法使用 '%select{.|->}2' 存取 %1 的成員 %0"
 # "cannot refer to type member %0 in %1 with '%select{.|->}2'"
@@ -18967,7 +18967,7 @@ H50389542B8AD: '無法設定不完整類型 %0 的虛函數表指標驗證'
 # 'cannot set vtable pointer authentication on monomorphic type %0'
 H365AD22227CA: '無法為單態類別 %0 啟用vtable指標驗證'
 # "cannot specialize %select{|(with 'template<>') }0a member of an unspecialized template"
-H21C951459621: "無法%select{|(使用 'template<>') }0特化未特化的模板成員"
+H21C951459621: "無法 %select{|(使用 'template<>') }0特化未特化的模板成員"
 # 'cannot specialize a %select{dependent template|template template parameter}0'
 HC5BFF931F55D: '無法特化 %select{依賴範本|範本範本參數}0'
 # "cannot specify '%0%1' when compiling multiple source files"
@@ -19023,29 +19023,29 @@ H079B08EA2D25: '無法拋出指向不完整類型 %0 物件的指標'
 # 'cannot type cast @selector expression'
 H485C835C56BA: '無法對 @selector 表達式進行類型轉換'
 # "cannot use %select{'auto'|<ERROR>|'__auto_type'}0 with %select{initializer list|array}1 in C"
-HE2E4F9E6D620: "無法在C語言中將%select{'auto'|<ERROR>|'__auto_type'}0與%select{初始化列表|陣列}1一起使用"
+HE2E4F9E6D620: "無法在C語言中將 %select{'auto'|<ERROR>|'__auto_type'}0 與%select{初始化列表|陣列}1一起使用"
 # "cannot use %select{C++ 'try'|Objective-C '@try'}0 in the same function as SEH '__try'"
-H455974313E2A: "無法在同一函數中同時使用%select{C++ 'try'|Objective-C '@try'}0和SEH '__try'"
+H455974313E2A: "無法在同一函數中同時使用 %select{C++ 'try'|Objective-C '@try'}0 和SEH '__try'"
 # 'cannot use %select{dot|arrow}0 operator on a type'
 H546BD63E07E0: '無法對類型使用%select{點|箭號}0運算符'
 # "cannot use %select{unicode|wide}0 string literal in 'asm'"
-HD3FDC775E04A: "無法在 'asm' 中使用%select{Unicode|寬字符}0字元串字面量"
+HD3FDC775E04A: "無法在 'asm' 中使用 %select{Unicode|寬字符}0字元串字面量"
 # "cannot use '%0' in %select{__device__|__global__|__host__|__host__ __device__}1 function"
-H92A38A76E58C: "無法在%select{__device__|__global__|__host__|__host__ __device__}1函數中使用'%0'"
+H92A38A76E58C: "無法在 %select{__device__|__global__|__host__|__host__ __device__}1 函數中使用 '%0'"
 # "cannot use '%0' output with multiple -arch options"
-H1A59A50BBDD4: "無法在多個-arch選項下使用'%0'輸出"
+H1A59A50BBDD4: "無法在多個-arch選項下使用 '%0' 輸出"
 # "cannot use '%0' with '__vector bool'"
-HB212313EEF9A: "無法將'%0'與'__vector bool'一起使用"
+HB212313EEF9A: "無法將 '%0' 與 '__vector bool' 一起使用"
 # "cannot use '%0' with Objective-C exceptions disabled"
-H633899DC0353: "在停用Objective-C例外時無法使用'%0'"
+H633899DC0353: "在停用Objective-C例外時無法使用 '%0'"
 # "cannot use '%0' with exceptions disabled"
-H0F6B73A63960: "在停用例外處理時無法使用'%0'"
+H0F6B73A63960: "在停用例外處理時無法使用 '%0'"
 # "cannot use '_Complex' with '__vector'"
 HCFEB59CAC054: "'_Complex' 無法與 '__vector' 一起使用"
 # "cannot use 'float' with '__vector'"
 H8772A8A87C32: "'float' 無法與 '__vector' 一起使用"
 # "cannot use 'long double' with '__vector'"
-HD41E42BADD92: "'long double'無法與 '__vector' 一起使用"
+HD41E42BADD92: "'long double' 無法與 '__vector' 一起使用"
 # "cannot use 'long' with '__vector'"
 H0DD309217BB4: "'long' 無法與 '__vector' 一起使用"
 # "cannot use SEH '__try' in a coroutine when C++ exceptions are enabled"
@@ -19071,13 +19071,13 @@ H9F644F56E9E3: '無法將類型 %0 用作範圍'
 # 'cannot use type %0 as an iterator'
 H45599EAAF2D8: '無法將類型 %0 用作迭代器'
 # "cannot use type '%0' within '#pragma clang fp eval_method'; type is set according to the default eval method for the translation unit"
-HD91CCA267FD1: "無法在'#pragma clang fp eval_method'中使用類型'%0'；該類型根據翻譯單元的預設評估方法設定"
+HD91CCA267FD1: "無法在 '#pragma clang fp eval_method' 中使用類型 '%0'；該類型根據翻譯單元的預設評估方法設定"
 # 'cannot use variable %1 in collapsed imperfectly-nested loop %select{init|condition|increment}0 statement'
 H40887EDB8E4A: '無法在塌陷的不完全嵌套迴圈%select{初始化|條件|遞增}0語句中使用變數 %1'
 # 'cannot use variable-length arrays in %select{__device__|__global__|__host__|__host__ __device__}0 functions'
-H33A7639314BD: '無法在%select{__device__|__global__|__host__|__host__ __device__}0函式中使用可變長度陣列'
+H33A7639314BD: '無法在 %select{__device__|__global__|__host__|__host__ __device__}0 函式中使用可變長度陣列'
 # "cannot write file '%0': %1"
-H57D82DC5A945: "無法寫入檔案'%0'： %1"
+H57D82DC5A945: "無法寫入檔案 '%0'： %1"
 # 'cannot yet @encode type %0'
 H5CF1C5265DEE: '無法對此ABI編譯 %0'
 # 'cannot yet compile %0 in this ABI'
@@ -19099,7 +19099,7 @@ H4218AAE93F26: '在裝置或混合裝置lambda運算式中，以引用方式捕�
 # "capture of '*this' by copy is a C++17 extension"
 H9C3948693023: '以值方式捕獲*this 是C++17擴充語法'
 # "capture of variable '%0' as type %1 calls %select{private|protected}3 %select{default |copy |move |*ERROR* |*ERROR* |*ERROR* |}2constructor"
-H6489D0544330: "以類型 %1 捕獲變數 '%0' 調用%select{私有|受保護}3 %select{預設 |複製 |移動 |*ERROR* |*ERROR* |*ERROR* |}2建構函數"
+H6489D0544330: "以類型 %1 捕獲變數 '%0' 調用%select{私有|受保護}3 %select{預設 |複製 |移動 |*ERROR* |*ERROR* |*ERROR* |}2 建構函數"
 # 'captured structured bindings are a C++20 extension'
 HED60DD4C6A62: '捕獲結構化綁定是C++20擴充語法'
 # 'captured structured bindings are incompatible with C++ standards before C++20'
@@ -19117,9 +19117,9 @@ H94092A9759CB: 'case範圍與C2y標準之前版本不相容'
 # 'case value not in enumerated type %0'
 H4866E4105494: '枚舉類型 %0 中不存在該case值'
 # 'cast %diff{from $ to $ |}0,1converts to incompatible function type'
-HAE54FE7B3C1C: '將%diff{從 $ 轉換為 $ |}0,1轉換為不相容的函數類型'
+HAE54FE7B3C1C: '將%diff{從 $ 轉換為 $ |}0,1 轉換為不相容的函數類型'
 # "cast between incompatible calling conventions '%0' and '%1'; calls through this pointer may abort at runtime"
-HB4A395B83746: "在'%0'和'%1'間進行呼叫約定轉換；通過此指標的呼叫可能在執行階段中斷"
+HB4A395B83746: "在 '%0' 和 '%1' 間進行呼叫約定轉換；通過此指標的呼叫可能在執行階段中斷"
 # 'cast between pointer-to-function and pointer-to-object is an extension'
 H276B46B48964: '函數指標與物件指標轉換是擴展功能'
 # 'cast between pointer-to-function and pointer-to-object is incompatible with C++98'
@@ -19129,7 +19129,7 @@ H1D7499C23CFE: '將運算式轉換為void以消除警告'
 # 'cast from %0 is not allowed in a constant expression %select{in C++ standards before C++2c|because the pointed object type %2 is not similar to the target type %3}1'
 H542ED6DEC45B: '在C++標準C++2c之前%select{不允許在常量運算式中從 %0 轉換|因為所指物件類型 %2 與目標類型 %3 不相似}1'
 # 'cast from %0 to %1 drops %select{const and volatile qualifiers|const qualifier|volatile qualifier}2'
-HA3B03023258D: '從 %0 轉換為 %1 會丟失%select{const和volatile修飾符|const修飾符|volatile修飾符}2'
+HA3B03023258D: '從 %0 轉換為 %1 會丟失 %select{const和volatile修飾符|const修飾符|volatile修飾符}2'
 # 'cast from %0 to %1 increases required alignment from %2 to %3'
 H4A02BB23383F: '從 %0 轉換為 %1 會將必要對齊值從 %2 提升至 %3'
 # 'cast from %0 to %1 must have all intermediate pointers const qualified to be safe'
@@ -19139,7 +19139,7 @@ H8CE3B0EB72DC: '將類型 %0 的函數呼叫轉換為不匹配的類型 %1'
 # 'cast from pointer to smaller type %2 loses information'
 H60D928000B5D: '將指標轉換為較小的類型 %2 會導致資料遺失'
 # 'cast of %select{Objective-C|block|C}0 pointer type %1 to %select{Objective-C|block|C}2 pointer type %3 cannot use %select{__bridge|__bridge_transfer|__bridge_retained}4'
-H2F5F45B60576: '%select{Objective-C|區塊|C}0指標類型 %1 轉換為 %select{Objective-C|區塊|C}2 指標類型 %3 不能使用%select{__bridge|__bridge_transfer|__bridge_retained}4'
+H2F5F45B60576: '%select{Objective-C|區塊|C}0 指標類型 %1 轉換為 %select{Objective-C|區塊|C}2 指標類型 %3 不能使用 %select{__bridge|__bridge_transfer|__bridge_retained}4'
 # 'cast of type %0 to %1 is deprecated; use sel_getName instead'
 HC7428E5162D0: '將類型 %0 轉換為 %1 已被棄用；請改用sel_getName'
 # 'cast one or both operands to int to silence this warning'
@@ -19285,7 +19285,7 @@ HC409A532BB3A: '類別模板參數推導為 %0 選擇了明確的 %select{建構
 # 'class template argument deduction for alias templates is incompatible with C++ standards before C++20'
 H0A109AC10809: '對別名模板進行類別模板參數推導與 C++20 之前的標準不相容'
 # 'class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0'
-HCFEDA0AEF7C1: '類別模板參數推導與 C++17 之前的標準不相容%select{|；為保持相容性，請使用明確類型名稱 %1}0'
+HCFEDA0AEF7C1: '類別模板參數推導與 C++17 之前的標準不相容 %select{|；為保持相容性，請使用明確類型名稱 %1}0'
 # 'class template partial specialization %0 cannot be redeclared'
 HD6C67286FA78: '類別模板的部分特化 %0 不能重新宣告'
 # "class with destructor marked '%select{final|sealed}0' cannot be inherited from"
@@ -19347,7 +19347,7 @@ H20F85EBECAC2: 'NULL與非指標類型進行比較 (%select{(NULL 和 %1)|(%1 �
 # 'comparison between pointer and integer (%0 and %1)'
 H9205163E9BD4: '指標與整數（%0 和 %1）之間的比較'
 # "comparison between pointers to unrelated objects '%0' and '%1' has unspecified value"
-H722AC288816C: "未相關物件的指標'%0'與'%1'之間的比較結果未指定"
+H722AC288816C: "未相關物件的指標 '%0' 與 '%1' 之間的比較結果未指定"
 # "comparison between two arrays compare their addresses and will be deprecated in c++20; to compare array addresses, use unary '+' to decay operands to pointers"
 H5D551E6212F9: "兩個陣列的比較會比較其位址，並將在C++20中被棄用；如需比較陣列位址，請使用一元 '+' 運算子使操作數衰減為指標"
 # "comparison between two arrays is deprecated; to compare array addresses, use unary '+' to decay operands to pointers"
@@ -19355,7 +19355,7 @@ H4D3F55AAB37F: "兩個陣列的比較已被棄用；如需比較陣列位址，�
 # "comparison between two arrays is ill-formed in C++26; to compare array addresses, use unary '+' to decay operands to pointers"
 H20B4EE22A6C2: "C++26中兩個陣列的比較不符合語法規範；如需比較陣列位址，請使用一元 '+' 運算子使操作數衰減為指標"
 # "comparison of %select{address of|function|array}0 '%1' %select{not |}2equal to a null pointer is always %select{true|false}2"
-H61B7557646A7: "與空指標的 %select{地址的|函數的|陣列的}0 '%1' %select{不|}2比較始終為 %select{true|false}2"
+H61B7557646A7: "與空指標的 %select{地址的|函數的|陣列的}0 '%1' %select{不|}2 比較始終為 %select{true|false}2"
 # 'comparison of address of base class subobject %0 of class %1 to field %2 has unspecified value'
 HCEA4BEB9DFF0: '基類子物件 %0（類別 %1）與成員 %2 的地址比較值未指定'
 # 'comparison of address of fields %0 and %2 of %4 with differing access specifiers (%1 vs %3) has unspecified value'
@@ -19373,7 +19373,7 @@ H1D24D97A54FF: '不同類型的指標比較%diff{（$ 和 $）|}0,1'
 # 'comparison of integers of different signs: %0 and %1'
 H8C3AA027FA1B: '不同符號類型的整數比較：%0 和 %1'
 # "comparison of nonnull %select{function call|parameter}0 '%1' %select{not |}2equal to a null pointer is '%select{true|false}2' on first encounter"
-H9EDFDB49F3E3: "非空 %select{函數呼叫|參數}0 '%1' %select{不|}2與空指標的比較值在首次執行時為 %select{true|false}2"
+H9EDFDB49F3E3: "非空 %select{函數呼叫|參數}0 '%1' %select{不|}2 與空指標的比較值在首次執行時為 %select{true|false}2"
 # "comparison of numeric address '%0' with pointer '%1' can only be performed at runtime"
 HFBF28443EB32: '數值地址 %0 與指標 %1 的比較只能在執行階段進行'
 # 'comparison of pointer to virtual member function %0 has unspecified value'
@@ -19597,7 +19597,7 @@ H9CBE3FDAF244: "具類型 %0 的 'constexpr' 變數無效"
 # 'constexpr variable declaration must be a definition'
 H28D5C206A058: "'constexpr' 變數宣告必須為定義"
 # 'constrained by %select{|implicitly }1%select{private|protected}0 inheritance here'
-HA215ECA901D4: '因%select{|隱式 }1%select{私有|受保護}0繼承在此處受限制'
+HA215ECA901D4: '因 %select{|隱式 }1%select{私有|受保護}0繼承在此處受限制'
 # "constrained placeholder types other than simple 'auto' on non-type template parameters not supported yet"
 HA5CE432D2BF4: "非類型範型參數上除簡單 'auto' 以外的佔位符類型尚未支援"
 # "constraint '%0' is already present here"
@@ -19665,7 +19665,7 @@ HF68AF1DBEB64: '固定點與 %0 之間的轉換尚未支援'
 # 'conversion between matrix type %0 and incompatible type %1 is not allowed'
 H499A22E2DD8F: '不允許在不相容類型 %0 與 %1 的矩陣類型之間轉換'
 # 'conversion between matrix types%diff{ $ and $|}0,1 of different size is not allowed'
-H82DF9F4CF265: '不允許不同大小的矩陣類型%diff{ $和$|}0,1之間轉換'
+H82DF9F4CF265: '不允許不同大小的矩陣類型%diff{ $和$|}0,1 之間轉換'
 # 'conversion candidate %0 not viable: constraints not satisfied'
 H1A87D3FA633E: '轉換候選 %0 不可行：約束條件不符合'
 # 'conversion candidate of type %0'
@@ -19679,7 +19679,7 @@ HC6DC2FD11DE6: '不允許通過虛基類 %2 將類 %0 的成員指標轉換為�
 # 'conversion from string literal to %0 is deprecated'
 H1DEAC81E3C65: '將字串字面量轉換為 %0 已被棄用'
 # 'conversion function %diff{from $ to $|between types}0,1 invokes a deleted function%select{|: %3}2'
-H302A0E48B3BA: '轉換函數%diff{從$到$的轉換|類型之間的轉換}0,1 調用了已刪除的函數%select{|: %3}2'
+H302A0E48B3BA: '轉換函數%diff{從$到$的轉換|類型之間的轉換}0,1 調用了已刪除的函數 %select{|: %3}2'
 # 'conversion function cannot be redeclared'
 HA31D9D61E048: '轉換函式不可重新宣告'
 # 'conversion function cannot be variadic'
@@ -19763,27 +19763,27 @@ HB22CC79010F2: "CPU '%0' 不支援rv%select{32|64}1"
 # 'create a static PC table'
 HA9821FD0C9F2: '建立靜態程序計數器表'
 # "current API version is '%0', but plugin was compiled with version '%1'"
-H399ED19E4A74: "目前API版本為'%0'，但插件編譯時使用版本為'%1'"
+H399ED19E4A74: "目前API版本為 '%0'，但插件編譯時使用版本為 '%1'"
 # 'current file is older than dependency %0'
 HCE89B30434E7: '目前檔案比依賴項 %0 舊'
 # "current handling of vector bool and vector pixel types in this context are deprecated; the default behaviour will soon change to that implied by the '-altivec-compat=xl' option"
-H2144886C992F: "當前向量布林值和向量像素類型在此語境中的處理方式已棄用；預設行為將很快變更為'-altivec-compat=xl'選項所暗示的行為"
+H2144886C992F: "當前向量布林值和向量像素類型在此語境中的處理方式已棄用；預設行為將很快變更為 '-altivec-compat=xl' 選項所暗示的行為"
 # "current_version does not match: '%0' (provided) vs '%1' (found)"
-H84F45A8B13FB: "版本不相符：提供的'%0'對比找到的'%1'"
+H84F45A8B13FB: "版本不相符：提供的 '%0' 對比找到的 '%1'"
 # "cycle in acquired_before/after dependencies, starting with '%0'"
-HCB49175AA5FC: "取得.acquire_before/.after依賴項循環，起始於'%0'"
+HCB49175AA5FC: "取得.acquire_before/.after依賴項循環，起始於 '%0'"
 # "cyclic dependency in module '%0': %1"
-H2C783846485B: "模組'%0'中存在循環依賴：%1"
+H2C783846485B: "模組 '%0' 中存在循環依賴：%1"
 # 'data argument not used by format string'
 HB79E446EA7A1: '格式字串未使用資料參數'
 # "data argument position '%0' exceeds the number of data arguments (%1)"
-H3A25FAA1F4B4: "資料參數位置'%0'超過資料參數總數(%1)"
+H3A25FAA1F4B4: "資料參數位置 '%0' 超過資料參數總數(%1)"
 # 'data layout string to use'
 HBFBB6DFFCFDF: '要使用的資料布局字串'
 # 'data member instantiated with function type %0'
 HE2AF1A6B9D7C: '以函式類型 %0 實體化的資料成員'
 # "data-sharing attribute '%0' in '%1' clause requires OpenMP version %2 or above"
-H12FB4E840EF7: "'%0' 資料共用屬性在'%1'子句中需要OpenMP版本 %2 或更高版本"
+H12FB4E840EF7: "'%0' 資料共用屬性在 '%1' 子句中需要OpenMP版本 %2 或更高版本"
 # 'dbx'
 H362301DA6431: 'dbx'
 # "dealloc return type must be correctly specified as 'void' under ARC, instead of %0"
@@ -19809,7 +19809,7 @@ H96F07A99E632: "宣告 %0 被發現定義在多個模組單元中，第一個來
 # "declaration '%0' is %select{weak defined|thread local}1, but symbol is not in dynamic library"
 HFB32CBE0F1C5: "宣告 '%0' 是%select{弱定義|執行緒局部}1，但符號不在動態函式庫中"
 # "declaration '%0' is marked %select{available|unavailable}1, but symbol is %select{not |}2exported in dynamic library"
-H01B92D3A7F34: "宣告 '%0' 標記%select{可用|不可用}1，但符號%select{未 |}2在動態函式庫中匯出"
+H01B92D3A7F34: "宣告 '%0' 標記%select{可用|不可用}1，但符號%select{未 |}2 在動態函式庫中匯出"
 # "declaration cannot be inferred '%0' because it has no definition in this translation unit"
 HFACBBC5D211B: "無法推斷宣告 '%0'，因為在此翻譯單元中沒有定義它"
 # 'declaration conflicts with target of using declaration already in scope'
@@ -19933,7 +19933,7 @@ H745CF12AB2DC: '分解宣告 %0 需要初始化式'
 # 'decomposition declaration cannot be a template'
 H12444CAF9EB2: '分解宣告不能是範型'
 # "decomposition declaration cannot be declared %plural{1:'%1'|:with '%1' specifiers}0"
-HEDAF4E9407D4: "分解宣告不能宣告%plural{1:'%1'|:具有 '%1' 指定符}0"
+HEDAF4E9407D4: "分解宣告不能宣告 %plural{1:'%1'|:具有 '%1' 指定符}0"
 # "decomposition declaration cannot be declared with constrained 'auto'"
 H33CAEB57113F: "分解宣告不能宣告受限的 'auto'"
 # 'decomposition declaration cannot be declared with parentheses'
@@ -19941,9 +19941,9 @@ H02314396E4F0: '分解宣告不能以括號宣告類型'
 # "decomposition declaration cannot be declared with type %0; declared type must be 'auto' or reference to 'auto'"
 H3DD0947995B7: "分解宣告不能宣告類型 %0；宣告類型必須為 'auto' 或 'auto' 的引用"
 # "decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is a C++20 extension"
-HED6397EE7170: "分解宣告宣告%plural{1:'%1'|:具有 '%1' 指定符}0 是 C++20 扩展"
+HED6397EE7170: "分解宣告宣告 %plural{1:'%1'|:具有 '%1' 指定符}0 是 C++20 扩展"
 # "decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20"
-H3B1B7DD7D4A6: "分解宣告宣告%plural{1:'%1'|:具有 '%1' 指定符}0 與 C++20 之前標準不相容"
+H3B1B7DD7D4A6: "分解宣告宣告 %plural{1:'%1'|:具有 '%1' 指定符}0 與 C++20 之前標準不相容"
 # 'decomposition declaration must be the only declaration in its group'
 H36F7861E46A5: '分解宣告必須是其宣告群組中的唯一宣告'
 # 'decomposition declaration not permitted in this context'
@@ -19953,11 +19953,11 @@ H41B58BACEDBD: '分解宣告是 C++17 扩展'
 # 'decomposition declarations are incompatible with C++ standards before C++17'
 H6F6939D7899C: '分解宣告與 C++17 之前標準不相容'
 # 'deduced conflicting types %diff{($ vs $) |}0,1for initializer list element type'
-H41EB8FB5647B: '推導出初始化清單元素類型的衝突類型%diff{( $ 與 $ ) |}0,1'
+H41EB8FB5647B: '推導出初始化清單元素類型的衝突類型 %diff{( $ 與 $ ) |}0,1'
 # 'deduced incomplete pack %0 for template parameter %1'
 H03080CBC4C1A: '推導出模板參數 %1 的不完整包 %0'
 # 'deduced non-type template argument does not have the same type as the corresponding template parameter%diff{ ($ vs $)|}0,1'
-H6489085BE16C: '推導出的非類型模板參數與對應模板參數類型不同%diff{( $ 與 $ ) |}0,1'
+H6489085BE16C: '推導出的非類型模板參數與對應模板參數類型不同 %diff{( $ 與 $ ) |}0,1'
 # "deduced return type for defaulted %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator must be 'auto', not %1"
 H209B0E7EFC40: "預設的 %select{<ERROR>|相等性|三向|相等性|關係}0 比較運算子的推導傳回類型必須為 'auto'，而不是 %1"
 # 'deduced return types are a C++14 extension'
@@ -20061,7 +20061,7 @@ H8204A4BEFE67: "預設的 %0 因其隱含的 %select{|'==' |'<' }1 比較 %selec
 # 'defaulted %0 is implicitly deleted because it would invoke a %select{private|protected}3 %4%select{ member of %6| member of %6 to compare member %2| to compare base class %2}1'
 HA2763C071EBA: '預設的 %0 因其會調用 %select{私有|受保護}3 %4%select{ 的 %6 成員| 的 %6 成員用於比較成員 %2| 用於比較基底類別 %2 }1 而被隱式刪除'
 # 'defaulted %0 is implicitly deleted because it would invoke a deleted comparison function%select{| for member %2| for base class %2}1'
-H73AE2279ECF2: '預設的 %0 因其會調用被刪除的比較函數%select{| 針對成員 %2| 針對基底類別 %2 }1 而被隱式刪除'
+H73AE2279ECF2: '預設的 %0 因其會調用被刪除的比較函數 %select{| 針對成員 %2| 針對基底類別 %2 }1 而被隱式刪除'
 # "defaulted %0 is implicitly deleted because there is no viable %select{three-way comparison function|'operator=='}1 for %select{|member |base class }2%3"
 HC9957DD8DD53: "預設的 %0 因 %select{三向比較函數|'operator=='}1 對 %select{|成員 |基底類別 }2%3 無有效實作而被隱式刪除"
 # 'defaulted %0 is implicitly deleted because this non-rewritten comparison function would be the best match for the comparison'
@@ -20133,7 +20133,7 @@ H40BB23B29C3F: "宏 '%0' 在 AST 檔案 '%3' ('%1') 與命令列 ('%2') 中的�
 # "definition of module '%0' is not available; use -fmodule-file= to specify path to precompiled module interface"
 H1ED33479DE5D: "模組 '%0' 的定義不可用；使用 -fmodule-file= 指定預編譯模組介面的路徑"
 # 'definition of type %0 conflicts with %select{typedef|type alias}1 of the same name'
-H5C3C4CCA94AB: '類型 %0 的定義與同名的%select{typedef|類型別名}1產生衝突'
+H5C3C4CCA94AB: '類型 %0 的定義與同名的 %select{typedef|類型別名}1產生衝突'
 # 'definition of variable with array type needs an explicit size or an initializer'
 H79E09A4784DB: '陣列類型的變數定義需要明確指定大小或提供初始化值'
 # 'definition or redeclaration of %0 cannot name the global scope'
@@ -20231,15 +20231,15 @@ H6533BAA0653D: '複數的個別組成元件的銷毀在常數運算式中尚未�
 # 'destruction of object that is already being destroyed'
 HBC86CD58BD53: '正在銷毀已經處於銷毀中的物件'
 # 'destructor cannot be declared %select{<ERROR>|constexpr|consteval|constinit}0'
-H39B25D41B01F: '銷毀子不能宣告為%select{<ERROR>|constexpr|consteval|constinit}0'
+H39B25D41B01F: '銷毀子不能宣告為 %select{<ERROR>|constexpr|consteval|constinit}0'
 # 'destructor cannot be declared %select{<ERROR>|constexpr|consteval|constinit}0 because %select{data member %2|base class %3}1 does not have a constexpr destructor'
-HEA62090F1654: '銷毀子不能宣告為%select{<ERROR>|constexpr|consteval|constinit}0，因為%select{資料成員 %2|基類 %3}1 沒有 constexpr 的銷毀子'
+HEA62090F1654: '銷毀子不能宣告為 %select{<ERROR>|constexpr|consteval|constinit}0，因為%select{資料成員 %2|基類 %3}1 沒有 constexpr 的銷毀子'
 # "destructor cannot be declared '%0'"
 H18788E54B072: "銷毀子不能宣告為 '%0'"
 # 'destructor cannot be declared as a template'
 H2A9016676C0B: '銷毀子不能宣告為模板'
 # 'destructor cannot be declared using a %select{typedef|type alias}1 %0 of the class name'
-HD2E86EDB043A: '銷毀子不能使用類別名稱的%select{typedef|類型別名}1 %0 來宣告'
+HD2E86EDB043A: '銷毀子不能使用類別名稱的 %select{typedef|類型別名}1 %0 來宣告'
 # 'destructor cannot be redeclared'
 H7C102E557BD9: '銷毀子不能重新宣告'
 # 'destructor cannot be variadic'
@@ -20343,7 +20343,7 @@ HE6AB93C50673: '%select{主要介面|擴充宣告|分類}0 中宣告的直接方
 # 'direct property cannot be @dynamic'
 HE7907E55F6FD: '直接屬性不能為@dynamic'
 # "directive '#pragma omp %0' cannot contain more than one '%1' clause%select{| with '%3' name modifier| with 'source' dependence}2"
-H4FF8713761CF: "指令 '#pragma omp %0' 不可包含超過一個 '%1' 子句%select{| 具有 '%3' 名稱修飾符| 具有 'source' 依賴性}2"
+H4FF8713761CF: "指令 '#pragma omp %0' 不可包含超過一個 '%1' 子句 %select{| 具有 '%3' 名稱修飾符| 具有 'source' 依賴性}2"
 # "directive '#pragma omp %0' cannot contain more than one 'seq_cst',%select{ 'relaxed',|}1 'acq_rel', 'acquire' or 'release' clause"
 HAC63F783B13F: "指令 '#pragma omp %0' 不可包含超過一個 'seq_cst'，%select{ 'relaxed'，|}1 'acq_rel'、'acquire' 或 'release' 子句"
 # "directive '#pragma omp %0' requires the '%1' clause"
@@ -20473,7 +20473,7 @@ H410E3DC30FB6: '不顯示。'
 # 'domain argument %0 does not point to an NSString or CFString constant'
 H04276D1D8088: 'domain引數 %0 不指向前NSString或CFString常數'
 # 'domain argument %select{|%1 }0does not refer to global constant'
-H427CD3AEDAC3: 'domain引數%select{|%1 }0未引用全域常數'
+H427CD3AEDAC3: 'domain引數 %select{|%1 }0未引用全域常數'
 # "don't always align innermost loop to 32 bytes on ppc"
 H8446540436C8: '不總是將最內層迴圈對齊至 32 位元組（在ppc上）'
 # "don't demangle symbols"
@@ -20485,11 +20485,11 @@ H2CD70DD9AB50: '不測試失敗'
 # 'double precision constant requires %select{cl_khr_fp64|cl_khr_fp64 and __opencl_c_fp64}0, casting to single precision'
 H4D72ED1FA64B: '雙精度常數需要 %select{cl_khr_fp64|cl_khr_fp64和__opencl_c_fp64}0，轉換為單精度'
 # 'double-quoted include "%0" cannot be aliased to angle-bracketed include <%1>'
-H136E4A788F48: '雙引號包含路徑"%0"無法轉為尖括號包含路徑<%1>'
+H136E4A788F48: '雙引號包含路徑 "%0" 無法轉為尖括號包含路徑 <%1>'
 # 'double-quoted include "%0" in framework header, expected angle-bracketed instead'
 H2D4306614026: '框架標頭中使用雙引號包含的 "%0"，應改用尖括號包含'
 # 'due to %0 being dllexported%select{|; try compiling in C++11 mode}1'
-HB6A4EDE022F4: '由於 %0 被 dllexport 標記%select{|；嘗試以C++11模式編譯}1'
+HB6A4EDE022F4: '由於 %0 被 dllexport 標記 %select{|；嘗試以C++11模式編譯}1'
 # 'due to lvalue conversion of the controlling expression, association of type %0 will never be selected because it is %select{of array type|qualified}1'
 HE4CE0D7DDF88: '由於控制運算式的左值轉換，類型 %0 的關聯將永遠不會被選取，因為其%select{是陣列類型|已修飾}1'
 # 'dump CFG of functions with unknown control flow'
@@ -20551,7 +20551,7 @@ HE35AD70400C4: '傾印檔案資訊'
 # 'dump file summary'
 HBC127C99D732: '傾印檔案摘要'
 # "dump function CFGs to graphviz format after each stage;enable '-print-loops' for color-coded blocks"
-H790226C2A523: "在每個階段後將函數控制流圖（CFG）轉存為Graphviz格式；啟用'-print-loops'以顯示彩色區塊"
+H790226C2A523: "在每個階段後將函數控制流圖（CFG）轉存為Graphviz格式；啟用 '-print-loops' 以顯示彩色區塊"
 # 'dump function into assembly'
 H160A471B29E4: '將函數轉存為組裝語言'
 # 'dump id hashes and index offsets'
@@ -20599,17 +20599,17 @@ H7BC6D646456E: '將產生的效能測試物件寫入磁碟並印出訊息以存�
 # "duplicate %0 clause in an 'external_source_symbol' attribute"
 H3523FE9C404F: "在 'external_source_symbol' 屬性中重複的 %0 子句"
 # "duplicate '%0' declaration specifier"
-HD8ED5E5CBF0B: "重複的宣告指定詞'%0'"
+HD8ED5E5CBF0B: "重複的宣告指定詞 '%0'"
 # "duplicate 'virtual' in base specifier"
 HA0A16A07E97F: "基類指定中的重複'虛基類'"
 # "duplicate asm qualifier '%0'"
-HE8EA4F072983: "重複的asm限定詞'%0'"
+HE8EA4F072983: "重複的asm限定詞 '%0'"
 # "duplicate attribute subject matcher '%0'"
-H1D5786B873EA: "重複的屬性主體匹配器'%0'"
+H1D5786B873EA: "重複的屬性主體匹配器 '%0'"
 # "duplicate case value '%0'"
-H4BDEA82874BB: "重複的case值'%0'"
+H4BDEA82874BB: "重複的case值 '%0'"
 # "duplicate case value: '%0' and '%1' both equal '%2'"
-HCE899F8A3E5C: "重複的case值：'%0'和'%1'都等於'%2'"
+HCE899F8A3E5C: "重複的case值：'%0' 和 '%1' 都等於 '%2'"
 # 'duplicate code segment specifiers'
 HBEFD6978776A: '重複的程式碼段指定項'
 # 'duplicate declaration of method %0'
@@ -20631,9 +20631,9 @@ H066136189F8C: '重複的宏參數名稱 %0'
 # 'duplicate member %0'
 HC0ECCD41D310: '重複的成員 %0'
 # "duplicate modifier '%0' in '%1' clause"
-HF11C4EF9CA32: "在'%1'子句中重複的修飾符'%0'"
+HF11C4EF9CA32: "在 '%1' 子句中重複的修飾符 '%0'"
 # "duplicate module file extension block name '%0'"
-HCCAD463A8663: "重複的模組檔案擴展區塊名稱'%0'"
+HCCAD463A8663: "重複的模組檔案擴展區塊名稱 '%0'"
 # 'duplicate nullability specifier %0'
 HBA9CD0A409AC: '重複的nullability指定符 %0'
 # 'duplicate parameter modifier %0'
@@ -20643,9 +20643,9 @@ HD20F74839349: '忽略 %0 的重複協定定義'
 # 'duplicate unconditional branches that cross a cache line'
 H33FDED0520CF: '跨越快取線的無條件分支重複出現'
 # 'duplicate use of asm operand name "%0"'
-H3EAACD3C87CF: '重複使用asm運算子名稱"%0"'
+H3EAACD3C87CF: '重複使用asm運算子名稱 "%0"'
 # "duplicated command '%select{\\|@}0%1'"
-H76B78FD8FF48: "重複的命令'%select{\\|@}0%1'"
+H76B78FD8FF48: "重複的命令 '%select{\\|@}0%1'"
 # 'during field initialization in %select{this|the implicit default}0 constructor'
 H865BE3842864: '在%select{這個|隱式預設}0建構函式中進行成員變數初始化時'
 # 'during template argument deduction for %select{class|variable}0 template %select{partial specialization |}1%2 %3'
@@ -20681,7 +20681,7 @@ H72D209AC7B7A: '元素 %0 已隱式指定 %1，而另一元素已指定相同值
 # 'eliminate unreachable code'
 H5CECE35D9DC9: '移除無法達成的程式碼'
 # 'ellipsis in pack %select{|init-}0capture must appear %select{after|before}0 the name of the capture'
-H6C27D3CFC7C1: '封包%select{|init-}0捕獲中的省略號必須出現在捕獲名稱%select{之後|之前}0'
+H6C27D3CFC7C1: '封包 %select{|init-}0 捕獲中的省略號必須出現在捕獲名稱%select{之後|之前}0'
 # 'embedded and GOT-based position independence are incompatible'
 H471F7EE0F065: '嵌入式與 GOT 基底的位元元位置獨立性不相容'
 # 'embedding a #%0 directive within macro arguments is not supported'
@@ -20791,15 +20791,15 @@ H0CF57E62B75D: '在AArch64上啟用redzone的使用'
 # 'enable/disable all ARC Optimizations'
 H0DFE6EE5AB14: '啟用/停用所有ARC優化'
 # 'enclose %0 in %select{an @available|a __builtin_available}1 check to silence this warning'
-HC0011ACD5CEF: '將 %0 包裝在%select{@available的檢查|__builtin_available的檢查}1中以消除此警告'
+HC0011ACD5CEF: '將 %0 包裝在 %select{@available的檢查|__builtin_available的檢查}1中以消除此警告'
 # 'encoding of %0 type is incomplete because %1 component has unknown encoding'
 HE63ED9F43B42: '%0 類型的編碼不完整，因為 %1 組成部分具有未知的編碼'
 # "encoding prefix '%0' on an unevaluated string literal has no effect%select{| and is incompatible with c++2c}1"
-HFB264777D8F6: "在未計算的字串字面值上使用編碼前綴'%0'無效%select{|且與c++2c不相容}1"
+HFB264777D8F6: "在未計算的字串字面值上使用編碼前綴 '%0' 無效 %select{|且與c++2c不相容}1"
 # 'end tag'
 HE76165194C35: '結束標籤'
 # "entering module '%0' due to this pragma"
-H00CF7F723C1C: "因這個pragma進入模組'%0'"
+H00CF7F723C1C: "因這個pragma進入模組 '%0'"
 # 'enum %0 was explicitly specialized here'
 H888313DD02EB: '枚舉 %0 在此處被明確專門化'
 # 'enumeration %0 is incomplete'
@@ -20807,9 +20807,9 @@ HACD4B99390E7: '枚舉 %0 不完整'
 # 'enumeration cannot be a template'
 H0777CF5091AE: '枚舉不能是範本'
 # 'enumeration previously declared as %select{un|}0scoped'
-H979505490BD1: '枚舉先前已宣告為%select{未作用域|}0作用域枚舉'
+H979505490BD1: '枚舉先前已宣告為%select{未作用域|}0 作用域枚舉'
 # 'enumeration previously declared with %select{non|}0fixed underlying type'
-H8C078F2C2E0F: '枚舉先前已宣告具有%select{非|}0固定基礎類型'
+H8C078F2C2E0F: '枚舉先前已宣告具有%select{非|}0 固定基礎類型'
 # 'enumeration redeclared with different underlying type %0 (was %1)'
 H67E555152513: '枚舉重新宣告時使用不同的基礎類型 %0（原為 %1）'
 # 'enumeration type %0 is not allowed in a vector conditional'
@@ -20917,7 +20917,7 @@ H65240A881DB2: '在字符陣列初始化器中有過多元素'
 # 'excess elements in initializer for indivisible sizeless type %0'
 HF6B0539A54ED: '在不可分割且無大小類型 %0 的初始化器中有過多元素'
 # 'excess precision is requested but the target does not support excess precision which may result in observable differences in complex division behavior%select{|, additional uses where the requested higher precision cannot be honored were found but not diagnosed}0'
-H46192DCC4FC7: '要求過度精確，但目標不支援過度精確，這可能導致複雜除法行為的可觀測差異%select{|, 發現無法滿足的更高精確度要求的其他用例但未診斷}0'
+H46192DCC4FC7: '要求過度精確，但目標不支援過度精確，這可能導致複雜除法行為的可觀測差異 %select{|, 發現無法滿足的更高精確度要求的其他用例但未診斷}0'
 # 'exe called with module IR after each pass that changes it'
 H9DCF33C92D4F: '在每個修改模組的 pass 後，將模組 IR 傳遞給 exe'
 # 'execute only is not supported for the %0 sub-architecture'
@@ -20927,7 +20927,7 @@ HBE1A4247ED95: '__weak屬性 %0 的現有實例變數 %1 必須為__weak'
 # 'existing instance variable %1 for property %0 with %select{unsafe_unretained|assign}2 attribute must be __unsafe_unretained'
 H45768C1508E1: '具有 %select{unsafe_unretained|assign}2 屬性的屬性 %0 的現有實例變數 %1 必須為__unsafe_unretained'
 # 'existing instance variable %1 for strong property %0 may not be %select{|__unsafe_unretained||__weak}2'
-H98A6ABD1A54E: '強屬性 %0 的現有實例變數 %1 不可為%select{|__unsafe_unretained||__weak}2'
+H98A6ABD1A54E: '強屬性 %0 的現有實例變數 %1 不可為 %select{|__unsafe_unretained||__weak}2'
 # 'existing instance variable %1 for strong property %0 may not be __weak'
 HD554DEC7881B: '強屬性 %0 的現有實例變數 %1 不可為__weak'
 # 'exit after writing aggregated data file'
@@ -20939,7 +20939,7 @@ H816E771096AD: '日期或時間宏的展開不可重複產生'
 # 'expansion of macro %0 requested here'
 H97F2144252C9: '這裡請求展開宏 %0'
 # "expansion of predefined identifier '%0' to a string literal is a Microsoft extension"
-H89888E84B8EB: "將預定義識別項'%0'展開為字串文字是Microsoft擴充"
+H89888E84B8EB: "將預定義識別項 '%0' 展開為字串文字是Microsoft擴充"
 # 'expected "FILENAME" or <FILENAME>'
 H6038B7E6D091: '期望 "FILENAME" 或 <FILENAME>'
 # "expected #pragma pack parameter to be '1', '2', '4', '8', or '16'"
@@ -21129,7 +21129,7 @@ HFF7E5AC24A63: '期望 clang 編譯器命令'
 # "expected a class method selector with single argument, e.g., 'colorWithCGColor:'"
 H747F5E4807D4: "期望帶有單一參數的類方法選擇器，例如 'colorWithCGColor:'"
 # "expected a class name after '~' to name a destructor"
-H0B5DBF4FC4A5: "在'~'之後期望指定一個類名來命名析構函數"
+H0B5DBF4FC4A5: "在 '~' 之後期望指定一個類名來命名析構函數"
 # 'expected a feature name'
 H83F9EEF32768: '期望指定一個功能名稱'
 # "expected a field designator, such as '.field = 4'"
@@ -21137,11 +21137,11 @@ HE811DCDC9E5C: "期望指定一個成員變量設計標，例如 '.field = 4'"
 # 'expected a foldable binary operator in fold expression'
 H442801240371: '在展開表達式中期望指定一個可展開的二元運算子'
 # "expected a for, while, or do-while loop to follow '%0'"
-H6905E348753C: "期望在'%0'後面出現 for、while 或 do-while 迴圈"
+H6905E348753C: "期望在 '%0' 後面出現 for、while 或 do-while 迴圈"
 # "expected a header attribute name ('size' or 'mtime')"
 H7FCC0389B837: "期望指定標頭屬性名稱（'size' 或 'mtime'）"
 # "expected a header name after '%0'"
-HC5548A9AEA32: "在'%0'之後期望指定標頭名稱"
+HC5548A9AEA32: "在 '%0' 之後期望指定標頭名稱"
 # 'expected a memory order clause'
 H8A1509342CF4: '期望指定記憶體順序子句'
 # "expected a message describing the conflict with '%0'"
@@ -21395,27 +21395,27 @@ HBE410C345F41: '期望陣列 %select{下標|區段}0 的基底變數名稱'
 # "expected variable name or 'this' in lambda capture list"
 H9A94F049DF94: "在lambda捕獲清單中期望變數名稱或 'this'"
 # 'expected variable name%select{| or data member of current class}0'
-H829F4F463842: '期望變數名稱%select{|或當前類別的資料成員}0'
+H829F4F463842: '期望變數名稱 %select{|或當前類別的資料成員}0'
 # 'expected variable name%select{|, data member of current class}0, array element or array section'
-HEAE159C816D1: '期望變數名稱%select{|、當前類別的資料成員}0、陣列元素或陣列區段'
+HEAE159C816D1: '期望變數名稱 %select{|、當前類別的資料成員}0、陣列元素或陣列區段'
 # 'expected variable of pointer type'
 H396A94544855: '期望指標型別的變數'
 # "expected variable of the '%0' type%select{|, not %2}1"
-H3293A68C1535: "期望型別為'%0'的變數%select{|，而非 %2}1"
+H3293A68C1535: "期望型別為 '%0' 的變數 %select{|，而非 %2}1"
 # "expected variable%select{| or static data member|, static data member, or non-static data member of current class}0 of type '%1'"
-H54FC8A6038F8: "期望型別為'%1'%select{|或靜態資料成員|、靜態資料成員或當前類別的非靜態資料成員}0的變數"
+H54FC8A6038F8: "期望型別為 '%1'%select{|或靜態資料成員|、靜態資料成員或當前類別的非靜態資料成員}0的變數"
 # 'expected%select{| %1}0 loop iteration variable'
-H9F489F0C181E: '期望%select{| %1}0迴圈迭代變數'
+H9F489F0C181E: '期望 %select{| %1}0 迴圈迭代變數'
 # "expected%select{| non-const}0 variable of type 'omp_interop_t'"
-H7FA31289BDF2: "期望%select{|非const}0型別為 'omp_interop_t' 的變數"
+H7FA31289BDF2: "期望 %select{|非const}0 型別為 'omp_interop_t' 的變數"
 # 'expected%select{| one of}0 %1 directive name modifier%select{|s}0'
-HF9EF92E2746A: '期望%select{|其中一個}0 %1 指令名稱修飾詞%select{|s}0'
+HF9EF92E2746A: '期望 %select{|其中一個}0 %1 指令名稱修飾詞 %select{|s}0'
 # "expecting %0 '%1' to be held at start of each loop"
 HFDC07BD9FDE6: "期望迴圈起始處持有 %0 '%1'"
 # "expecting %0 '%1' to be held at the end of function"
 H696ED076811B: "期望函式結尾處持有 %0 '%1'"
 # 'explicit %select{constructor|conversion function|deduction guide}0 is not a candidate%select{| (explicit specifier evaluates to true)}1'
-H1B61513FD8B6: '顯式%select{建構函數|轉換函數|推導指引}0 不是候選%select{| (顯式指定符評估為true)}1'
+H1B61513FD8B6: '顯式%select{建構函數|轉換函數|推導指引}0 不是候選 %select{| (顯式指定符評估為true)}1'
 # 'explicit %select{constructor|deduction guide}0 declared here'
 H110462FEE829: '在此處宣告顯式%select{建構函數|推導指引}0'
 # 'explicit %select{specialization|instantiation}0 of %select{non-|undeclared }3template %1 %2'
@@ -21425,9 +21425,9 @@ H39AD5352EF13: '顯式呼叫+initialize 會導致+initialize 的重複呼叫'
 # 'explicit call to [super initialize] should only be in implementation of +initialize'
 H9E99F53BFF8C: '對[super initialize]的顯式呼叫只能出現在+initialize 實作中'
 # "explicit capture of 'this' with a capture default of '=' is a C++20 extension"
-HAF0F203BEF2F: "使用'='捕獲預設值時顯式捕獲 'this' 是C++20擴充"
+HAF0F203BEF2F: "使用 '=' 捕獲預設值時顯式捕獲 'this' 是C++20擴充"
 # "explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20"
-H671AAB21DB7A: "使用'='捕獲預設值時顯式捕獲 'this' 與C++20之前標準不相容"
+H671AAB21DB7A: "使用 '=' 捕獲預設值時顯式捕獲 'this' 與C++20之前標準不相容"
 # 'explicit constructor calls are a Microsoft extension'
 H07E486E825A8: '顯式建構函數呼叫是Microsoft擴充'
 # 'explicit conversion functions are a C++11 extension'
@@ -21505,7 +21505,7 @@ HDBBF37665EBE: '%0 的顯式專門化在實體化之後'
 # 'explicit specialization of %0 in function scope'
 H4AB8E368275F: '函數作用域中的 %0 之顯式專門化'
 # "explicit template instantiation cannot have a definition; if this definition is meant to be an explicit specialization, add '<>' after the 'template' keyword"
-H88A1F449C08B: "顯式模板實體化不能有定義；如果此定義意圖為顯式專門化，請在 'template' 關鍵字後添加'<>'"
+H88A1F449C08B: "顯式模板實體化不能有定義；如果此定義意圖為顯式專門化，請在 'template' 關鍵字後添加 '<>'"
 # 'explicit template parameter list for lambdas is a C++20 extension'
 HF9AE6F1B9252: 'lambda的顯式模板參數列表是C++20擴充功能'
 # 'explicit template parameter list for lambdas is incompatible with C++ standards before C++20'
@@ -21515,7 +21515,7 @@ H07C70F747BCD: 'explicit(bool) 是C++20擴充功能'
 # 'explicit(bool) is incompatible with C++ standards before C++20'
 H2A0E673F4AE0: 'explicit(bool) 與C++20之前的C++標準不相容'
 # 'explicitly assigning value of variable of type %0 to itself%select{|; did you mean to assign to member %2?}1'
-HB1C6DD04C662: '將類型 %0 的變數值明確地賦值給自身%select{|; 是否想賦值給成員 %2？}1'
+HB1C6DD04C662: '將類型 %0 的變數值明確地賦值給自身 %select{|; 是否想賦值給成員 %2？}1'
 # "explicitly capture 'this'"
 HCF140BF35536: "明確捕獲 'this'"
 # 'explicitly cast the argument to size_t to silence this warning'
@@ -21525,7 +21525,7 @@ H8E24FB4D1062: '將指標明確轉換以消除此警告'
 # "explicitly declare getter %objcinstance0 with '%1' to return an 'unowned' object"
 H4E2F7B8127D2: "明確宣告getter %objcinstance0 使用 '%1' 以傳回 'unowned' 物件"
 # 'explicitly defaulted %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator is implicitly deleted'
-H811330B8F313: '明確預設的%select{<ERROR>|等同|三路|等同|關係}0比較運算子被隱式刪除'
+H811330B8F313: '明確預設的 %select{<ERROR>|等同|三路|等同|關係}0比較運算子被隱式刪除'
 # 'explicitly defaulted %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}0 is implicitly deleted'
 H4A686915F9DC: '明確預設的%select{預設建構子|複製建構子|移動建構子|複製分配運算子|移動分配運算子|析構子}0被隱式刪除'
 # 'explicitly defaulted function was implicitly deleted here'
@@ -21533,7 +21533,7 @@ HF8EF8D3E0A6F: '此明確預設的函數在此處被隱式刪除'
 # 'explicitly defaulting this %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}0 with a type different from the implicit type is incompatible with C++ standards before C++20'
 H5E5EF3FDD4E3: '使用與隱式類型不同的類型明確預設此%select{預設建構子|複製建構子|移動建構子|複製分配運算子|移動分配運算子|析構子}0，與C++20之前的C++標準不相容'
 # 'explicitly moving variable of type %0 to itself%select{|; did you mean to move to member %2?}1'
-H35CC5A2B002D: '明確地將類型 %0 的變數移動到自身%select{|; 是否想移動到成員 %2？}1'
+H35CC5A2B002D: '明確地將類型 %0 的變數移動到自身 %select{|; 是否想移動到成員 %2？}1'
 # 'explicitly specialized declaration is here'
 H0E01C428C014: '明確特殊化的宣告在此處'
 # 'explicitly-defaulted %select{copy|move}0 assignment operator must return %1'
@@ -21745,7 +21745,7 @@ H3AFCF68EDB4D: "無法在期望的 %1 中找到檔案 '%0'"
 # "file '%0' from the precompiled header has been overridden"
 H0CD8B8C2C117: "來自預編譯標頭的文件 '%0' 已被覆寫"
 # "file '%0' has been modified since the %select{precompiled header|module file|AST file}1 '%2' was built: %select{size|mtime|content}3 changed%select{| (was %5, now %6)}4"
-H031EEE30BF07: "自建立 %select{預編譯標頭|模組檔|AST 檔}1 '%2' 後，文件 '%0' 已被修改：%select{大小|mtime|內容}3 變更%select{| (原為 %5，現為 %6)}4"
+H031EEE30BF07: "自建立 %select{預編譯標頭|模組檔|AST 檔}1 '%2' 後，文件 '%0' 已被修改：%select{大小|mtime|內容}3 變更 %select{| (原為 %5，現為 %6)}4"
 # "file '%0' is not a module file"
 H5DD90DFEF976: "文件 '%0' 不是模組檔"
 # "file '%0' is too large for Clang to process"
@@ -21761,7 +21761,7 @@ H208E3D0A2BB0: "文件 '%1' 不是有效的預編譯 %select{PCH|module|AST}0 �
 # 'file containing an ordered list of functions to use for function reordering'
 HAA6E189FC7DA: '包含用於函數重新排序的有序函數列表的文件'
 # 'file entered %0 time%s0 using %1B (%human1B) of space%plural{0:|: plus %2B (%human2B) for macro expansions}2'
-H6D5FEB2AA58C: '該文件以 %1B（%human1B）的空間%plural{0:|: 加上 %2B（%human2B）用於宏展開}2 被 %0 time%s0存取過'
+H6D5FEB2AA58C: '該文件以 %1B（%human1B）的空間 %plural{0:|: 加上 %2B（%human2B）用於宏展開}2 被 %0 time%s0存取過'
 # 'file name for generated dot file'
 H3426DAEC804D: '生成的 DOT 檔案名稱'
 # 'file name where instrumented profile will be saved (default: /tmp/prof.fdata)'
@@ -21889,7 +21889,7 @@ H4D29848904BC: "格式指定符 '%0' 與 '%1' 不相容"
 # 'format specifies type %0 but the argument has %select{type|underlying type}2 %1'
 H2B1918042742: '格式指定符指定類型 %0，但引數具有 %select{type|underlying type}2 %1'
 # "format string contains '\\0' within the string body"
-H262604652293: "格式字串在字串本體中包含'\\0'"
+H262604652293: "格式字串在字串本體中包含 '\\0'"
 # 'format string is defined here'
 H2D8041B9330A: '格式字串定義在此處'
 # 'format string is empty'
@@ -21919,7 +21919,7 @@ H61734FDBAB98: '模板實體的前向宣告在此處'
 # "forward references to 'enum' types are a Microsoft extension"
 H747D15D3C5A0: '枚舉類型的前向引用是Microsoft擴充功能'
 # "found '<::' after a %select{template name|addrspace_cast|const_cast|dynamic_cast|reinterpret_cast|static_cast}0 which forms the digraph '<:' (aka '[') and a ':', did you mean '< ::'?"
-HFDE68D3C1582: "在%select{模板名稱|addrspace_cast|const_cast|dynamic_cast|reinterpret_cast|static_cast}0後發現 '<::'，這會形成二元符號 '<:' (即'[') 和':'，您是否想要 '< ::'？"
+HFDE68D3C1582: "在%select{模板名稱|addrspace_cast|const_cast|dynamic_cast|reinterpret_cast|static_cast}0 後發現 '<::'，這會形成二元符號 '<:' (即 '[') 和 ':'，您是否想要 '< ::'？"
 # "found near match '%0'"
 HE96C9DD0F351: "找到近似匹配 '%0'"
 # 'fp convert instructions on integers with more than <N> bits are expanded.'
@@ -21999,7 +21999,7 @@ H03F3D9700027: '此處宣告的函數為不拋出異常'
 # 'function declared with %0 attribute was previously declared without the %0 attribute'
 H5B84619C2423: '具有 %0 屬性的函數先前被宣告為不帶 %0 屬性'
 # 'function declared with regparm(%0) attribute was previously declared %plural{0:without the regparm|:with the regparm(%1)}1 attribute'
-HF6A7160FBDE6: '宣告為 regparm(%0) 屬性的函數先前%plural{0:未宣告具 regparm 屬性|:宣告具 regparm(%1) 屬性}1'
+HF6A7160FBDE6: '宣告為 regparm(%0) 屬性的函數先前 %plural{0:未宣告具 regparm 屬性|:宣告具 regparm(%1) 屬性}1'
 # "function definition declared 'typedef'"
 H4E2B82F177E3: "函數定義被宣告為 'typedef'"
 # 'function definition does not declare parameters'
@@ -22047,7 +22047,7 @@ HA3A32C570475: '函數模板 %q0 與特化版本 %1 適配'
 # 'function template partial specialization is not allowed'
 HA3F0ADD5EDBB: '函數模板的部分特化是不被允許的'
 # 'function template specialization %0 ambiguously refers to more than one function template; explicitly specify%select{| additional}1 template arguments to identify a particular function template'
-H64BC13156614: '函數模板特化 %0 模糊指向多於一個的函數模板；請%select{|額外}1指定模板參數以明確指定特定函數模板'
+H64BC13156614: '函數模板特化 %0 模糊指向多於一個的函數模板；請 %select{|額外}1指定模板參數以明確指定特定函數模板'
 # "function template with 'sycl_kernel' attribute must have a 'void' return type"
 HE8E9EA85C4E9: '標記有「sycl_kernel」屬性的函數模板必須具有「void」返回類型'
 # "function template with 'sycl_kernel' attribute must have a single parameter"
@@ -22121,7 +22121,7 @@ HCB66D133764C: '屬性重宣告（%1）與其原始宣告（%0）的getter名稱
 # 'given <sectname>,<filename>[@<sym>=<offset>,...]  add the content of <filename> to <sectname>'
 HB3C96722F67D: '將 <filename> 的內容添加到 <sectname> 部分'
 # "glob '%0' did not match any header file"
-H7F85F549D444: "glob '%0'未匹配任何標頭檔"
+H7F85F549D444: "glob '%0' 未匹配任何標頭檔"
 # 'global sampler requires a const or constant address space qualifier'
 H418F4CC80105: '全域取樣器需要const或constant地址空間修飾符'
 # 'granularity of memprof shadow mapping'
@@ -22137,13 +22137,13 @@ H4CC0B372F96B: '半精度常數需要cl_khr_fp16'
 # 'hardware TLS register is not supported for the %0 sub-architecture'
 HDE3B68F7C8A6: '硬體TLS寄存器不支援 %0 子架構'
 # "header attribute '%0' specified multiple times"
-H7E7CB9EE75BF: "標頭屬性'%0'被多次指定"
+H7E7CB9EE75BF: "標頭屬性 '%0' 被多次指定"
 # "header file %0 (aka '%1') cannot be imported because it is not known to be a header unit"
-H0A389CC3DB5F: "無法導入標頭檔 %0（即'%1'），因為它未被識別為標頭單元"
+H0A389CC3DB5F: "無法導入標頭檔 %0（即 '%1'），因為它未被識別為標頭單元"
 # "header file '%0' input '%1' does not match the type of prior input in api extraction; use '-x %2' to override"
-HCC1F871B655D: "在API提取期間，標頭檔'%0'的輸入'%1'與先前輸入類型不符；使用'-x %2'覆蓋"
+HCC1F871B655D: "在API提取期間，標頭檔 '%0' 的輸入 '%1' 與先前輸入類型不符；使用 '-x %2' 覆蓋"
 # "header file '%0' input type '%1' does not match type of prior input in module compilation; use '-x %2' to override"
-H089F6388D5E8: "在模組編譯期間，標頭檔'%0'的輸入類型'%1'與先前輸入類型不符；使用'-x %2'覆蓋"
+H089F6388D5E8: "在模組編譯期間，標頭檔 '%0' 的輸入類型 '%1' 與先前輸入類型不符；使用 '-x %2' 覆蓋"
 # 'heap allocation performed here'
 H3CBBD5C4CC88: '此处進行堆分配'
 # 'hexadecimal floating %select{constant|literal}0 requires %select{an exponent|a significand}1'
@@ -22155,7 +22155,7 @@ H37A919BEDE1E: '十六進制浮點文字是C++17的特性'
 # 'hexadecimal floating literals are incompatible with C++ standards before C++17'
 HDD6000DF6583: '十六進制浮點文字與C++17之前的標準不相容'
 # 'hidden overloaded virtual function %q0 declared here%select{|: different classes%diff{ ($ vs $)|}2,3|: different number of parameters (%2 vs %3)|: type mismatch at %ordinal2 parameter%diff{ ($ vs $)|}3,4|: different return type%diff{ ($ vs $)|}2,3|: different qualifiers (%2 vs %3)|: different exception specifications}1'
-HAF71C2F007E8: '隱藏的重載虛函數%q0 在此宣告%select{|：不同類別%diff{ ($ vs $)|}2,3|：參數數量不同 (%2 vs %3)|：第%ordinal2 個參數類型不同%diff{ ($ vs $)|}3,4|：傳回類型不同%diff{ ($ vs $)|}2,3|：修飾符不同 (%2 vs %3)|：例外規格不同}1'
+HAF71C2F007E8: '隱藏的重載虛函數%q0 在此宣告 %select{|：不同類別%diff{ ($ vs $)|}2,3|：參數數量不同 (%2 vs %3)|：第%ordinal2 個參數類型不同%diff{ ($ vs $)|}3,4|：傳回類型不同%diff{ ($ vs $)|}2,3|：修飾符不同 (%2 vs %3)|：例外規格不同}1'
 # "hidden visibility cannot be applied to 'dllexport' declaration"
 HF663B246106D: "'dllexport' 声明不能應用隱藏可視性"
 # 'higher order bits are zeroes after implicit conversion'
@@ -22179,7 +22179,7 @@ H9BF7AFAC2ABF: '物件銷毀運算式中的識別碼 %0 未指定類型'
 # 'identifier %0 in object destruction expression does not name the type %1 of the object being destroyed'
 H3AA5F97C4B64: '物件銷毀運算式中的識別碼 %0 未指定正在銷毀物件的類型 %1'
 # "identifier %0 is reserved because %select{<ERROR>|it starts with '_' at global scope|it starts with '_' and has C language linkage|it starts with '__'|it starts with '_' followed by a capital letter|it contains '__'}1"
-HB25A0B12A970: '識別碼 %0 被保留因為%select{<ERROR>|它在全域作用域以 "_" 開頭|它以 "_" 開頭且具有C語言連結|它包含 "__"|它以 "_" 後接大寫字母開頭|它包含 "__"}1'
+HB25A0B12A970: '識別碼 %0 被保留因為 %select{<ERROR>|它在全域作用域以 "_" 開頭|它以 "_" 開頭且具有C語言連結|它包含 "__"|它以 "_" 後接大寫字母開頭|它包含 "__"}1'
 # 'identifier %0 preceded by whitespace in a literal operator declaration is deprecated'
 H0DD590ABAF7E: '字元串前有空白的字元串運算子宣告中的 %0 已棄用'
 # 'identifier after literal will be treated as a reserved user-defined literal suffix in C++11'
@@ -22187,9 +22187,9 @@ HC12CCB91962D: '字元串後的識別碼在C++11中將被視為保留的用戶�
 # 'identifier after literal will be treated as a user-defined literal suffix in C++11'
 HBE6CD4B6A8AE: '字元串後的識別碼在C++11中將被視為用戶定義文字後綴'
 # 'identifier contains Unicode character <U+%0> that is invisible in some environments'
-H5D7B884070AB: '識別項包含在部分環境中不可見的Unicode字元<U+%0>'
+H5D7B884070AB: '識別項包含在部分環境中不可見的Unicode字元 <U+%0>'
 # "identifier followed by '<' indicates a class template specialization but %0 %select{does not refer to a template|refers to a function template|<unused>|refers to a variable template|<unused>|<unused>|refers to a concept}1"
-HAF5607DFBCE7: "接續'<'的識別項表示類模板特化，但 %0 %select{未引用模板|引用函式模板|<unused>|引用變數模板|<unused>|<unused>|引用概念}1"
+HAF5607DFBCE7: "接續 '<' 的識別項表示類模板特化，但 %0 %select{未引用模板|引用函式模板|<unused>|引用變數模板|<unused>|<unused>|引用概念}1"
 # "if processing a memory profile, filter out stack or heap accesses that won't be useful for BOLT to reduce profile file size"
 HECF8ECDF0776: '若處理記憶體剖析，過濾對BOLT無用的堆疊或堆存取以減少剖析檔大小'
 # 'if reorder-functions is used, order functions putting hottest last'
@@ -22221,7 +22221,7 @@ H79AFD225957D: '建立呼叫圖時忽略遞迴呼叫'
 # "ignored 'inline' attribute on kernel function %0"
 HD7F59CCBC545: "忽略核心函式 %0 的 'inline' 屬性"
 # "ignored asm label '%0' on automatic variable"
-H457253219067: "忽略自動變數上的組合語言標籤'%0'"
+H457253219067: "忽略自動變數上的組合語言標籤 '%0'"
 # 'ignored trigraph would end block comment'
 HC0EDD32FEF14: '被忽略的三字元會結束區塊註解'
 # 'ignoring %0 attribute because its argument is invalid'
@@ -22229,33 +22229,33 @@ H5CBA55A0FD5C: '因參數無效而忽略屬性 %0'
 # 'ignoring %select{return value|temporary}0 of type %2 declared with %1 attribute%select{|: %4}3'
 H18EB408CFE62: '忽略宣告具有 %1 屬性的類型 %2 的%select{返回值|臨時物件}0%select{|：%4}3'
 # "ignoring '%0' as it conflicts with that implied by '%1' (%2)"
-HB9837B039EA4: "忽略'%0'，因為它與'%1'所暗示的 %2 相衝突"
+HB9837B039EA4: "忽略 '%0'，因為它與 '%1' 所暗示的 %2 相衝突"
 # "ignoring '%0' option as it cannot be used with %select{implicit usage of|}1 -mabicalls and the N64 ABI"
-H17CC723C2497: "忽略'%0'選項，因為它無法與%select{默認使用|}1 -mabicalls及N64 ABI一起使用"
+H17CC723C2497: "忽略 '%0' 選項，因為它無法與%select{默認使用|}1 -mabicalls及N64 ABI一起使用"
 # "ignoring '%0' option as it is not currently supported for processor '%1'"
-H14E6B917A2E6: "忽略'%0'選項，因為它目前不支援處理器'%1'"
+H14E6B917A2E6: "忽略 '%0' 選項，因為它目前不支援處理器 '%1'"
 # "ignoring '%0' option as it is not currently supported for target '%1'"
-H4AA39F54EF26: "忽略'%0'選項，因為它目前不支援目標平台'%1'"
+H4AA39F54EF26: "忽略 '%0' 選項，因為它目前不支援目標平台 '%1'"
 # "ignoring '%0' option for offload arch '%1' as it is not currently supported there. Use it with an offload arch containing '%2' instead"
-H788152E08844: "忽略在卸載架構'%1'中的'%0'選項，因為該處目前不支援。請改用包含'%2'的卸載架構"
+H788152E08844: "忽略在卸載架構 '%1' 中的 '%0' 選項，因為該處目前不支援。請改用包含 '%2' 的卸載架構"
 # "ignoring '%select{static|inline}0' keyword on explicit template instantiation"
 H8A80FA7727CA: '忽略在顯式模板實例化上的 %select{static|inline}0 關鍵字'
 # "ignoring '-f%select{no-|}0raw-string-literals', which is only valid for C and C++ standards before C++11"
-H135D75731B01: "忽略'-f%select{no-|}0raw-string-literals'，因為它僅對C++11之前的C和C++標準有效"
+H135D75731B01: "忽略 '-f%select{no-|}0raw-string-literals'，因為它僅對C++11之前的C和C++標準有效"
 # "ignoring '-mabs=2008' option because the '%0' architecture does not support it"
-H5F88EE5F0A3D: "忽略'-mabs=2008'選項，因為'%0'架構不支援"
+H5F88EE5F0A3D: "忽略 '-mabs=2008' 選項，因為 '%0' 架構不支援"
 # "ignoring '-mabs=legacy' option because the '%0' architecture does not support it"
-HE0FE9F3B46CA: "忽略'-mabs=legacy'選項，因為'%0'架構不支援"
+HE0FE9F3B46CA: "忽略 '-mabs=legacy' 選項，因為 '%0' 架構不支援"
 # "ignoring '-mcompact-branches=' option because the '%0' architecture does not support it"
-H60C9F0D89DB6: "忽略'-mcompact-branches='選項，因為'%0'架構不支援"
+H60C9F0D89DB6: "忽略 '-mcompact-branches=' 選項，因為 '%0' 架構不支援"
 # "ignoring '-mgpopt' option as it cannot be used with %select{|the implicit usage of }0-mabicalls"
-H2A6F793FDFBC: "忽略'-mgpopt'選項，因為它無法與%select{ |默認使用 }0-mabicalls一起使用"
+H2A6F793FDFBC: "忽略 '-mgpopt' 選項，因為它無法與%select{ |默認使用 }0-mabicalls一起使用"
 # "ignoring '-mlong-calls' option as it is not currently supported with %select{|the implicit usage of }0-mabicalls"
-HD076A9DC69A3: "忽略'-mlong-calls'選項，因為它目前無法與%select{ |默認使用 }0-mabicalls一起使用"
+HD076A9DC69A3: "忽略 '-mlong-calls' 選項，因為它目前無法與%select{ |默認使用 }0-mabicalls一起使用"
 # "ignoring '-mnan=2008' option because the '%0' architecture does not support it"
-H29C27F0049E3: "忽略'-mnan=2008'選項，因為'%0'架構不支援"
+H29C27F0049E3: "忽略 '-mnan=2008' 選項，因為 '%0' 架構不支援"
 # "ignoring '-mnan=legacy' option because the '%0' architecture does not support it"
-HADAF322768AC: "忽略'-mnan=legacy'選項，因為'%0'架構不支援"
+HADAF322768AC: "忽略 '-mnan=legacy' 選項，因為 '%0' 架構不支援"
 # 'ignoring -fapple-kext which is valid for C++ and Objective-C++ only'
 H88A745D4B73F: '忽略專門用於C++和Objective-C++的-fapple-kext'
 # 'ignoring -fdiscard-value-names for LLVM Bitcode'
@@ -22265,21 +22265,21 @@ H36FCA7FF86DB: '忽略-fverify-debuginfo-preserve-export=%0，因為-fverify-deb
 # 'ignoring __declspec(allocator) because the function return type %0 is not a pointer or reference type'
 H6AAEF2701683: '忽略__declspec(allocator)，因為該函數返回類型 %0 不是指標或引用類型'
 # "ignoring availability attribute %select{on '+load' method|with constructor attribute|with destructor attribute}0"
-H24871179ED63: "忽略在%select{'+load'方法上|具有構造函數屬性|具有析構函數屬性}0的可用性屬性"
+H24871179ED63: "忽略在 %select{'+load' 方法上|具有構造函數屬性|具有析構函數屬性}0的可用性屬性"
 # "ignoring extension '%0' because the '%1' architecture does not support it"
 HD131D7C5772F: "忽略擴展 '%0'，因為架構 '%1' 不支援它"
 # "ignoring invalid -ftabstop value '%0', using default value %1"
 H55F6E19B595A: "忽略無效的 -ftabstop 值 '%0'，使用預設值 %1"
 # "ignoring invalid /arch: argument '%0'; for %select{64|32}1-bit expected one of %2"
-HF5AE60D7E4BF: "忽略無效的/arch: 參數'%0'；對 %select{64|32}1 位期望其中一個 %2"
+HF5AE60D7E4BF: "忽略無效的/arch: 參數 '%0'；對 %select{64|32}1 位期望其中一個 %2"
 # 'ignoring redefinition of Objective-C qualifier macro'
 HE01ADCD1C19E: '忽略重新定義的 Objective-C 修飾符宏'
 # 'ignoring return value of function declared with %0 attribute'
 H0B36C4D66510: '忽略宣告具有 %0 屬性的函數的傳回值'
 # 'ignoring return value of function declared with %0 attribute%select{|: %2}1'
-H9DECD2C6A7A4: '忽略宣告具有 %0 屬性的函數的傳回值%select{|： %2}1'
+H9DECD2C6A7A4: '忽略宣告具有 %0 屬性的函數的傳回值 %select{|： %2}1'
 # 'ignoring temporary created by a constructor declared with %0 attribute%select{|: %2}1'
-H0FFFAF84F31C: '忽略由宣告具有 %0 屬性的建構子所創建的臨時物件%select{|： %2}1'
+H0FFFAF84F31C: '忽略由宣告具有 %0 屬性的建構子所創建的臨時物件 %select{|： %2}1'
 # "ignoring the 'branch-protection' attribute because the '%0' architecture does not support it"
 HF5FC687425B2: "忽略 'branch-protection' 屬性，因為架構 '%0' 不支援它"
 # 'illegal OpenMP user-defined mapper identifier'
@@ -22313,7 +22313,7 @@ H77F956612F13: "在類別擴展 %0 中對 'readwrite' 屬性的非法重新宣�
 # "illegal redeclaration of property in class extension %0 (attribute must be 'readwrite', while its primary must be 'readonly')"
 HA09E774D29B3: "在類別擴展 %0 中對屬性的非法重新宣告（屬性必須是 'readwrite'，而其主要宣告必須是 'readonly'）"
 # 'illegal scalar extension cast on argument %0 to %select{|in}1out paramemter'
-HF91E5CAEA96B: '在參數 %0 到%select{|in}1out參數上進行非法標量擴展轉換'
+HF91E5CAEA96B: '在參數 %0 到 %select{|in}1out參數上進行非法標量擴展轉換'
 # 'illegal storage class on file-scoped variable'
 H601564466459: '文件作用域變數上的非法存儲類別'
 # 'illegal storage class on function'
@@ -22339,11 +22339,11 @@ H9AA979884A67: '實作已棄用的%select{方法|類別|類別別名}0'
 # 'implementing unavailable method'
 H0D7D4644123A: '實作不可用的方法'
 # 'implicit %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}0 inferred target collision: call to both %select{__device__|__global__|__host__|__host__ __device__}1 and %select{__device__|__global__|__host__|__host__ __device__}2 members'
-HDD95624FC57A: '隱式%select{預設建構函數|複製建構函數|移動建構函數|複製賦值運算子|移動賦值運算子|析構函數}0推斷目標衝突：同時呼叫%select{__device__|__global__|__host__|__host__ __device__}1和%select{__device__|__global__|__host__|__host__ __device__}2成員'
+HDD95624FC57A: '隱式%select{預設建構函數|複製建構函數|移動建構函數|複製賦值運算子|移動賦值運算子|析構函數}0推斷目標衝突：同時呼叫 %select{__device__|__global__|__host__|__host__ __device__}1 和 %select{__device__|__global__|__host__|__host__ __device__}2 成員'
 # 'implicit boolean conversion of Objective-C object literal always evaluates to true'
 HFAC6148E9355: 'Objective-C物件字面量的隱式布林轉換始終評估為true'
 # "implicit capture of 'this' with a capture default of '=' is deprecated"
-H7D01BFC1D4A1: "隐含使用默认值'='捕获 'this' 是已弃用的"
+H7D01BFC1D4A1: "隐含使用默认值 '=' 捕获 'this' 是已弃用的"
 # 'implicit capture of lambda object due to conversion to block pointer here'
 H9CBFA98934C5: '隐含將 lambda 物件轉換為 block 指標時的捕獲'
 # 'implicit cast from type %0 to type %1 drops __unaligned qualifier'
@@ -22459,11 +22459,11 @@ HEC9C616BA3F9: 'asm 中的不可能約束：無法將值存入寄存器'
 # 'in %select{implicit|defaulted}0 %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}1 for %2 first required here'
 H7F88B1ED021A: '在%select{隱式|已預設的}0%select{預設建構函式|複製建構函式|移動建構函式|複製指派運算子|移動指派運算子|析構函式}1的 %2 中，首次需要在此處'
 # "in call to '%0'"
-H5F44B6591F5A: "在調用'%0'時"
+H5F44B6591F5A: "在調用 '%0' 時"
 # "in call to printing function with arguments '(%0)' while dumping struct"
-H5B10BE57CF69: "在列印函式調用時，以參數'(%0)'傾印結構"
+H5B10BE57CF69: "在列印函式調用時，以參數 '(%0)' 傾印結構"
 # 'in defaulted %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator for %1 first required here'
-H41C2C013E2E2: '在 %1 的預設%select{<ERROR>|等式|三向|等式|關聯}0比較運算子中，首次需要在此處'
+H41C2C013E2E2: '在 %1 的預設 %select{<ERROR>|等式|三向|等式|關聯}0比較運算子中，首次需要在此處'
 # 'in evaluating default argument here'
 HA6EC671D8C49: '在評估此處的預設參數時'
 # 'in evaluation of exception specification for %q0 needed here'
@@ -22471,7 +22471,7 @@ H94CE96486393: '在評估%q0所需的例外規格時'
 # 'in first definition, possible difference is here'
 HAF3474709EF4: '在首次定義中，可能的差異在此處'
 # "in implicit call to 'operator%select{!=|*|++}0' for iterator of type %1"
-HA1274A4A4765: "在 %1 類型的迭代器隱式調用'operator%select{!=|*|++}0'時"
+HA1274A4A4765: "在 %1 類型的迭代器隱式調用 'operator%select{!=|*|++}0' 時"
 # 'in implicit initialization for inherited constructor of %0'
 HE4CCA87F39AA: '在 %0 的繼承建構函式的隱式初始化時'
 # 'in implicit initialization of %select{array element %1 with omitted initializer|field %1 with omitted initializer|trailing array elements in runtime-sized array new}0'
@@ -22525,7 +22525,7 @@ H6D9691DC0D28: '在 %0 的預設初始化式中'
 # 'in value-initialization of type %0 here'
 H74E349C94BB1: '在此處對類型 %0 進行值初始化'
 # 'in%select{| implicit}0 constructor here'
-H24F20A5C047E: '在%select{| 隱含}0 建構函數中這裡'
+H24F20A5C047E: '在 %select{| 隱含}0 建構函數中這裡'
 # 'in-class initializer for static data member is not a constant expression'
 H9B69A27F211E: '類別內靜態資料成員的初始化式並非常數運算式'
 # 'in-class initializer for static data member is not a constant expression; folding it to a constant is a GNU extension'
@@ -22579,7 +22579,7 @@ H349444057F6C: '%select{%diff{將$指派給$型別 | 指派不同型別}1,0|%dif
 # 'incomplete definition of type %0'
 H74F733EC60E9: '不完整的型別 %0 定義'
 # "incomplete delimited universal character name; treating as '\\' '%0' '{' identifier"
-H45A3D640545C: "不完整的界定通用字符名称；視為'\\' '%0' '{' 标識符"
+H45A3D640545C: "不完整的界定通用字符名称；視為 '\\' '%0' '{' 标識符"
 # 'incomplete format specifier'
 HC2682570C017: '格式指定項不完整'
 # 'incomplete receiver type %0'
@@ -22607,7 +22607,7 @@ HB57B0356D109: '型別 %0 的物件呼叫中使用不完整型別'
 # 'incomplete universal character name'
 H0184822E59BB: '不完整的通用字符名稱'
 # "incomplete universal character name; treating as '\\' followed by identifier"
-H5B8C01DBAD90: "不完整的通用字符名称；視為'\\'後接标识符"
+H5B8C01DBAD90: "不完整的通用字符名称；視為 '\\' 後接标识符"
 # 'inconsistent number of instance variables specified'
 H7EB07F9DCA1E: '規定的實例變數數量不一致'
 # "incorrect adjust_args type, expected 'need_device_ptr' or 'nothing'"
@@ -22699,7 +22699,7 @@ H77EF2E241D1F: '所有初始化方法必須返回與接收器類型相關的類�
 # 'init methods must return an object pointer type, not %0'
 HA49BF476668F: '初始化方法必須返回物件指標類型，而非 %0'
 # "initialization clause of OpenMP for loop is not in canonical form ('var = init' or 'T var = init')"
-H55BD0EE327C7: 'OpenMP for迴圈的初始化子句必須為標準形式（"var = init"或"T var = init"）'
+H55BD0EE327C7: 'OpenMP for迴圈的初始化子句必須為標準形式（"var = init" 或 "T var = init"）'
 # 'initialization is not supported for __shared__ variables'
 H36A01643C5A6: '__shared__變數不支援初始化'
 # 'initialization of %0 may run twice when built into a shared library: it has hidden visibility and external linkage'
@@ -22739,7 +22739,7 @@ H7BA4847E4BDF: '初始化的 lambda 封包捕獲是 C++20 的擴充功能'
 # 'initializer %0 does not name a non-static data member or base class; did you mean the %select{base class|member}1 %2?'
 HBFA8CB0E43F8: '初始化器 %0 未指定非靜態資料成員或基類；您是否指的是 %select{基類|成員}1 %2？'
 # 'initializer %select{partially |}0overrides prior initialization of this subobject'
-H5DE4CB24B2D2: '初始化器 %select{部分覆蓋|}0先前對此子物件的初始化'
+H5DE4CB24B2D2: '初始化器 %select{部分覆蓋|}0 先前對此子物件的初始化'
 # 'initializer element is not a compile-time constant'
 H132D68BCCE73: '初始化器元素並非編譯期間常數'
 # 'initializer for aggregate is not a compile-time constant'
@@ -22763,7 +22763,7 @@ HD6A61B62F49C: '型別 %1 的變數 %0 初始值設定為空'
 # 'initializer for virtual base class %0 of abstract class %1 will never be used'
 H377D13F4BA4B: '抽象類別 %1 的虛基類 %0 的初始值設定器永遠不會被使用'
 # "initializer list cannot be used on the %select{left|right}0 hand side of operator '%1'"
-H08A1BB46A564: "初始化清單無法用於運算子'%1'的%select{左|右}0邊側"
+H08A1BB46A564: "初始化清單無法用於運算子 '%1' 的%select{左|右}0邊側"
 # 'initializer missing for lambda capture %0'
 H362962332DA4: 'lambda傳遞清單 %0 缺少初始值設定'
 # 'initializer of %0 is not a constant expression'
@@ -22789,7 +22789,7 @@ H822723DC0E42: '從空初始值清單初始化 %0 與C++98不相容'
 # "initializing 'char8_t' array with plain string literal"
 H1EA4AB240813: "使用純字面字串初始化 'char8_t' 陣列"
 # "initializing an array from a '%0' predefined identifier is a Microsoft extension"
-H8573434E16CF: "從'%0'預定義識別符初始化陣列是Microsoft擴充"
+H8573434E16CF: "從 '%0' 預定義識別符初始化陣列是Microsoft擴充"
 # 'initializing char array with wide string literal'
 H698D73717CFB: '使用寬字元字面值初始化char陣列'
 # 'initializing field %0 with default member initializer'
@@ -22819,7 +22819,7 @@ H0812ED282234: '區塊作用域中不允许 %0 的內联宣告'
 # 'inline function %q0 is not defined'
 HC9FA92373F42: '內联函數%q0未定義'
 # 'inline function not defined%select{| before the private module fragment}0'
-H195EBE25939A: '內联函數未定義%select{|前的私人模組片段}0'
+H195EBE25939A: '內联函數未定義 %select{|前的私人模組片段}0'
 # 'inline function performs a conversion which is forbidden in ARC'
 H46AB09EDECD4: '內联函數在ARC中執行了被禁止的轉換'
 # 'inline functions based on how much of the function is a scop.'
@@ -22849,7 +22849,7 @@ H427269D7064C: '內聯變數是C++17擴充'
 # 'inline variables are incompatible with C++ standards before C++17'
 HCE89C300F33E: '內聯變數與C++17之前的標準不相容'
 # "inner loops must be tightly nested inside a '%0' clause on a '%1' construct"
-HE18366CA8367: "'%1'結構中的'%0'子句必須將內部迴圈緊密嵌套於其內"
+HE18366CA8367: "'%1' 結構中的 '%0' 子句必須將內部迴圈緊密嵌套於其內"
 # 'input bitcode file which can override previously defined symbol(s)'
 HDFE5316187C5: '可覆寫先前定義符號的輸入位元碼檔案'
 # 'input conversion stopped due to an input byte that does not belong to the input codeset UTF-8'
@@ -22861,13 +22861,13 @@ H0BA9CA2C72E0: "輸入不是PCH檔案：'%0'"
 # 'input objects'
 H6ADBB11C54B0: '輸入物件'
 # "insert '%0;' to silence this warning"
-H7C4DAFCB5A75: "插入'%0;'以消除此警告"
+H7C4DAFCB5A75: "插入 '%0;' 以消除此警告"
 # "insert '%select{_Nonnull|_Nullable|_Null_unspecified}0' if the %select{pointer|block pointer|member pointer|array parameter}1 %select{should never be null|may be null|should not declare nullability}0"
-H95F6AD57B128: "若%select{指標|區塊指標|成員指標|陣列參數}1%select{永遠不會為空|可能為空|應不宣告空值}0，請插入'%select{_Nonnull|_Nullable|_Null_unspecified}0'"
+H95F6AD57B128: "若%select{指標|區塊指標|成員指標|陣列參數}1%select{永遠不會為空|可能為空|應不宣告空值}0，請插入 '%select{_Nonnull|_Nullable|_Null_unspecified}0'"
 # "insert ',' before '...' to silence this warning"
-H84706E906BF0: '在"..."前插入","以消除此警告'
+H84706E906BF0: '在 "..." 前插入 "," 以消除此警告'
 # "insert 'break;' to avoid fall-through"
-H4EC7EA05AEDF: '插入"break;"以避免穿透'
+H4EC7EA05AEDF: '插入 "break;" 以避免穿透'
 # 'insert an explicit cast to silence this issue'
 H21D74C2B0346: '插入明確轉換以抑制此問題'
 # 'insert tail call traps'
@@ -22917,7 +22917,7 @@ H467EDA4122CE: '使用 %0 個參數實例化摺疊運算式時超過了 %1 層�
 # 'instantiation of %q0 is different in different modules'
 H7179BAA1427A: '%q0在不同模組中的實例化不同'
 # "instantiation of '%0' not supported yet"
-H5578212F4DA3: "尚未支援'%0'的實例化"
+H5578212F4DA3: "尚未支援 '%0' 的實例化"
 # 'instantiation of function %q0 required here, but no definition is available'
 H88BC3AB38294: '在此處需要實例化函數%q0，但未提供定義'
 # 'instantiation of variable %q0 required here, but no definition is available'
@@ -22955,13 +22955,13 @@ H38F9A13FA923: '枚舉類型 %0 的整數常量超出範圍'
 # 'integer literal is too large to be represented in a signed integer type, interpreting as unsigned'
 H510046C2B2ED: '整數字面量無法用有符號整數類型表示，將解釋為無符號類型'
 # 'integer literal is too large to be represented in any %select{signed |}0integer type'
-H586D057CD6B8: '整數字面量無法在%select{有符號 |}0整數類型中表示'
+H586D057CD6B8: '整數字面量無法在%select{有符號 |}0 整數類型中表示'
 # "integer literal is too large to be represented in type 'long' and is subject to undefined behavior under C++98, interpreting as 'unsigned long'; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards"
-H84C22AB83CDC: "此字面量在C++11及之後版本將%select{具有'long long'類型|不符合語法}0。因無法在 'long' 類型中表示，根據C++98將解釋為'unsigned long'"
+H84C22AB83CDC: "此字面量在C++11及之後版本將%select{具有 'long long' 類型|不符合語法}0。因無法在 'long' 類型中表示，根據C++98將解釋為 'unsigned long'"
 # "integer literal is too large to be represented in type 'long', interpreting as 'unsigned long' per C++98; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards"
-H4C2C8A72E536: "此字面量在C++11及之後版本將%select{具有'long long'類型|不符合語法}0。因無法在 'long' 類型中表示，根據C89將解釋為'unsigned long'"
+H4C2C8A72E536: "此字面量在C++11及之後版本將%select{具有 'long long' 類型|不符合語法}0。因無法在 'long' 類型中表示，根據C89將解釋為 'unsigned long'"
 # "integer literal is too large to be represented in type 'long', interpreting as 'unsigned long' per C89; this literal will %select{have type 'long long'|be ill-formed}0 in C99 onwards"
-H58DBBF3A9BD1: "此字面量在C99及之後版本將%select{具有'long long'類型|不符合語法}0。因無法在 'long' 類型中表示，根據C89將解釋為'unsigned long'"
+H58DBBF3A9BD1: "此字面量在C99及之後版本將%select{具有 'long long' 類型|不符合語法}0。因無法在 'long' 類型中表示，根據C89將解釋為 'unsigned long'"
 # 'integer overflow in preprocessor expression'
 H24214C6EA913: '預處理器運算式中發生整數溢位'
 # 'integer sequences must have integral element type'
@@ -22983,7 +22983,7 @@ HE603DB4B7CDD: '介面類型無法繼承%select{結構|非公開介面|類別}0 
 # "interface types cannot specify '%select{private|protected}0' access"
 H5BB34D1AC02B: "介面類型無法指定'%select{私有|受保護}0'存取修飾符"
 # "interop type '%0' cannot be specified more than once"
-H92EFF909211E: "互通類型'%0'只能指定一次"
+H92EFF909211E: "互通類型 '%0' 只能指定一次"
 # 'interop variable %0 used in multiple action clauses'
 H6D1E048E9343: '互通變數 %0 用於多個動作子句中'
 # "interop variable must be of type 'omp_interop_t'"
@@ -23007,7 +23007,7 @@ H33DD8376B05A: '無效的#ident指示項'
 # 'invalid %% escape in inline assembly string'
 HDBE197B56289: '內嵌組裝字串中無效的%%轉義'
 # "invalid %0 at end of declaration; did you mean '='?"
-H6911F0CCF565: '宣告末尾的 %0 無效；您是否想要使用"="？'
+H6911F0CCF565: '宣告末尾的 %0 無效；您是否想要使用 "="？'
 # 'invalid %select{arithmetic between|bitwise operation between|comparison of|conditional expression between|compound assignment of}0 %select{floating-point|enumeration}1 type %2 %plural{2:with|4:from|:and}0 %select{enumeration|floating-point}1 type %3'
 H06A881D8D9FE: '無效的%select{浮點數/列舉型別間的算術運算|浮點數/列舉型別間的位元運算|浮點數/列舉型別的比較|浮點數/列舉型別間的條件運算式|浮點數/列舉型別的複合指派}0 %select{浮點數|列舉}1 類型 %2 %plural{2:與|4:從|:和}0 %select{列舉|浮點數}1 類型 %3'
 # 'invalid %select{arithmetic between|bitwise operation between|comparison of|conditional expression between|compound assignment of}0 different enumeration types%diff{ ($ and $)|}1,2'
@@ -23027,17 +23027,17 @@ H91493C3284DF: "無效的CoreFoundation執行階段ABI '%0'；必須是以下其
 # 'invalid Darwin version number: %0'
 HA0C57A49CA76: '無效的Darwin版本號：%0'
 # "invalid OS value '%0' in '%1'"
-H00BD3F016742: "無效的作業系統值'%0'在'%1'中"
+H00BD3F016742: "無效的作業系統值 '%0' 在 '%1' 中"
 # 'invalid OpenACC clause %0'
 HA3099393E590: '無效的OpenACC子句 %0'
 # "invalid OpenACC directive %select{%1|'%1 %2'}0"
-H74A42ADBF419: "無效的OpenACC指令%select{%1|'%1 %2'}0"
+H74A42ADBF419: "無效的OpenACC指令 %select{%1|'%1 %2'}0"
 # 'invalid PCS type'
 H696D824B4D2C: '無效的PCS類型'
 # "invalid RVV vector size '%0', expected size is '%1' based on LMUL of type and '-mrvv-vector-bits'"
-H96A03531A0AD: "無效的RVV向量大小'%0'，根據類型的LMUL和'-mrvv-vector-bits'，期望的大小為'%1'"
+H96A03531A0AD: "無效的RVV向量大小 '%0'，根據類型的LMUL和 '-mrvv-vector-bits'，期望的大小為 '%1'"
 # "invalid SVE vector size '%0', must match value set by '-msve-vector-bits' ('%1')"
-HF993CA8A3093: "無效的SVE向量大小'%0'，必須與'-msve-vector-bits'設置的值（'%1'）一致"
+HF993CA8A3093: "無效的SVE向量大小 '%0'，必須與 '-msve-vector-bits' 設置的值（'%1'）一致"
 # 'invalid UTF-8 in comment'
 H58EB41DE8F48: '注釋中的無效UTF-8'
 # "invalid Xarch argument: '%0', not all driver options can be forwared via Xarch argument"
@@ -23049,17 +23049,17 @@ H9A97FF7B54BE: '無效的__hlsl_resource_t類型屬性'
 # 'invalid address discrimination mode %0'
 H1D217687F248: '無效的地址區分模式 %0'
 # "invalid alignment option in '#pragma %select{align|options align}0' - ignored"
-H410475644E70: "在'#pragma %select{align|options align}0'中發現無效的對齊選項 - 已忽略"
+H410475644E70: "在 '#pragma %select{align|options align}0' 中發現無效的對齊選項 - 已忽略"
 # "invalid application of '%0' to %select{an incomplete|sizeless}1 type %2"
-H3984632B643A: "對%select{不完整|無尺寸}1類型 %2 不恰當地應用'%0'"
+H3984632B643A: "對%select{不完整|無尺寸}1類型 %2 不恰當地應用 '%0'"
 # "invalid application of '%0' to WebAssembly table"
-HA443432F106F: "對WebAssembly表格不恰當地應用'%0'"
+HA443432F106F: "對WebAssembly表格不恰當地應用 '%0'"
 # "invalid application of '%0' to a function type"
-HFD1A077F0D84: "對函數類型不恰當地應用'%0'"
+HFD1A077F0D84: "對函數類型不恰當地應用 '%0'"
 # "invalid application of '%0' to a void type"
-H3290D1C688B6: "對void類型不恰當地應用'%0'"
+H3290D1C688B6: "對void類型不恰當地應用 '%0'"
 # "invalid application of '%select{sizeof|alignof|typeof|typeof_unqual}0' to bit-field"
-H4D97635BE644: "不恰當地對位域使用'%select{sizeof|alignof|typeof|typeof_unqual}0'"
+H4D97635BE644: "不恰當地對位域使用 '%select{sizeof|alignof|typeof|typeof_unqual}0'"
 # "invalid application of '__builtin_omp_required_simd_align' to an expression, only type is allowed"
 H0F35C466B34C: "對表達式不恰當地使用 '__builtin_omp_required_simd_align'，只能用於類型"
 # "invalid application of 'alignof' to a field of a class still being defined"
@@ -23067,31 +23067,31 @@ H584C8A2541E4: "對仍在定義中的類別的成員不恰當地使用 'alignof'
 # "invalid application of 'offsetof' to a field of a virtual base"
 H7E5DD90FD952: "對虛基類的成員不恰當地使用 'offsetof'"
 # "invalid arch name '%0'"
-H053EB6DE40C8: "無效的CPU名稱'%0'"
+H053EB6DE40C8: "無效的CPU名稱 '%0'"
 # "invalid arch name '%0', %1"
-HAF3A77CFBCF8: "無效的CPU名稱'%0'，%1"
+HAF3A77CFBCF8: "無效的CPU名稱 '%0'，%1"
 # 'invalid argument %0 to function: %1, expecting a generic pointer argument'
 H45B49DB90594: '函數 %0 的無效參數類型：%1，期望一個通用指標參數'
 # "invalid argument '%0' not allowed with '%1'"
-H5F814EC912CC: "與'%1'一起使用時，'%0'參數無效"
+H5F814EC912CC: "與 '%1' 一起使用時，'%0' 參數無效"
 # "invalid argument '%0' only allowed with '%1'"
-HCD365CC8E5D4: "只有與'%1'一起使用時才允許'%0'參數"
+HCD365CC8E5D4: "只有與 '%1' 一起使用時才允許 '%0' 參數"
 # "invalid argument '%0' to -%1"
-H8405E80D8137: "對-%1 使用無效參數'%0'"
+H8405E80D8137: "對-%1 使用無效參數 '%0'"
 # "invalid argument '%0' to -malign-branch=; each element must be one of: %1"
-H20657E1CDBBF: "對-malign-branch=使用無效參數'%0'；每個元素必須是以下之一：%1"
+H20657E1CDBBF: "對-malign-branch=使用無效參數 '%0'；每個元素必須是以下之一：%1"
 # "invalid argument '%0' to -mfpu=; must be one of: 64, 32, none, 0 (alias for none)"
-HF131652C4C29: "對-mfpu=使用無效參數'%0'；必須是以下之一：64、32、none、0（none的別名）"
+HF131652C4C29: "對-mfpu=使用無效參數 '%0'；必須是以下之一：64、32、none、0（none的別名）"
 # "invalid argument '%0' to -msimd=; must be one of: none, lsx, lasx"
-H2BA112BC46B6: "對-msimd=使用無效參數'%0'；必須是以下之一：none、lsx、lasx"
+H2BA112BC46B6: "對-msimd=使用無效參數 '%0'；必須是以下之一：none、lsx、lasx"
 # "invalid argument '%0' to atomic attribute; valid options are: 'remote_memory', 'fine_grained_memory', 'ignore_denormal_mode' (optionally prefixed with 'no_')"
-H438B1A442EF4: "原子屬性無效參數'%0'；有效選項包括：'remote_memory'、'fine_grained_memory'、'ignore_denormal_mode'（可選擇在前面加上 'no_'）"
+H438B1A442EF4: "原子屬性無效參數 '%0'；有效選項包括：'remote_memory'、'fine_grained_memory'、'ignore_denormal_mode'（可選擇在前面加上 'no_'）"
 # "invalid argument '-mno-amdgpu-ieee' only allowed with relaxed NaN handling"
 H507F0448DDCC: '對-mno-amdgpu-ieee使用無效參數，僅允許在鬆弛NaN處理時使用'
 # "invalid argument in '%0', only integer or 'auto' is supported"
-H40210717B247: "在'%0'中使用無效參數，僅支持整數或 'auto'"
+H40210717B247: "在 '%0' 中使用無效參數，僅支持整數或 'auto'"
 # "invalid argument in '%0', only integers are supported"
-H7CC5EAE0927D: "在'%0'中使用無效參數，僅支持整數"
+H7CC5EAE0927D: "在 '%0' 中使用無效參數，僅支持整數"
 # 'invalid argument of type %0; expected an integer type'
 HDC97D348BCF9: '類型 %0 的無效引數；期望整數類型'
 # 'invalid argument to convert to character'
@@ -23109,7 +23109,7 @@ H369903756AB7: "無效引數；期望 'enable'%select{|, 'full'}0%select{|, 'ass
 # 'invalid authentication key %0'
 H1380B8ED725A: '無效的驗證金鑰 %0'
 # 'invalid block pointer conversion %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2'
-H1E4447440EDF: '無效的區塊指標轉換%select{%diff{將$指派給$|指派給不同類型}1,0|%diff{將$傳遞給類型$的參數|傳遞到不同類型的參數}1,0|%diff{從返回類型為$的函數返回$|從不同返回類型的函數返回}1,0|%diff{將$轉換為類型$|在類型之間轉換}1,0|%diff{用類型$的運算式初始化$|用不同類型的運算式初始化}1,0|%diff{將$傳送到類型$的參數|傳送到不同類型的參數}1,0|%diff{將$轉換為類型$|在類型之間轉換}1,0}2'
+H1E4447440EDF: '無效的區塊指標轉換 %select{%diff{將$指派給$|指派給不同類型}1,0|%diff{將$傳遞給類型$的參數|傳遞到不同類型的參數}1,0|%diff{從返回類型為$的函數返回$|從不同返回類型的函數返回}1,0|%diff{將$轉換為類型$|在類型之間轉換}1,0|%diff{用類型$的運算式初始化$|用不同類型的運算式初始化}1,0|%diff{將$傳送到類型$的參數|傳送到不同類型的參數}1,0|%diff{將$轉換為類型$|在類型之間轉換}1,0}2'
 # 'invalid block variable declaration - must be %select{const qualified|initialized}0'
 HF892D907A5A7: '無效的區塊變數宣告 - 必須%select{具const修飾|已初始化}0'
 # "invalid block variable declaration - using 'extern' storage class is disallowed"
@@ -23119,13 +23119,13 @@ HC49FDF0B5C89: '非法分支到OpenACC Compute/Combined Construct內部'
 # 'invalid branch out of OpenACC Compute/Combined Construct'
 H921800904C81: '非法從OpenACC Compute/Combined Construct分支出去'
 # "invalid branch protection option '%0' in '%1'"
-H69A222420F22: "在'%1'中無效的分支保護選項'%0'"
+H69A222420F22: "在 '%1' 中無效的分支保護選項 '%0'"
 # "invalid character '%0' in raw string delimiter; use PREFIX( )PREFIX to delimit raw string"
-H82170E32D0E4: "原始字串分隔符中的無效字元'%0'；使用PREFIX( )PREFIX來界定原始字串"
+H82170E32D0E4: "原始字串分隔符中的無效字元 '%0'；使用PREFIX( )PREFIX來界定原始字串"
 # "invalid comparison flag %0; use 'layout_compatible' or 'must_be_null'"
 H677EA1A68EB0: "無效的比較旗標 %0；使用 'layout_compatible' 或 'must_be_null'"
 # "invalid component '%0' used; expected 'x', 'y', 'z', or 'w'"
-H32632D0CDE2F: "使用了無效的元件'%0'；期望的元件為 'x'、'y'、'z' 或 'w'"
+H32632D0CDE2F: "使用了無效的元件 '%0'；期望的元件為 'x'、'y'、'z' 或 'w'"
 # 'invalid constructor from class in system header, should not be explicit'
 HEFC602372E3E: '系統標頭中的類別構造器不應為顯式'
 # 'invalid conversion between ext-vector type %0 and %1'
@@ -23135,9 +23135,9 @@ HAD5A2EB8C76E: '與不同大小的整數類型 %1 之間的向量類型 %0 轉�
 # 'invalid conversion between vector type %0 and scalar type %1'
 H0E21BE8324C1: '與純量類型 %1 之間的向量類型 %0 轉換無效'
 # 'invalid conversion between vector type%diff{ $ and $|}0,1 of different size'
-H62FB40425AFD: '與%diff{ $ 和 $|}1,0不同大小的向量類型轉換無效'
+H62FB40425AFD: '與%diff{ $ 和 $|}1,0 不同大小的向量類型轉換無效'
 # "invalid conversion specifier '%0'"
-H36DE3CE25255: "無效的格式指定符'%0'"
+H36DE3CE25255: "無效的格式指定符 '%0'"
 # 'invalid covariant return for virtual function: %1 is a %select{private|protected}2 base class of %0'
 HB307942D226E: '虛函數的協变返回類型無效：%1 是 %0 的 %select{私有|受保護}2 基類'
 # 'invalid cpu feature string for builtin'
@@ -23187,9 +23187,9 @@ H1627FB393F43: '大小為 %2 的封包 %1 的無效索引 %0'
 # "invalid input constraint '%0' in asm"
 H09D927559067: "組合語言中的無效輸入限制 '%0'"
 # "invalid input for analyzer-config option '%0', that expects %1 value"
-HB14EB9C7A93F: "分析器配置選項'%0'的輸入無效，該選項期望 %1 值"
+HB14EB9C7A93F: "分析器配置選項 '%0' 的輸入無效，該選項期望 %1 值"
 # "invalid input for checker option '%0', that expects %1"
-H784B521FDFA9: "檢查器選項'%0'的輸入無效，該選項期望 %1"
+H784B521FDFA9: "檢查器選項 '%0' 的輸入無效，該選項期望 %1"
 # "invalid input size for constraint '%0'"
 H8F6CDB6F0449: "限制 '%0' 的無效輸入大小"
 # "invalid integral value '%1' in '%0'"
@@ -23217,7 +23217,7 @@ HF6C358E90110: '原始字串分隔符中包含無效的換行字符；請使用P
 # 'invalid number of arguments to function: %0'
 H3D5EA8973A6F: '函數的參數數量無效：%0'
 # "invalid offload arch combinations: '%0' and '%1' (for a specific processor, a feature should either exist in all offload archs, or not exist in any offload archs)"
-H92F337A26551: "無效的卸載架構組合：'%0'和'%1'（針對特定處理器，某個功能應同時存在於所有卸載架構，或完全不存在於任何卸載架構）"
+H92F337A26551: "無效的卸載架構組合：'%0' 和 '%1'（針對特定處理器，某個功能應同時存在於所有卸載架構，或完全不存在於任何卸載架構）"
 # 'invalid operand number in inline asm string'
 H3DCCD1026997: '內聯組合語言字串中的操作數編號無效'
 # 'invalid operand of type %0 where %1 or a vector of such type is required'
@@ -23225,39 +23225,39 @@ HD52C15C02D70: '類型 %0 的操作數無效，此處需要 %1 類型或該類�
 # 'invalid operand of type %0 where floating, complex or a vector of such types is required'
 HC1A341FFC462: '類型 %0 的操作數無效，此處需要浮點、複數或該類型的向量'
 # 'invalid operand of type %0%select{| where a scalar or vector is required}1'
-H848780E5A063: '類型 %0 的操作數無效%select{|，此處需要純量或向量}1'
+H848780E5A063: '類型 %0 的操作數無效 %select{|，此處需要純量或向量}1'
 # 'invalid operands to binary expression (%0 and %1)'
 HC5560B091967: '二元運算式中的操作數無效（%0 和 %1）'
 # "invalid option '%0' for %select{cpu_specific|cpu_dispatch}1"
-HEFAAB35E81AF: "%select{cpu_specific|cpu_dispatch}1 的選項'%0'無效"
+HEFAAB35E81AF: "%select{cpu_specific|cpu_dispatch}1 的選項 '%0' 無效"
 # "invalid option '%0' not of the form <from-file>;<to-file>"
-HCB5BB85712F1: "選項'%0'無效，非<from-file>;<to-file>格式"
+HCB5BB85712F1: "選項 '%0' 無效，非 <from-file>;<to-file> 格式"
 # 'invalid option combination; LASX depends on LSX'
 H7E946D645C29: '無效的選項組合；LASX依賴於LSX'
 # "invalid or misplaced branch protection specification '%0'"
-H9377B8FCDAC3: "無效或位置錯誤的分支保護規格'%0'"
+H9377B8FCDAC3: "無效或位置錯誤的分支保護規格 '%0'"
 # "invalid or unsupported offload target: '%0'"
 H4E7457AF1786: "無效或不受支援的卸載目標：'%0'"
 # "invalid or unsupported rounding mode in '#pragma STDC FENV_ROUND' - ignored"
-HDB0B7F11E503: "在'#pragma STDC FENV_ROUND'中指定的無效或不受支援的捨入模式 - 已忽略"
+HDB0B7F11E503: "在 '#pragma STDC FENV_ROUND' 中指定的無效或不受支援的捨入模式 - 已忽略"
 # "invalid output constraint '%0' in asm"
-H686C32E03A9D: "組合語言中的輸出約束'%0'無效"
+H686C32E03A9D: "組合語言中的輸出約束 '%0' 無效"
 # "invalid output size for constraint '%0'"
-HA9017C3CAD23: "限制'%0'的輸出大小無效"
+HA9017C3CAD23: "限制 '%0' 的輸出大小無效"
 # "invalid output type '%0' for use with gcc tool"
-H1AE0ECD8B562: "與gcc工具一起使用時，輸出類型'%0'無效"
+H1AE0ECD8B562: "與gcc工具一起使用時，輸出類型 '%0' 無效"
 # "invalid parameter name: '%0' is a keyword"
-HBA4C66D8A8AA: "無效的參數名稱：'%0'是保留字"
+HBA4C66D8A8AA: "無效的參數名稱：'%0' 是保留字"
 # 'invalid parameter type for defaulted %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator; found %1, expected %2%select{| or %4}3'
-H1333988BA8FC: '預設的%select{<ERROR>|等同性|三向|等同性|關係}0比較運算子的參數類型無效；發現 %1，期望 %2%select{|或 %4}3'
+H1333988BA8FC: '預設的 %select{<ERROR>|等同性|三向|等同性|關係}0比較運算子的參數類型無效；發現 %1，期望 %2%select{|或 %4}3'
 # 'invalid parameter type for non-member defaulted %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator; found %1, expected class or reference to a constant class'
-HEB967961C960: '非成員預設的%select{<ERROR>|等同性|三向|等同性|關係}0比較運算子的參數類型無效；發現 %1，期望類別或對常量類別的引用'
+HEB967961C960: '非成員預設的 %select{<ERROR>|等同性|三向|等同性|關係}0比較運算子的參數類型無效；發現 %1，期望類別或對常量類別的引用'
 # 'invalid pipe access modifier (expecting %0)'
 HA4FFF117B821: '無效的管道存取修飾符（期望 %0）'
 # 'invalid position specified for %select{field width|field precision}0'
 H5DF564C1B18C: '指定的%select{字段寬度|字段精確度}0位置無效'
 # "invalid preprocessing directive%select{|, did you mean '#%1'?}0"
-H852ECDD7D2C3: '無效的預處理指令%select{|，您是否想輸入"#%1"？}0'
+H852ECDD7D2C3: '無效的預處理指令 %select{|，您是否想輸入 "#%1"？}0'
 # 'invalid profile : %0'
 H35AB0F2CB838: '無效的剖析： %0'
 # 'invalid protocol qualifiers on non-ObjC type'
@@ -23265,27 +23265,27 @@ H3723A726B37F: '非ObjC類型上的協定修飾符無效'
 # 'invalid prototype, variadic arguments are not allowed in OpenCL'
 H5E1888FFA26E: '無效的原型，OpenCL中不允許使用可變參數'
 # "invalid range expression of type %0; did you mean to dereference it with '*'?"
-H1FCBEB4D2213: '類型 %0 的範圍運算式無效；是否想用"*"解引用它？'
+H1FCBEB4D2213: '類型 %0 的範圍運算式無效；是否想用 "*" 解引用它？'
 # "invalid range expression of type %0; no viable '%select{begin|end}1' function available"
-H76B630AFA57F: '類型 %0 的範圍運算式無效；沒有可用的"%select{begin|end}1"函數'
+H76B630AFA57F: '類型 %0 的範圍運算式無效；沒有可用的 "%select{begin|end}1" 函數'
 # "invalid range following '-' in expected %0"
 H99FD9B7E0352: '在期望的 %0 後面的範圍無效'
 # "invalid reduction operator,  expected '+', '*', 'max', 'min', '&', '|', '^', '&&', or '||'"
-H3407BE2F5E5D: '無效的約簡運算子，期望"+", "*", "max", "min", "&", "|", "^", "&&", 或 "||"'
+H3407BE2F5E5D: '無效的約簡運算子，期望 "+", "*", "max", "min", "&", "|", "^", "&&", 或 "||"'
 # 'invalid reference to function %0: constraints not satisfied'
 H9E6FAF3D6010: '對函數 %0 的引用無效：約束條件未滿足'
 # 'invalid reinterpretation: sizes of %0 and %1 must match'
 HC6E0606A101D: '無效的重新詮釋：%0 和 %1 的大小必須匹配'
 # "invalid resource class specifier '%0' for packoffset, expected 'c'"
-H2B96C40BB1F0: "packoffset的無效資源類別指定符'%0'，期望為 'c'"
+H2B96C40BB1F0: "packoffset的無效資源類別指定符 '%0'，期望為 'c'"
 # 'invalid rounding argument'
 HD77BD554C068: '無效的捨入參數'
 # "invalid runtime library name in argument '%0'"
-HCC4F20591ADF: "參數'%0'中的無效執行階段程式庫名稱"
+HCC4F20591ADF: "參數 '%0' 中的無效執行階段程式庫名稱"
 # 'invalid size value'
 H41C03C7DB477: '無效的大小值'
 # "invalid space specifier '%0' used; expected 'space' followed by an integer, like space1"
-HB8CFB0AAB2CD: "使用了無效的間隔指定符'%0'；期望以 'space' 後跟整數，例如space1"
+HB8CFB0AAB2CD: "使用了無效的間隔指定符 '%0'；期望以 'space' 後跟整數，例如space1"
 # 'invalid special register for builtin'
 H26E533E2D360: '無效的內建特殊寄存器'
 # 'invalid storage class specifier in function declarator'
@@ -23293,19 +23293,19 @@ HF2FD2E42B318: '函數宣告中的無效存儲類別指定符'
 # "invalid string literal, ignoring final '\\'"
 H550F921F116D: "無效的字串文字，忽略最後的 '\\'"
 # "invalid suffix '%0' on %select{integer|floating|fixed-point}1 constant"
-HFE61994BB7A3: "%select{integer|floating|fixed-point}1 常數的無效後綴'%0'"
+HFE61994BB7A3: "%select{integer|floating|fixed-point}1 常數的無效後綴 '%0'"
 # 'invalid suffix on literal; C++11 requires a space between literal and identifier'
 H3AC3DC712C63: '字面值的無效後綴；C++11要求字面值和識別符之間有空格'
 # "invalid tag %0 on '%1' %select{directive|clause}2"
-HB6EF4B837656: "在'%1'的%select{指令|子句}2上使用無效標籤 %0"
+HB6EF4B837656: "在 '%1' 的%select{指令|子句}2上使用無效標籤 %0"
 # "invalid target ID '%0'; format is a processor name followed by an optional colon-delimited list of features followed by an enable/disable sign (e.g., 'gfx908:sramecc+:xnack-')"
-HF2F065F66FFD: "無效的目標ID '%0'；格式為處理器名稱後跟可選的以冒號分隔的功能清單，再後跟啟用/禁用符號（例如'gfx908:sramecc+:xnack-'）"
+HF2F065F66FFD: "無效的目標ID '%0'；格式為處理器名稱後跟可選的以冒號分隔的功能清單，再後跟啟用/禁用符號（例如 'gfx908:sramecc+:xnack-'）"
 # 'invalid target type %0 for dynamic_cast; target type must be a reference or pointer type to a defined class'
 HFE4D2B7D8E06: 'dynamic_cast的無效目標類型 %0；目標類型必須是已定義類別的引用或指標類型'
 # "invalid thread model '%0' in '%1' for this target"
-HE75965380195: "此目標在'%1'中的無效執行緒模型'%0'"
+HE75965380195: "此目標在 '%1' 中的無效執行緒模型 '%0'"
 # "invalid thread pointer reading mode '%0'"
-H602D0823E0FB: "無效的執行緒指標讀取模式'%0'"
+H602D0823E0FB: "無效的執行緒指標讀取模式 '%0'"
 # 'invalid token at start of a preprocessor expression'
 HAAFAB4DB043C: '預處理器表達式開頭處的無效記號'
 # 'invalid token in macro parameter list'
@@ -23317,7 +23317,7 @@ HE41F37E3851B: '在iboutletcollection屬性的引數中，類型 %0 無效'
 # 'invalid type %0 in asm %select{input|output}1'
 H2A71CC82E6A7: '在asm的%select{輸入|輸出}1中包含無效類型 %0'
 # "invalid type %0 in asm input for constraint '%1'"
-H1E6A37C4D619: "在asm輸入中類型 %0 不符合約束'%1'"
+H1E6A37C4D619: "在asm輸入中類型 %0 不符合約束 '%1'"
 # 'invalid type %0 is a %select{member|base}1 of %2'
 HB6D9D0DC110A: '無效的類型 %0 是 %2 的%select{成員|基底}1'
 # 'invalid type %0 to %1 operator'
@@ -23325,7 +23325,7 @@ H4C8C1A65C2A4: '無效的類型 %0 轉換為 %1 運算子'
 # 'invalid universal character'
 H73C6676CA247: '無效的通用字元'
 # "invalid unwind library name in argument '%0'"
-HD675186A50F6: "在引數'%0'中包含無效的unwind函式庫名稱"
+HD675186A50F6: "在引數 '%0' 中包含無效的unwind函式庫名稱"
 # "invalid use of '__funcref' keyword outside the WebAssembly triple"
 H5B018C340841: '在非WebAssembly三元組中使用__funcref關鍵字無效'
 # "invalid use of '__super', %0 has no base classes"
@@ -23345,7 +23345,7 @@ H50EBCD910232: '在%select{靜態|顯式物件}1成員函數中使用成員 %0 �
 # 'invalid use of non-static data member %0'
 H59D616D352F1: '使用非靜態資料成員 %0 無效'
 # 'invalid use of pointer to member type after %select{.*|->*}0'
-H48A2AD1643D5: '在%select{.*|->*}0之後使用成員類型指標無效'
+H48A2AD1643D5: '在 %select{.*|->*}0 之後使用成員類型指標無效'
 # 'invalid validator version : %0; format of validator version is "<major>.<minor>" (ex:"1.4")'
 H4B1AA82F67A0: '無效的驗證器版本：%0；驗證器版本格式為"<主要>.<次要>"（例如："1.4"）'
 # 'invalid validator version : %0; if validator major version is 0, minor version must also be 0'
@@ -23597,15 +23597,15 @@ HCE669C9CA888: 'lcov 追蹤檔輸出'
 # 'left hand operand of type %0 to compound assignment cannot be truncated when used with right hand operand of type %1'
 H00D9FE7F4F87: '左操作元的類型 %0 在複合指派時，與右操作元的類型 %1 混合時不能被截斷'
 # 'left hand operand to %0 must be a %select{|pointer to }1class compatible with the right hand operand, but is %2'
-HE8A81161D486: '%0 的左操作元必須與右操作元兼容的%select{|指標到 }1類別，但實際是 %2'
+HE8A81161D486: '%0 的左操作元必須與右操作元兼容的 %select{|指標到 }1類別，但實際是 %2'
 # "left hand side of assignment operation('%0') must match one side of the sub-operation on the right hand side('%1' and '%2')"
-HA99FEEFA45D5: "指派運算的左邊（'%0'）必須與右邊的子運算（'%1'和'%2'）其中一邊的類型一致"
+HA99FEEFA45D5: "指派運算的左邊（'%0'）必須與右邊的子運算（'%1' 和 '%2'）其中一邊的類型一致"
 # 'left operand of comma operator has no effect'
 H1D36CC5E4D5A: '逗號運算子的左操作元無效'
 # 'left shift of negative value %0'
 HF788BD55C118: '對負值 %0 進行左移位操作'
 # "length modifier '%0' results in undefined behavior or no effect with '%1' conversion specifier"
-HDCB24BE7C9E8: "長度修飾符'%0'與'%1'轉換說明符一起使用時會導致未定義行為或無效"
+HDCB24BE7C9E8: "長度修飾符 '%0' 與 '%1' 轉換說明符一起使用時會導致未定義行為或無效"
 # 'libclc builtin preparation tool\n'
 H8679FDE4DA62: 'libclc內建準備工具\n'
 # 'limit number of targets to consider when doing indirect call promotion on calls. 0 = no limit'
@@ -23647,7 +23647,7 @@ HED4CB34A956C: '要跳過的函數清單'
 # 'list of functions with call sites for which to specialize memcpy() for size 1'
 HD7F5B54EFF49: '要針對大小 1 進行memcpy()特殊化的呼叫位址所屬函數清單'
 # "list of sections containing functions used for hugifying hot text. BOLT makes sure these functions are not placed on the same page as the hot text. (default='.stub,.mover')."
-H07A4ADB5443D: '包含用於hugifying熱文本的函數的區段清單。BOLT確保這些函數不會與熱文本放在同一頁面上。（預設值為".stub,.mover"）'
+H07A4ADB5443D: '包含用於hugifying熱文本的函數的區段清單。BOLT確保這些函數不會與熱文本放在同一頁面上。（預設值為 ".stub,.mover"）'
 # 'list of sections to reorder'
 HE8B5B16B7FA7: '要重新排序的區段清單'
 # 'list of symbol names that can be reordered'
@@ -23739,13 +23739,13 @@ H09900D49A0E3: '%0 的本地宣告遮蔽了實例變數'
 # 'local type %0 as template argument is incompatible with C++98'
 H6116FD3EFF04: '在 C++98 中，將本地類型 %0 作為模板參數是不相容的。'
 # "local variable '%0' should not be used in 'declare target' directive;"
-HF2D2B034481C: "在'declare target'指令中不应使用本地變數'%0'；"
+HF2D2B034481C: "在 'declare target' 指令中不应使用本地變數 '%0'；"
 # "local variable cannot be declared 'constinit'"
 HE35DCF249418: "本地變數不能被聲明為 'constinit'"
 # "locking '%0' to build module '%1'"
-H36ABFAB03219: "將'%0'鎖定以建立模組'%1'"
+H36ABFAB03219: "將 '%0' 鎖定以建立模組 '%1'"
 # 'logical expression with vector %select{type %1 and non-vector type %2|types %1 and %2}0 is only supported in C++'
-H1200F428FBB0: '帶有向量%select{類型 %1 和非向量類型 %2|類型 %1 和 %2}0的邏輯運算式僅在C++中受支援'
+H1200F428FBB0: '帶有向量%select{類型 %1 和非向量類型 %2|類型 %1 和 %2}0 的邏輯運算式僅在C++中受支援'
 # 'logical not is only applied to the left hand side of this %select{comparison|bitwise operator}0'
 H9E8ECD267F25: '邏輯非僅應用於此%select{比較運算子|位元運算子}0的左邊操作數'
 # 'lookup from the current scope refers here'
@@ -23757,7 +23757,7 @@ H52F57D0BB44E: '在成員存取運算式中查找 %0 存在歧義'
 # 'lookup of %0 in member access expression is ambiguous; using member of %1'
 H632E112FD2AD: '在成員存取運算式中查找 %0 存在歧義；使用 %1 的成員'
 # "loop iteration variable in the associated loop of 'omp %1' directive may not be %0, predetermined as %2"
-H777624FA6F75: "與'omp %1'指令相關的循環迭代變數不能是 %0，其已被預先確定為 %2"
+H777624FA6F75: "與 'omp %1' 指令相關的循環迭代變數不能是 %0，其已被預先確定為 %2"
 # 'loop step is expected to be %select{negative|positive}0 due to this condition'
 HF9B9B19EF744: '期望因這個條件，迴圈步長為%select{負數|正數}0'
 # 'loop to be fully unrolled must have a constant trip count'
@@ -23769,13 +23769,13 @@ HDD2F7E9780FE: '循環變數 %0 綁定到由類型 %1 的範圍產生的臨時�
 # 'loop variable %0 creates a copy from type %1'
 H0EB738A6DA64: '循環變數 %0 從類型 %1 創建副本'
 # "loop variable %0 may not be declared %select{'extern'|'static'|'__private_extern__'|'auto'|'register'|'constexpr'|'thread_local'}1"
-HD1C2B82FE9FA: "循環變數 %0 不能被聲明為%select{'extern'|'static'|'__private_extern__'|'auto'|'register'|'constexpr'|'thread_local'}1"
+HD1C2B82FE9FA: "循環變數 %0 不能被聲明為 %select{'extern'|'static'|'__private_extern__'|'auto'|'register'|'constexpr'|'thread_local'}1"
 # "loop variable of loop associated with an OpenACC '%0' construct must be of integer, pointer, or random-access-iterator type (is %1)"
-HDE685F11E1FA: "與OpenACC '%0'結構相關的循環變數必須是整數、指標或隨機存取迭代器類型（目前為 %1）"
+HDE685F11E1FA: "與OpenACC '%0' 結構相關的循環變數必須是整數、指標或隨機存取迭代器類型（目前為 %1）"
 # 'loop will run at most once (loop increment never executed)'
 H41A7771F3080: '此循環最多執行一次（循環增量從未執行）'
 # "loop with a '%0' clause may not exist in the region of a '%1' clause%select{| on a '%3' construct}2"
-H31D69B81DD7A: "在'%1'子句的區域%select{|在'%3'結構上}2中，可能不存在具有'%0'子句的迴圈"
+H31D69B81DD7A: "在 '%1' 子句的區域 %select{|在 '%3' 結構上}2中，可能不存在具有 '%0' 子句的迴圈"
 # 'lower transpose without using a runtime call'
 H1DC7FFF629C0: '不使用執行階段調用進行轉置'
 # 'mac68k alignment pragma is not supported on this target'
@@ -23783,15 +23783,15 @@ H13A22B895D9E: '此目標不支援mac68k對齊pragma'
 # 'macro %0 defined here'
 H224BD0DEAAD4: '在此處定義的宏 %0'
 # 'macro %0 has been marked as deprecated%select{|: %2}1'
-HB9E9BBB38434: '宏 %0 已被標記為已棄用%select{|： %2}1'
+HB9E9BBB38434: '宏 %0 已被標記為已棄用 %select{|： %2}1'
 # 'macro %0 has been marked as final and should not be %select{undefined|redefined}1'
 H416ADCAF4BDC: '宏 %0 已被標記為最終且不得%select{未定義|重新定義}1'
 # 'macro %0 has been marked as unsafe for use in headers%select{|: %2}1'
-H0BD2BA6647E5: '此宏 %0 不應在標頭中使用%select{|： %2}1'
+H0BD2BA6647E5: '此宏 %0 不應在標頭中使用 %select{|： %2}1'
 # "macro '%0' contains embedded newline; text after the newline is ignored"
-HCA29C3134207: "宏'%0' 包含嵌入式換行符；換行符後的文本將被忽略"
+HCA29C3134207: "宏 '%0' 包含嵌入式換行符；換行符後的文本將被忽略"
 # "macro '%0' was %select{defined|undef'd}1 in the AST file '%2' but %select{undef'd|defined}1 on the command line"
-HEF8B87D78B88: "AST 檔案'%2' 中的宏'%0' 被%select{定義|#undef'd}0，但命令列中%select{#undef'd|定義}0"
+HEF8B87D78B88: "AST 檔案 '%2' 中的宏 '%0' 被%select{定義|#undef'd}0，但命令列中 %select{#undef'd|定義}0"
 # "macro expansion producing 'defined' has undefined behavior"
 H6CE80CBEAD13: "產生 'defined' 的宏展開具有未定義行為"
 # 'macro is not used'
@@ -23923,7 +23923,7 @@ HE96F2F88498F: '成員 %0 在不同類型的多個基底類別中找到'
 # 'member %0 has the same name as its class'
 HBDCB2F361AEB: '成員 %0 的名稱與其類別相同'
 # 'member %0 of %1 is not a template; did you mean %select{|simply }2%3?'
-H88F478FC5C17: '成員 %0 的 %1 不是模板；你是指%select{|直接 }2%3？'
+H88F478FC5C17: '成員 %0 的 %1 不是模板；你是指 %select{|直接 }2%3？'
 # 'member %0 used before its declaration'
 H21EA4914C844: '成員 %0 在宣告前使用'
 # 'member access into incomplete type %0'
@@ -24015,7 +24015,7 @@ H93D8788321DF: '方法鍵參數類型 %0 不是物件類型'
 # 'method marked as designated initializer of the class here'
 H6D873EC57BBB: '此方法被標記為類別的指定初始值設定項'
 # "method name referenced in property setter attribute must end with ':'"
-H48FC25BCA089: "屬性設定方法屬性中引用的方法名稱必須以':'結尾"
+H48FC25BCA089: "屬性設定方法屬性中引用的方法名稱必須以 ':' 結尾"
 # 'method object parameter type %0 is not object type'
 H7C5EC09F4D4E: '方法物件參數類型 %0 不是物件類型'
 # 'method override for the designated initializer of the superclass %objcinstance0 not found'
@@ -24029,13 +24029,13 @@ HF2DE0E720AA4: '此方法可能缺少[super %0]調用'
 # 'method returns unexpected type %0 (should be an object type)'
 HDA228B7E04A3: '方法返回了意外類型 %0（應為物件類型）'
 # "method type specifier must start with '-' or '+'"
-H60683402DB43: "方法類型指定符必須以'-'或'+'開頭"
+H60683402DB43: "方法類型指定符必須以 '-' 或 '+' 開頭"
 # "method was declared as %select{an 'alloc'|a 'copy'|an 'init'|a 'new'}0 method, but its implementation doesn't match because %select{its result type is not an object pointer|its result type is unrelated to its receiver type}1"
-H0332DF98668A: "此方法被宣告為%select{一個 'alloc'|一個 'copy'|一個 'init'|一個 'new'}0方法，但其實作不符，因為%select{其回傳類型並非物件指標|其回傳類型與接收者類型無關}1"
+H0332DF98668A: "此方法被宣告為%select{一個 'alloc'|一個 'copy'|一個 'init'|一個 'new'}0 方法，但其實作不符，因為%select{其回傳類型並非物件指標|其回傳類型與接收者類型無關}1"
 # 'methods that %select{override superclass methods|implement protocol requirements}0 cannot be direct'
 H10E1F7CDD559: '%select{覆寫超類方法|實作協定需求}0的方法不能直接呼叫'
 # "micromips is not supported for target CPU '%0'"
-H17AAF1CF7567: "目標CPU '%0'不支援micromips"
+H17AAF1CF7567: "目標CPU '%0' 不支援micromips"
 # 'minimal size of the basic block that should be aligned'
 H9310AFA3C7C1: '應對齊的基本區塊的最小大小'
 # 'minimum address considered valid for heatmap (default 0)'
@@ -24057,9 +24057,9 @@ HB503599C3686: '約簡運算中使用減法（-）運算子已被棄用；建議
 # 'misaligned atomic operation may incur significant performance penalty; the expected alignment (%0 bytes) exceeds the actual alignment (%1 bytes)'
 HB642C05FEFCE: '未對齊的原子操作可能會導致顯著的效能損失；期望的對齊度（%0 個位元組）超過實際對齊度（%1 個位元組）'
 # "misleading indentation; statement is not part of the previous '%select{if|else|for|while}0'"
-H2D720E07A9B5: "誤導性的縮排；此語句並非前一個'%select{if|else|for|while}0'的部分"
+H2D720E07A9B5: "誤導性的縮排；此語句並非前一個 '%select{if|else|for|while}0' 的部分"
 # "mismatch between architecture and environment in target triple '%0'; did you mean '%1'?"
-HFB1C45E0F3D8: "目標三元組'%0'中的架構與環境不符；是否應指定為'%1'？"
+HFB1C45E0F3D8: "目標三元組 '%0' 中的架構與環境不符；是否應指定為 '%1'？"
 # 'mismatch in number of block parameters and local size arguments passed'
 H297CC009BE30: '區塊參數數量與傳遞的本地大小引數數量不匹配'
 # 'misplaced %0; expected %0 here'
@@ -24073,7 +24073,7 @@ H71A0939C10D8: '缺少 %0 後面的 %1'
 # "missing '(' after '#pragma %0' - ignoring"
 H9BCF4D2D832C: "在 '#pragma %0' 後缺少 '(' - 忽略"
 # "missing '(' following __VA_OPT__"
-HFEF64C94E397: "在__VA_OPT__後缺少'('"
+HFEF64C94E397: "在__VA_OPT__後缺少 '('"
 # "missing ')' after '#pragma %0' - ignoring"
 HD628B31A25D9: "在 '#pragma %0' 後缺少 ')' - 忽略"
 # "missing ')' in macro parameter list"
@@ -24119,7 +24119,7 @@ HAF73F9C8E8E7: "在 %q0 的定義末尾缺少 '}'"
 # 'missing actual type specifier for pipe'
 H369BCA42F29A: '缺少管道的實際類型規格'
 # "missing argument to '#pragma %0'%select{|; expected %2}1"
-H85D43DEA45AB: '#pragma %0 缺少參數%select{|；期望 %2}1'
+H85D43DEA45AB: '#pragma %0 缺少參數 %select{|；期望 %2}1'
 # "missing argument to '%0'"
 H52AC6CD34BC9: "'%0' 缺少參數"
 # "missing argument to debug command '%0'"
@@ -24221,7 +24221,7 @@ H6556B7A46703: "模組 '%0' 已經以 '%1' 的名稱重新導出"
 # "module '%0' conflicts with already-imported module '%1': %2"
 HED958876B86C: "模組 '%0' 與已導入的模組 '%1' 冲突：%2"
 # "module '%0' in AST file '%1' %select{(imported by AST file '%2') |}4is not defined in any loaded module map file; maybe you need to load '%3'?"
-H951252F32734: "AST 檔案 '%1' 中的模組 '%0' %select{(由 AST 檔案 '%2' 引入) |}4未在任何已載入的模組地圖檔中定義；可能需要載入 '%3'？"
+H951252F32734: "AST 檔案 '%1' 中的模組 '%0' %select{(由 AST 檔案 '%2' 引入) |}4 未在任何已載入的模組地圖檔中定義；可能需要載入 '%3'？"
 # "module '%0' is defined in both '%1' and '%2'"
 H9937FAC6E395: "模組 '%0' 同時在 '%1' 和 '%2' 中定義"
 # "module '%0' is needed but has not been provided, and implicit use of module files is disabled"
@@ -24269,7 +24269,7 @@ HB98F31FF7B9A: '模組分割僅支援 C++20 及更新版本'
 # 'module search directory'
 H3FAA97FDA5D1: '模組搜尋目錄'
 # 'module%select{| partition}0 imports cannot be in the %select{global|private}1 module fragment'
-HE6F2588D0369: '模組%select{| 分割}0 的導入不得位於 %select{全域|私人}1 模組片段中'
+HE6F2588D0369: '模組 %select{| 分割}0 的導入不得位於 %select{全域|私人}1 模組片段中'
 # "more '%%' conversions than data arguments"
 H9766AC9D490A: "'%%' 轉換數多於資料參數"
 # "more than one 'device_type' clause is specified"
@@ -24607,13 +24607,13 @@ HFC0C70B06D89: '找不到名為 %0 的範本'
 # 'no template named %0 in %1'
 H16DB7E6BC24D: '在 %1 中未找到名為 %0 的範本'
 # 'no template named %0 in %1; did you mean %select{|simply }2%3?'
-HCDFE5581F7D6: '在 %1 中未找到名為 %0 的範本; 是否%select{|僅}2指 %3?'
+HCDFE5581F7D6: '在 %1 中未找到名為 %0 的範本; 是否 %select{|僅}2指 %3?'
 # 'no template named %0; did you mean %1?'
 H32AFF6E21FDC: '未找到名為 %0 的範本; 是否指 %1?'
 # 'no type named %0 in %1'
 H6E87E8CAFF42: '在 %1 中未找到名為 %0 的類型'
 # 'no type named %0 in %1; did you mean %select{|simply }2%3?'
-H014C7B262D03: '在 %1 中未找到名為 %0 的類型; 是否%select{|僅}2指 %3?'
+H014C7B262D03: '在 %1 中未找到名為 %0 的類型; 是否 %select{|僅}2指 %3?'
 # "no type named 'type' in %0; 'enable_if' cannot be used to disable this declaration"
 H03B3775679FC: "在 %0 中未找到名為 'type' 的類型; 'enable_if' 無法用來禁用此宣告"
 # 'no type or protocol named %0'
@@ -24623,7 +24623,7 @@ H136795D57206: "OpenACC 'declare' 指令中未指定有效的子句"
 # 'no variable template matches specialization; did you mean to use %0 as function template instead?'
 H702E78FBEC31: '未找到匹配的變數範本專門化; 是否應改用 %0 作為函數範本?'
 # 'no variable template matches%select{| partial}0 specialization'
-H0903C7695A91: '未找到匹配的%select{|部分}0專門化變數範本'
+H0903C7695A91: '未找到匹配的 %select{|部分}0專門化變數範本'
 # 'no viable candidate for explicit instantiation of %0'
 HAEBC7520AFB0: '無法明確實體化 %0 的可行候選'
 # 'no viable constructor %select{copying variable|copying parameter|initializing template parameter|returning object|initializing statement expression result|throwing object|copying member subobject|copying array element|allocating object|copying temporary|initializing base subobject|initializing vector element|capturing value}0 of type %1'
@@ -24635,7 +24635,7 @@ HECA595B57B5C: '無法找到可用的構造函數或範型參數推論指引以�
 # 'no viable conversion%diff{ from $ to incomplete type $|}0,1'
 H0DDC152C267D: '無法進行轉換%diff{從$轉換為不完整類型$|}0,1'
 # 'no viable conversion%select{%diff{ from $ to $|}1,2|%diff{ from returned value of type $ to function return type $|}1,2}0'
-H742AD0829398: '無法進行轉換%select{%diff{從$轉換為$|}1,2|%diff{從返回值類型$轉換為函數返回類型$|}1,2}0'
+H742AD0829398: '無法進行轉換 %select{%diff{從$轉換為$|}1,2|%diff{從返回值類型$轉換為函數返回類型$|}1,2}0'
 # 'no viable destructor found for class %0'
 HE8AA8B1D9E66: '類別 %0 沒有合適的析構函數'
 # "no viable overloaded '%0'"
@@ -24675,7 +24675,7 @@ H2C52662649BE: '非預設的 #pragma pack 值會改變包含檔案中結構或�
 # "non-default visibility cannot be applied to 'dllimport' declaration"
 H2A9EC7D43705: "無法將非預設的可見性套用到 'dllimport' 声明"
 # 'non-defining declaration of enumeration with a fixed underlying type is only permitted as a standalone declaration%select{|; missing list of enumerators?}0'
-H4D151B6B2BF9: '具有固定基礎類型的枚舉的非定義宣告只能作為獨立宣告使用%select{|; 缺少枚舉器列表？}0'
+H4D151B6B2BF9: '具有固定基礎類型的枚舉的非定義宣告只能作為獨立宣告使用 %select{|; 缺少枚舉器列表？}0'
 # 'non-deleted function %0 cannot override a deleted function'
 H2F21A881D5B2: '非已刪除的函數 %0 不能覆寫已刪除的函數'
 # 'non-extern declaration of %0 follows extern declaration'
@@ -24771,7 +24771,7 @@ H2465AB2AA5B5: '非常式模板參數值指向非靜態資料成員 %0'
 # 'non-type template argument refers to non-static member function %0'
 H6A037F433017: '非常式模板參數值指向非靜態成員函數 %0'
 # "non-type template argument refers to subobject '%0'"
-HD30CEA1C7504: "非常式模板參數值指向子物件'%0'"
+HD30CEA1C7504: "非常式模板參數值指向子物件 '%0'"
 # 'non-type template argument refers to thread-local object'
 H1DFBA6B66CEF: '非類型模板參數引用執行緒局部物件'
 # 'non-type template argument specializes a template parameter with dependent type %0'
@@ -24811,21 +24811,21 @@ H6156F12DC3F9: '非虛函數 %0 掩蓋了虛成員 %select{函數|函數們}1'
 # 'non-void %select{constexpr|consteval}1 function %0 should return a value'
 HCF55E17BA989: '非 void %select{constexpr|consteval}1 函數 %0 應該回傳值'
 # 'non-void %select{function|block|lambda|coroutine}0 does not return a value%select{| in all control paths}1'
-H75EE618D1AA4: '非void的%select{函數|區塊|lambda|coroutine}0未回傳值%select{|在所有控制路徑中}1'
+H75EE618D1AA4: '非void的%select{函數|區塊|lambda|coroutine}0 未回傳值 %select{|在所有控制路徑中}1'
 # 'non-void %select{function|method}1 %0 should return a value'
 HEE95067001EB: '非void的%select{函數|方法}1 %0 應回傳值'
 # 'non-void block should return a value'
 H66594B013217: '非void的區塊應回傳值'
 # "nonnull %select{function call|parameter}0 '%1' will evaluate to 'true' on first encounter"
-H925BCFBBE426: "非空%select{函數呼叫|參數}0 '%1'在首次遇到時將評估為 'true'"
+H925BCFBBE426: "非空%select{函數呼叫|參數}0 '%1' 在首次遇到時將評估為 'true'"
 # 'not a Doxygen trailing comment'
 HB02E938B9DEC: '不是Doxygen的尾注註解'
 # "not currently inside '#pragma clang arc_cf_code_audited'"
-HD79C4D940185: "目前不在'#pragma clang arc_cf_code_audited'指令內"
+HD79C4D940185: "目前不在 '#pragma clang arc_cf_code_audited' 指令內"
 # "not currently inside '#pragma clang assume_nonnull'"
-HF77D5E6601B3: "目前不在'#pragma clang assume_nonnull'指令內"
+HF77D5E6601B3: "目前不在 '#pragma clang assume_nonnull' 指令內"
 # "not currently inside '#pragma unsafe_buffer_usage'"
-H658512A345D7: "目前不在'#pragma unsafe_buffer_usage'指令內"
+H658512A345D7: "目前不在 '#pragma unsafe_buffer_usage' 指令內"
 # 'not enough variable arguments in %0 declaration to fit a sentinel'
 H9930B56495BC: '在 %0 宣告中可變參數不足以適配哨兵'
 # 'not packing field %0 as it is non-POD for the purposes of layout'
@@ -24937,7 +24937,7 @@ HA318D6E65846: "必須是 'for'、'parallel'、'sections' 或 'taskgroup' 其中
 # 'one possibility'
 HF5AE3D1F7A2D: '一個可能選項'
 # "only %select{'omp_priv' or 'omp_orig'|'omp_in' or 'omp_out'}0 variables are allowed in %select{initializer|combiner}0 expression"
-HBFBFE733ACC9: "在%select{初始式|組合式}0 表達式中，僅允許%select{'omp_priv' 或 'omp_orig'|'omp_in' 或 'omp_out'}0 變數"
+HBFBFE733ACC9: "在%select{初始式|組合式}0 表達式中，僅允許 %select{'omp_priv' 或 'omp_orig'|'omp_in' 或 'omp_out'}0 變數"
 # "only '*' can be exported from an inferred submodule"
 HB1E7869E1AA8: "只能從推論的子模組中匯出 '*'"
 # "only 'device_type(any)' clause is allowed with indirect clause"
@@ -24999,7 +24999,7 @@ H1F90A0F5DC05: '僅在迴圈定義很可能未被使用時替換退出值'
 # 'only show the top N results'
 H31C65CA913F9: '僅顯示頂部 N 個結果'
 # 'only special member functions %select{|and comparison operators }0may be defaulted'
-H7676F4E831FD: '僅特殊成員函數%select{|和比較運算子 }0可以被預設'
+H7676F4E831FD: '僅特殊成員函數 %select{|和比較運算子 }0可以被預設'
 # 'only submodules and framework modules may be inferred with wildcard syntax'
 HB41F304027AC: '只能使用通配符語法推斷子模組和框架模組'
 # 'only the first dimension of an allocated array may have dynamic size'
@@ -25065,7 +25065,7 @@ H583C3C9DA6E7: "選項 '%0' 需要與 '%1' 一同指定"
 # "option '%0' requires input to be LLVM bitcode"
 HA5B4E61775E4: "選項 '%0' 需要輸入為LLVM位元碼"
 # "option '%0' was ignored by the %1 toolchain, using '-fPIC'"
-H22B2E1051C0B: "選項 '%0' 被 %1 工具鏈忽略，改用'-fPIC'"
+H22B2E1051C0B: "選項 '%0' 被 %1 工具鏈忽略，改用 '-fPIC'"
 # "option '-MG' requires '-M' or '-MM'"
 HCCC4BA63CA80: "選項 '-MG' 需要搭配 '-M' 或 '-MM'"
 # "option '-ffine-grained-bitfield-accesses' cannot be enabled together with a sanitizer; flag ignored"
@@ -25249,9 +25249,9 @@ HB6BB1AF1B37E: '參數 %0 已設定但未使用'
 # "parameter %0 was not declared, defaults to 'int'; ISO C99 and later do not support implicit int"
 H41790618129F: "參數 %0 未宣告，預設為 'int'；ISO C99及之後版本不支援隱含int類型"
 # "parameter '%0' is already documented"
-HF9B7DF355428: "參數'%0'已被文檔化"
+HF9B7DF355428: "參數 '%0' 已被文檔化"
 # "parameter '%0' not found in the function declaration"
-HD7CC3BBE6634: "在函數宣告中未找到參數'%0'"
+HD7CC3BBE6634: "在函數宣告中未找到參數 '%0'"
 # "parameter '%0' not in expected state when the function returns: expected '%1', observed '%2'"
 H6EE5C60DD591: "參數 '%0' 在函數返回時未處於期望狀態：期望 '%1'，觀察到 '%2'"
 # "parameter cannot be named '%select{global|unknown}0' while using 'lifetime_capture_by(%select{global|unknown}0)'"
@@ -25273,7 +25273,7 @@ H6E3911EE67CF: '%0 屬性必須是Objective-C %select{類|協定}1的單一名�
 # 'parameter of %0 cannot have a default argument'
 H9997206462BD: '%0 的參數不能有預設參數值'
 # "parameter of literal operator must have type 'unsigned long long', 'long double', 'char', 'wchar_t', 'char16_t', 'char32_t', or 'const char *'"
-H18EF0BD0BEB6: "字面運算子的參數必須具有類型'unsigned long long'、'long double'、'char'、'wchar_t'、'char16_t'、'char32_t' 或'const char *'"
+H18EF0BD0BEB6: "字面運算子的參數必須具有類型 'unsigned long long'、'long double'、'char'、'wchar_t'、'char16_t'、'char32_t' 或 'const char *'"
 # 'parameter of overloaded %0 cannot have a default argument'
 H31033CF29CE2: '重載的 %0 參數不能有預設參數值'
 # "parameter of overloaded post-%select{increment|decrement}1 operator must have type 'int' (not %0)"
@@ -25301,9 +25301,9 @@ H10627ACFF3E1: "'omp %select{取消點|取消}0' 建構式的父區域不能為 
 # "parent region for 'omp %select{cancellation point|cancel}0' construct cannot be ordered"
 H2F8AAD55F0CC: "'omp %select{取消點|取消}0' 建構式的父區域不能為 ordered"
 # "parent umbrella does not match: '%0' (provided) vs '%1' (found)"
-H38C90C7CC02F: "父層傘目錄不匹配：'%0'（提供）與'%1'（找到）"
+H38C90C7CC02F: "父層傘目錄不匹配：'%0'（提供）與 '%1'（找到）"
 # "parent umbrella missing from %0: '%1'"
-HCD77F7184E7F: "父層傘目錄 %0 中缺少'%1'"
+HCD77F7184E7F: "父層傘目錄 %0 中缺少 '%1'"
 # 'parentheses are required around macro argument containing braced initializer list'
 H41A73FF55953: '包含花括號初始化清單的宏參數必須加上括號'
 # 'parentheses are required around this expression in a requires clause'
@@ -25335,13 +25335,13 @@ H84CBC790F3FB: '%0 的部分特化未使用其任何模板參數'
 # 'pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions'
 HB623B7D5D4C9: '傳遞-fsafe-buffer-usage-suggestions以取得程式碼強化建議'
 # 'passing %0-byte aligned argument to %1-byte aligned parameter %2%select{| of %4}3 may result in an unaligned pointer access'
-H8E7373BFAB19: '傳遞 %0 位元組對齊的引數至 %1 位元組對齊的參數 %2%select{| of %4}3可能导致未對齊的指標存取'
+H8E7373BFAB19: '傳遞 %0 位元組對齊的引數至 %1 位元組對齊的參數 %2%select{| of %4}3 可能导致未對齊的指標存取'
 # 'passing %select{address of|reference to}0 local temporary object to musttail function'
 H185CAE78405D: '將本地臨時物件%select{的位址|的參考}0傳遞給musttail函數'
 # "passing %select{an object that undergoes default argument promotion|an object of reference type|a parameter declared with the 'register' keyword}0 to 'va_start' has undefined behavior"
 H71043E0BAFE6: "將%select{經預設參數提升的物件|引用類型的物件|以 'register' 關鍵字宣告的參數}0傳遞給 'va_start' 具有未定義行為"
 # "passing '%0' format string where '%1' format string is expected"
-HB0DCC631BCB0: "傳遞'%0'格式字串，而這裡期望的是'%1'格式字串"
+HB0DCC631BCB0: "傳遞 '%0' 格式字串，而這裡期望的是 '%1' 格式字串"
 # "passing a type argument as the first operand to '_Generic' is a C2y extension"
 H9B0C1A1B2AAD: "將類型參數作為 '_Generic' 的第一個操作數傳遞是C2y的擴充功能"
 # "passing a type argument as the first operand to '_Generic' is incompatible with C standards before C2y"
@@ -25353,39 +25353,39 @@ H30E4C5FD05FE: '這裡傳遞參數 %0 的參數值'
 # 'passing argument to parameter here'
 HC7C3DD07B432: '這裡傳遞參數的參數值'
 # 'passing arguments to %select{a function|%1}0 without a prototype is deprecated in all versions of C and is not supported in C23'
-H192BBFFB4918: '將參數傳遞給%select{函數|%1}0而無原型在所有C版本中均已被棄用，且不支援C23'
+H192BBFFB4918: '將參數傳遞給%select{函數|%1}0 而無原型在所有C版本中均已被棄用，且不支援C23'
 # 'passing byval argument %0 with potentially incompatible alignment here'
 H730F797EFCA9: '這裡傳遞具有潛在不相容對齊的byval參數 %0'
 # "passing no argument for the '...' parameter of a variadic macro is a C++20 extension"
-H6D5DB0C5BBB6: "未為可變參數宏的'...'參數傳遞參數是C++20的擴充功能"
+H6D5DB0C5BBB6: "未為可變參數宏的 '...' 參數傳遞參數是C++20的擴充功能"
 # "passing no argument for the '...' parameter of a variadic macro is a C23 extension"
-H0F0C361742D6: "未為可變參數宏的'...'參數傳遞參數是C23的擴充功能"
+H0F0C361742D6: "未為可變參數宏的 '...' 參數傳遞參數是C23的擴充功能"
 # "passing no argument for the '...' parameter of a variadic macro is incompatible with C standards before C23"
-HCA1A72FB669A: "未為可變參數宏的'...'參數傳遞參數與C23之前的C標準不相容"
+HCA1A72FB669A: "未為可變參數宏的 '...' 參數傳遞參數與C23之前的C標準不相容"
 # "passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20"
-H2B8F35860B3B: "未為可變參數宏的'...'參數傳遞參數與C++20之前的C++標準不相容"
+H2B8F35860B3B: "未為可變參數宏的 '...' 參數傳遞參數與C++20之前的C++標準不相容"
 # 'passing non-generic address space pointer to %0 may cause dynamic conversion affecting performance'
 HAEF068C749A4: '將非通用位址空間指標傳遞給 %0 可能導致動態轉換而影響效能'
 # "passing object of class type %0 through variadic %select{function|block|method|constructor}1%select{|; did you mean to call '%3'?}2"
-H39C1EFFB876B: "將類型 %0 的物件透過可變參數%select{函數|區塊|方法|建構函數}1傳遞%select{|；您是否想呼叫'%3'？}2"
+H39C1EFFB876B: "將類型 %0 的物件透過可變參數%select{函數|區塊|方法|建構函數}1傳遞 %select{|；您是否想呼叫 '%3'？}2"
 # 'passing object of trivial but non-POD type %0 through variadic %select{function|block|method|constructor}1 is incompatible with C++98'
 HD5D2FE67C0FC: '將類型 %0 的物件（其為非POD但具有平凡特性的類型）透過可變參數%select{函數|區塊|方法|建構函數}1傳遞與C++98不相容'
 # "passing only one argument to 'va_start' is incompatible with C standards before C23"
 H0DFF95F6ABB1: "僅傳遞一個參數給 'va_start' 與C23之前的C標準不相容"
 # "passing pointer %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
-H9E268E19A549: "傳遞指標 %1 需要持有 %0 %select{'%2'|'獨佔的 %2'}3"
+H9E268E19A549: "傳遞指標 %1 需要持有 %0 %select{'%2'|' 獨佔的 %2'}3"
 # "passing pointer to variable %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
-H0E1F82092409: "傳遞變數 %1 的指標需要持有 %0 %select{'%2'|'獨佔的 %2'}3"
+H0E1F82092409: "傳遞變數 %1 的指標需要持有 %0 %select{'%2'|' 獨佔的 %2'}3"
 # "passing the value that %1 points to by reference requires holding %0 %select{'%2'|'%2' exclusively}3"
-HFB2B4F9A02B6: "以引用方式傳遞 %1 所指物件的值需要持有 %0 %select{'%2'|'獨佔的 %2'}3"
+HFB2B4F9A02B6: "以引用方式傳遞 %1 所指物件的值需要持有 %0 %select{'%2'|' 獨佔的 %2'}3"
 # 'passing union across security boundary via %select{parameter %1|return value}0 may leak information'
 HA1E50C08E561: '透過%select{參數 %1|傳回值}0傳遞聯組跨越安全性邊界可能會洩漏資訊'
 # "passing variable %1 by reference requires holding %0 %select{'%2'|'%2' exclusively}3"
-HB011E968C37B: "以引用方式傳遞變量 %1 需要持有 %0 %select{'%2'|'排他性持有的 %2'}3"
+HB011E968C37B: "以引用方式傳遞變量 %1 需要持有 %0 %select{'%2'|' 排他性持有的 %2'}3"
 # "pasting formed '%0', an invalid preprocessing token"
-H17B929BA26C6: "拼接形成'%0'，這是無效的預處理符號"
+H17B929BA26C6: "拼接形成 '%0'，這是無效的預處理符號"
 # "pasting two '/' tokens into a '//' comment is a Microsoft extension"
-HBFF0AAF786C4: "將兩個'/'符號拼接成'//'註解是Microsoft擴展"
+HBFF0AAF786C4: "將兩個 '/' 符號拼接成 '//' 註解是Microsoft擴展"
 # 'path to a pass plugin for HIP to SPIR-V passes.'
 HF42DFD9FA413: 'HIP到SPIR-V管線的插件路徑'
 # 'path to instrumented binary in case if /proc/self/map_files is not accessible due to access restriction issues'
@@ -25423,7 +25423,7 @@ H653C9447EE92: 'performSelector可能因選擇子未知導致記憶體洩漏'
 # 'performSelector names a selector which retains the object'
 HF51E4C8347B0: 'performSelector 指定的選擇器會保留該物件'
 # 'performing pointer arithmetic on a null pointer has undefined behavior%select{| if the offset is nonzero}0'
-HA288389E9F6A: '在空指標上執行指標運算具有未定行為%select{|如果偏移量不為零}0'
+HA288389E9F6A: '在空指標上執行指標運算具有未定行為 %select{|如果偏移量不為零}0'
 # 'performing pointer subtraction with a null pointer %select{has|may have}0 undefined behavior'
 HB725A707608F: '使用空指標進行指標減法%select{具有|可能具有}0 未定行為'
 # 'performs disassembly sequentially'
@@ -25581,9 +25581,9 @@ HBCF9A92B45C8: '保留中間的.o 檔案'
 # 'pretty-print DWARF debug information in object files and debug info archives.\n'
 HFF4E6027BC6C: '在物件檔和除錯資訊存檔中美觀列印DWARF除錯資訊。\n'
 # 'previous %select{template type|non-type template|template template}0 parameter%select{| pack}1 declared here'
-HEDFC0D57E1AE: '先前%select{模板類型|非類型模板|模板模板}0 參數%select{| 包}1 在此宣告'
+HEDFC0D57E1AE: '先前%select{模板類型|非類型模板|模板模板}0 參數 %select{| 包}1 在此宣告'
 # 'previous %select{unmarked |}0overload of function is here'
-HAE3E66A916BE: '先前函數%select{未標記的 |}0重載在此處'
+HAE3E66A916BE: '先前函數%select{未標記的 |}0 重載在此處'
 # "previous '#pragma pack' directive that modifies alignment is here"
 H39F3F82E0571: '先前修改對齊的 "#pragma pack" 指令在此處'
 # "previous '%0' directive used here"
@@ -25597,7 +25597,7 @@ H6E32F6609895: '先前的屬性在此處'
 # 'previous binding pack specified here'
 H720F62C2E50B: '先前指定的綁定包在此處'
 # 'previous call is here%select{; set to nil to indicate it cannot be called afterwards|}0'
-HE8A56E8F5AF3: '先前的呼叫在此處%select{; 設置為nil以表示其後不可呼叫|}0'
+HE8A56E8F5AF3: '先前的呼叫在此處 %select{; 設置為nil以表示其後不可呼叫|}0'
 # 'previous case defined here'
 H67B17B33B89D: '先前定義的案例在此處'
 # 'previous clause is here'
@@ -25605,7 +25605,7 @@ HE9FAFB90DAE5: '先前的子句在此處'
 # 'previous clause with directive name modifier specified here'
 H59743B40EF38: '先前具有指令名稱修飾符的子句在此處指定'
 # "previous command '%select{\\|@}0%1' (an alias of '\\%2') here"
-HE969B475A653: '先前的指令 "%select{\\|@}0%1" (是"\\%2"的別名) 此處'
+HE969B475A653: '先前的指令 "%select{\\|@}0%1" (是 "\\%2" 的別名) 此處'
 # "previous command '%select{\\|@}0%1' here"
 H5B43AF8F451D: '先前的指令 "%select{\\|@}0%1" 此處'
 # 'previous declaration is here'
@@ -25635,7 +25635,7 @@ H2F8B22E01C4A: '先前的隱式宣告位於此處'
 # 'previous inheritance model specified here'
 HDD10F14D9687: '先前指定的繼承模型位於此處'
 # 'previous initialization %select{|with side effects }0is here%select{| (side effects will not occur at run time)}0'
-HFE059F4FA2A1: '先前的初始化 %select{|具有副作用 }0位於此處%select{|（執行階段不會產生副作用）}0'
+HFE059F4FA2A1: '先前的初始化 %select{|具有副作用 }0位於此處 %select{|（執行階段不會產生副作用）}0'
 # 'previous initialization for field %0 is here'
 HEF0E98EA391B: '先前的成員 %0 初始化位於此處'
 # 'previous module declaration is here'
@@ -25879,9 +25879,9 @@ H4ECC248CA95F: '屬性 %0 已實作'
 # 'property %0 is declared %select{deprecated|unavailable|partial}1 here'
 HC2D276377832: '屬性 %0 在此處宣告為%select{已停用|不可用|部分}1'
 # 'property %0 is implemented with %select{@synthesize|@dynamic}1 here'
-H43FFE47B4C6F: '屬性 %0 已使用%select{@synthesize|@dynamic}1實作'
+H43FFE47B4C6F: '屬性 %0 已使用 %select{@synthesize|@dynamic}1 實作'
 # 'property %0 is implemented with %select{@synthesize|@dynamic}1 in one translation but %select{@dynamic|@synthesize}1 in another translation unit'
-H7C85E91BA02D: '屬性 %0 在某個翻譯單元使用%select{@synthesize|@dynamic}1實作，但在另一個翻譯單元使用%select{@dynamic|@synthesize}1實作'
+H7C85E91BA02D: '屬性 %0 在某個翻譯單元使用 %select{@synthesize|@dynamic}1 實作，但在另一個翻譯單元使用 %select{@dynamic|@synthesize}1 實作'
 # 'property %0 is synthesized to different ivars in different translation units (%1 vs. %2)'
 HE49921A78EC2: '屬性 %0 在不同翻譯單元合成到不同的實例變數（%1 vs. %2）'
 # 'property %0 not found on object of type %1'
@@ -25899,7 +25899,7 @@ HD9354003F0AB: '屬性 %0 需要定義方法 %1 - 請使用@dynamic或在這個�
 # 'property %0 requires method %1 to be defined - use @synthesize, @dynamic or provide a method implementation in this class implementation'
 HD343415F7FA6: '屬性 %0 需要定義方法 %1 - 請使用@synthesize、@dynamic或在這個類別實作中提供方法實作'
 # "property %select{of type %1|with attribute '%1'|without attribute '%1'|with getter %1|with setter %1}0 was selected for synthesis"
-HAD70544BC938: "屬性%select{類型 %1|具有屬性'%1'|缺少屬性'%1'|具有getter%1|具有setter%1}0被選取進行合成"
+HAD70544BC938: "屬性%select{類型 %1|具有屬性 '%1'|缺少屬性 '%1'|具有getter%1|具有setter%1}0 被選取進行合成"
 # 'property access is using %0 method which is deprecated'
 HC446F861F2EE: '屬性存取正在使用已棄用的 %0 方法'
 # 'property access is using %0 method which is unavailable'
@@ -25909,13 +25909,13 @@ H1D3B4CAFB27A: '屬性存取結果未被使用 - getter不應用於副作用'
 # 'property attribute in class extension does not match the primary class'
 H928CE0C5C480: '類別延伸中的屬性屬性與主類不符'
 # "property attributes '%0' and '%1' are mutually exclusive"
-H4A7BE0C59F5F: "屬性屬性'%0'和'%1'是互斥的"
+H4A7BE0C59F5F: "屬性屬性 '%0' 和 '%1' 是互斥的"
 # 'property cannot have array or function type %0'
 HE68B6C09E364: '屬性宣告不能具有陣列或函數類型 %0'
 # 'property declaration cannot have a default member initializer'
 H5272D8E5D57E: '屬性宣告不能有預設成員初始化器'
 # "property declaration specifies '%0' accessor twice"
-H0E68E4E4BA05: "屬性宣告多次指定'%0'存取器"
+H0E68E4E4BA05: "屬性宣告多次指定 '%0' 存取器"
 # 'property declared as returning non-retained objects; getter returning retained objects'
 H53034807D818: '屬性宣告為傳回非保留物件；getter傳回保留物件'
 # 'property declared here'
@@ -25953,7 +25953,7 @@ H0BB379E6C96C: '此處合成屬性'
 # 'property type %0 is incompatible with type %1 inherited from %2'
 HDE3695134102: '屬性類型 %0 與從 %2 繼承的類型 %1 不相容'
 # "property with '%0' attribute must be of object type"
-H44EF18C35C26: "具有'%0'屬性的屬性必須為物件類型"
+H44EF18C35C26: "具有 '%0' 屬性的屬性必須為物件類型"
 # 'protected %select{constructor|destructor}0 can only be used to %select{construct|destroy}0 a base class subobject'
 H8490EFD629C0: '受保護的%select{建構函數|析構函數}0只能用於%select{建構|销毁}0基類子物件'
 # 'protocol %0 has no definition'
@@ -25971,7 +25971,7 @@ H850DBE7D30DB: '協定方法在此處'
 # 'protocol qualifiers must precede type arguments'
 HE1585F9267E6: '協定限定符必須出現在類型參數之前'
 # "provided host compiler IR file '%0' is required to generate code for OpenMP target regions but cannot be found"
-H4ECB10C5BABB: "提供的主編譯器IR文件'%0'需要生成OpenMP目標區域的代碼，但無法找到"
+H4ECB10C5BABB: "提供的主編譯器IR文件 '%0' 需要生成OpenMP目標區域的代碼，但無法找到"
 # 'pseudo-destructor call is not permitted in constant expressions until C++20'
 HFC660C022DFD: '在C++20之前，常量表達式中不允许使用偽析構函數調用'
 # 'pseudo-destructor destroys object of type %0 with inconsistently-qualified type %1'
@@ -25979,7 +25979,7 @@ HFC3306882505: '偽析構函數銷毀了類型 %0 的物件，其修飾類型 %1
 # 'pseudo-destructors on type void are a Microsoft extension'
 H6C76EC18D3A0: 'void類型的偽析構函數是Microsoft擴充功能'
 # "public framework header includes private framework header '%0'"
-H7F0AEF01704E: "公用框架標頭包含私有框架標頭'%0'"
+H7F0AEF01704E: "公用框架標頭包含私有框架標頭 '%0'"
 # 'pure virtual function %q0 called'
 H3187DE144A64: '純虛函數%q0被調用'
 # 'put the semicolon on a separate line to silence this warning'
@@ -25999,7 +25999,7 @@ H4C7D694E4A70: '修飾名稱引用%select{函式|變數}0模板 %1 的特化'
 # 'qualified reference to %0 is a constructor name rather than a %select{template name|type}1 in this context'
 H08AE31B94F15: '修飾的 %0 引用在此上下文中是建構函數名稱而非%select{模板名稱|類型}1'
 # "qualifier 'const' is needed for variables in address space '%0'"
-HADB69D493623: "在地址空間'%0'中的變數需要 'const' 修飾"
+HADB69D493623: "在地址空間 '%0' 中的變數需要 'const' 修飾"
 # 'qualifier in explicit instantiation of %q0 requires a template-id (a typedef is not permitted)'
 HB21409C3C5FB: '%q0的顯式實體化中的修飾需要一個template-id（不允許typedef）'
 # 'qualifiers after comma in declarator list are ignored'
@@ -26081,7 +26081,7 @@ H2965974DE860: '重宣告具有不同的對齊要求（%1 vs %0）'
 # "redeclaration of %0 must %select{not |}1have the 'overloadable' attribute"
 H9C609286F3D1: "重宣告 %0 必須%select{不具有 |}1'overloadable' 屬性"
 # 'redeclaration of %0 with a different type%diff{: $ vs $|}1,2'
-HEB05B74B4F52: '重宣告 %0 具有不同的類型%diff{: $ vs $|}1,2'
+HEB05B74B4F52: '重宣告 %0 具有不同的類型 %diff{: $ vs $|}1,2'
 # 'redeclaration of %q0 cannot add %q1 attribute'
 H437273BF8230: '重宣告%q0不能添加%q1屬性'
 # 'redeclaration of %q0 should not add %q1 attribute'
@@ -26115,9 +26115,9 @@ H6605A7137B7E: '%0 的重新定義在這個函數之外不可見'
 # 'redefinition of %0 with a different type%diff{: $ vs $|}1,2'
 HB1C0A119B95E: '%0 的重新定義，類型不同%diff{：%$ vs $|}1,2'
 # 'redefinition of %select{typedef|type alias}0 for variably-modified type %1'
-HB599B51A5F4D: '可變長度修飾類型 %1 的%select{typedef|類型別名}0的重新定義'
+HB599B51A5F4D: '可變長度修飾類型 %1 的 %select{typedef|類型別名}0的重新定義'
 # "redefinition of a 'extern inline' function %0 is not supported in %select{C99 mode|C++}1"
-HF158368144B8: '在%select{C99模式|C++}1中不支援重新定義extern inline函數 %0'
+HF158368144B8: '在 %select{C99模式|C++}1 中不支援重新定義extern inline函數 %0'
 # 'redefinition of concept %0 with different template parameters or requirements'
 H4C4283523181: '%0 概念的重新定義，其模板參數或需求不同'
 # 'redefinition of default argument'
@@ -26207,17 +26207,17 @@ H76762B8F478F: '在全域初始化器中引用 %select{__device__|__global__|__h
 # 'reference to %select{destructor|pseudo-destructor}0 must be called%select{|; did you mean to call it with no arguments?}1'
 H3484C551C20A: '必須呼叫 %select{析構函數|偽析構函數}0%select{|；您是否想要以無參數呼叫它？}1'
 # 'reference to %select{overloaded|multiversioned}1 function could not be resolved; did you mean to call it%select{| with no arguments}0?'
-HA7DE06C12730: '對 %select{重載|多版本}1 函數的引用無法解析；您是否想要以%select{|無參數}0呼叫它？'
+HA7DE06C12730: '對 %select{重載|多版本}1 函數的引用無法解析；您是否想要以 %select{|無參數}0呼叫它？'
 # "reference to a %select{bit-field|vector element|global register variable}0 in asm %select{input|output}1 with a memory constraint '%2'"
 HCCFE4F550EEB: '在asm的%select{輸入|輸出}1中引用具有記憶體約束‘%2’的%select{位段|向量元素|全域寄存器變數}0'
 # "reference to enumeration must use 'enum' not 'enum %select{struct|class}0'"
 HDC33545DFD9E: "引用枚舉時必須使用 'enum' 而不是 'enum %select{struct|class}0'"
 # 'reference to local %select{variable|binding}1 %0 declared in enclosing %select{%3|block literal|lambda expression|context}2'
-H9B72122A433C: '在封閉的%select{%3|區塊字面量|lambda expression|上下文}2中宣告的局部%select{變數|綁定}1 %0 被引用'
+H9B72122A433C: '在封閉的 %select{%3|區塊字面量|lambda expression|上下文}2中宣告的局部%select{變數|綁定}1 %0 被引用'
 # "reference to marker '%0' is ambiguous"
 HD452BD6D3FB0: '引用標記‘%0’是模稜兩可的'
 # 'reference to non-static member function must be called%select{|; did you mean to call it with no arguments?}0'
-H472EE5EB17CD: '引用非靜態成員函數必須被呼叫%select{|; 您是否想要呼叫時不帶參數？}0'
+H472EE5EB17CD: '引用非靜態成員函數必須被呼叫 %select{|; 您是否想要呼叫時不帶參數？}0'
 # 'reference to type %0 cannot bind to an initializer list'
 H9194F3CD2BD5: '類型 %0 的引用無法綁定到初始值列表'
 # 'reference to type %0 requires an initializer'
@@ -26231,7 +26231,7 @@ H8DB9210452D3: '被引用的成員 %0 在此宣告'
 # "referring to 'main' within an expression is a Clang extension"
 H5EC3F4017EE7: "在運算式中引用 'main' 是Clang的擴充功能"
 # "region cannot be%select{| closely}0 nested inside '%1' region%select{|; perhaps you forget to enclose 'omp %3' directive into a parallel region?|; perhaps you forget to enclose 'omp %3' directive into a for or a parallel for region with 'ordered' clause?|; perhaps you forget to enclose 'omp %3' directive into a target region?|; perhaps you forget to enclose 'omp %3' directive into a teams region?|; perhaps you forget to enclose 'omp %3' directive into a for, simd, for simd, parallel for, or parallel for simd region?}2"
-H9F4A9870BA07: "%select{|緊密}0嵌套在 '%1' 區域內%select{|; 可能您忘記將'omp %3'指令包圍在平行區域中？|; 可能您忘記將'omp %3'指令包圍在帶有 'ordered' 子句的for或parallel for區域中？|; 可能您忘記將'omp %3'指令包圍在target區域中？|; 可能您忘記將'omp %3'指令包圍在teams區域中？|; 可能您忘記將'omp %3'指令包圍在for、simd、for simd、parallel for或parallel for simd區域中？}2"
+H9F4A9870BA07: "%select{|緊密}0嵌套在 '%1' 區域內 %select{|; 可能您忘記將 'omp %3' 指令包圍在平行區域中？|; 可能您忘記將 'omp %3' 指令包圍在帶有 'ordered' 子句的for或parallel for區域中？|; 可能您忘記將 'omp %3' 指令包圍在target區域中？|; 可能您忘記將 'omp %3' 指令包圍在teams區域中？|; 可能您忘記將 'omp %3' 指令包圍在for、simd、for simd、parallel for或parallel for simd區域中？}2"
 # "register '%0' unsuitable for global register variables on this target"
 HAC3AEFE8413B: '此目標上寄存器‘%0’不適合用於全域寄存器變數'
 # 'register number should be an integer'
@@ -26271,7 +26271,7 @@ H40EB09D856D2: 'remarks_b'
 # "remove '_Noreturn'"
 H4CD6C2426BE8: "移除 '_Noreturn'"
 # "remove 'enum%select{| struct| class}0' to befriend an enum"
-H9CF5F9198489: "移除'enum%select{| struct| class}0'以與枚舉建立友元關係"
+H9CF5F9198489: "移除 'enum%select{| struct| class}0' 以與枚舉建立友元關係"
 # "remove 'u8' prefix to avoid a change of behavior; Clang encodes unprefixed narrow string literals as UTF-8"
 H40BFCE51D12C: '移除u8前綴以避免行為變化；Clang將未加前綴的窄字元字串字面量編碼為UTF-8'
 # 'remove call to max function and unsigned zero argument'
@@ -26289,7 +26289,7 @@ HBB1C1AF59745: '移除括號以消除此警告'
 # 'remove std::move call here'
 H87B3A4171A2A: '在此處移除std::move調用'
 # "remove the %select{'%1' if its condition|condition if it}0 is always %select{false|true}2"
-HE5C66C3841AD: "移除%select{'%1' 如果其條件|條件如果它}0始終為 %select{false|true}2"
+HE5C66C3841AD: "移除 %select{'%1' 如果其條件|條件如果它}0始終為 %select{false|true}2"
 # "remove the call to '%0' since unsigned values cannot be negative"
 H3BE7257796E7: "移除對 '%0' 的呼叫，因為無符號值不能為負數"
 # 'remove the kernel-info pass at the end of the full LTO pipeline'
@@ -26317,7 +26317,7 @@ H816EF14DCA64: '對同一字面運算式的重複評估可能產生不同的物�
 # "replace 'default' with 'delete'"
 H6143A5F8A323: "將 'default' 替換為 'delete'"
 # "replace expression with '%0' %select{|or use 'xor' instead of '^' }1to silence this warning"
-H8BD6D24EAB4A: "將運算式替換為'%0' %select{|或改用 'xor' 代替'^' }1以消除此警告"
+H8BD6D24EAB4A: "將運算式替換為 '%0' %select{|或改用 'xor' 代替 '^' }1以消除此警告"
 # 'replace parentheses with an initializer to declare a variable'
 H1CB1AEAC6164: '使用初始化器替換括號以宣告變數'
 # "replacement function %0 cannot be declared 'inline'"
@@ -26371,7 +26371,7 @@ H044B0871CB3F: 'restrict 需要指標或參考'
 # 'restrict requires a pointer or reference (%0 is invalid)'
 HB4AA3977DC42: 'restrict 需要指標或引用（%0 無效）'
 # "result argument to %select{overflow builtin|checked integer operation}0 must be a pointer to a non-const integer type %select{|other than plain 'char', 'bool', bit-precise, or an enumeration }0(%1 invalid)"
-HD81ECBB4661A: "%select{溢位內建函數|已檢查整數運算}0的結果參數必須是對非const整數類型的指標%select{|（不包括普通 'char'、'bool'、精確位元或列舉類型）}0（%1 無效）"
+HD81ECBB4661A: "%select{溢位內建函數|已檢查整數運算}0的結果參數必須是對非const整數類型的指標 %select{|（不包括普通 'char'、'bool'、精確位元或列舉類型）}0（%1 無效）"
 # "result of '%0' is %1; did you mean '%2' (%3)?"
 H369683737B3D: "'%0' 的結果是 %1；您是否是指 '%2'（%3）？"
 # "result of '%0' is %1; did you mean '%2'?"
@@ -26435,7 +26435,7 @@ H2AB9EE663373: '虛函數 %0 的返回類型與它覆寫的函數返回類型不
 # 'return type of virtual function %3 is not covariant with the return type of the function it overrides (ambiguous conversion from derived class %0 to base class %1:%2)'
 H94F1AF985110: '虛函數 %3 的返回類型與它覆寫的函數返回類型不協變（派生類 %0 到基類 %1 的轉換存在歧義：%2）'
 # "return value not in expected state; expected '%0', observed '%1'"
-H8EF54209E2EA: "返回值不在期望狀態；期望'%0'，觀察到'%1'"
+H8EF54209E2EA: "返回值不在期望狀態；期望 '%0'，觀察到 '%1'"
 # 'return value of %0 is a large (%1 bytes) pass-by-value object; pass it by reference instead ?'
 HA1B074D05D38: '%0 的返回值是大型（%1 位元組）傳遞值參數的物件；建議改用傳參考方式傳遞？'
 # 'returning %select{address of|reference to}0 local temporary object'
@@ -26445,15 +26445,15 @@ H7C6FDC7A79CE: '返回存活於局部堆疊的區塊'
 # 'returning block that lives on the local stack'
 HFB5C6DCAD180: '返回局部堆疊上的區塊指標'
 # "returning pointer %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
-H524B3D4E5221: "返回指標 %1 需要持有 %0 %select{'%2'|'%2'獨佔}3"
+H524B3D4E5221: "返回指標 %1 需要持有 %0 %select{'%2'|'%2' 獨佔}3"
 # "returning pointer to variable %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
-HC47B423E80E3: "返回 %1 變數的指標需要持有 %0 %select{'%2'|'%2'獨佔}3"
+HC47B423E80E3: "返回 %1 變數的指標需要持有 %0 %select{'%2'|'%2' 獨佔}3"
 # 'returning reference to local temporary object'
 H3C7B38DADD40: '返回局部暫時物件的引用'
 # "returning the value that %1 points to by reference requires holding %0 %select{'%2'|'%2' exclusively}3"
-HDFB7294684C5: "以引用返回 %1 所指的值需要持有 %0 %select{'%2'|'%2'獨佔}3"
+HDFB7294684C5: "以引用返回 %1 所指的值需要持有 %0 %select{'%2'|'%2' 獨佔}3"
 # "returning variable %1 by reference requires holding %0 %select{'%2'|'%2' exclusively}3"
-H5E5D0E85F387: "以引用返回 %1 變數需要持有 %0 %select{'%2'|'%2'獨佔}3"
+H5E5D0E85F387: "以引用返回 %1 變數需要持有 %0 %select{'%2'|'%2' 獨佔}3"
 # "rewriter doesn't support user-specified control flow semantics for @try/@finally (code may not execute properly)"
 H9C522D3EEF6D: '重寫器不支援使用者指定的@try/@finally控制流程語法（程式碼可能無法正確執行）'
 # 'rewriting block literal declared in global scope is not implemented'
@@ -26573,7 +26573,7 @@ HD63DCBC599F4: '隨機化種子'
 # "selected '%select{begin|end}0' %select{function|template }1%2 with iterator type %3"
 H752B6650220E: "選擇 '%select{begin|end}0' %select{函數|範本 }1%2，其迭代器類型為 %3"
 # "selected 'operator<=>' for %select{|member|base class}0 %1 declared here"
-H810A0D73AD55: "選擇 'operator<=>' 給%select{|成員|基類}0 %1，該處宣告"
+H810A0D73AD55: "選擇 'operator<=>' 給 %select{|成員|基類}0 %1，該處宣告"
 # 'selector element is not a valid lvalue'
 H0BFE26B0616A: '選擇器元素不是有效的左值'
 # 'selector element of type %0 cannot be a constant lvalue expression'
@@ -26701,7 +26701,7 @@ H3988159D97D2: '跳過傳回類型'
 # 'skip variable types'
 H1C4CB11B7B2B: '跳過變數類型'
 # "skipping '%0' because module declaration of '%1' lacks the 'framework' qualifier"
-H07A078D1E04E: "跳過'%0'，因為模組宣告'%1'缺少 'framework' 修飾符"
+H07A078D1E04E: "跳過 '%0'，因為模組宣告 '%1' 缺少 'framework' 修飾符"
 # 'skipping stray token'
 HF5D19BFCA4A8: '跳過孤立的記號'
 # 'sort hot data by hot function usage and count'
@@ -26781,7 +26781,7 @@ H593FAF497273: '根據函數執行頻率將跳轉表區段分割為 hot 和 cold
 # 'split-file Options'
 HDBFADA679092: '分割檔案選項'
 # "stack frame size (%0) exceeds limit (%1) in '%2'"
-HCF0AF62F4A65: "堆疊框架大小（%0）超過限制（%1）在'%2'中"
+HCF0AF62F4A65: "堆疊框架大小（%0）超過限制（%1）在 '%2' 中"
 # 'stack nearly exhausted; compilation time may suffer, and crashes due to stack overflow are likely'
 HD310C1B31961: '堆疊空間接近耗盡；編譯時間可能延長，且因堆疊溢位導致的崩潰風險增加'
 # "standard library implementation of %0 is not supported; %select{member '%2' does not have expected form|member '%2' is missing|the type is not trivially copyable|the type does not have the expected form}1"
@@ -26853,7 +26853,7 @@ H747267A37B70: '將函式指標轉換為物件指標的static_cast是Microsoft�
 # "std::coroutine_handle isn't a class template"
 H20FD07579F32: 'std::coroutine_handle不是類模板'
 # "std::coroutine_handle must have a member named '%0'"
-HC01B7EC5D8D7: "std::coroutine_handle必須有一個名為'%0'的成員"
+HC01B7EC5D8D7: "std::coroutine_handle必須有一個名為 '%0' 的成員"
 # "std::coroutine_traits isn't a class template"
 H3D3F8F520E5F: 'std::coroutine_traits不是類模板'
 # 'std::initializer_list must be a class template with a single type parameter'
@@ -26889,7 +26889,7 @@ HE2D46EB90348: '操作符後面的字串字面量不能有編碼前綴'
 # 'string literal after \'operator\' must be \'""\''
 HB2C541BB7B81: '操作符後面的字串字面量必須為空字串""'
 # 'string literal of length %0 exceeds maximum length %1 that %select{C90|ISO C99|C++}2 compilers are required to support'
-H446F1FE51F67: '長度為 %0 的字串字面量超過%select{C90|ISO C99|C++}2 編譯器必須支援的最大長度 %1'
+H446F1FE51F67: '長度為 %0 的字串字面量超過 %select{C90|ISO C99|C++}2 編譯器必須支援的最大長度 %1'
 # 'string literal operator templates are a GNU extension'
 HC7C4AAEBD81D: '字串字面量操作符範本是GNU擴充語法'
 # 'string literal with user-defined suffix cannot be used here'
@@ -27059,7 +27059,7 @@ H5C1974A3FA23: 'using宣告的目標與作用域內已存在的宣告衝突'
 # 'target profile option (-T) is missing'
 HD96117F3AEE8: '目標配置檔選項（-T）遺失'
 # 'target-attribute based function overloads are not supported by NVCC and will be treated as a function redeclaration:new declaration is %select{__device__|__global__|__host__|__host__ __device__}0 function, old declaration is %select{__device__|__global__|__host__|__host__ __device__}1 function'
-H48B3A7876AE7: '基於目標屬性的函數多載不受NVCC支援，將視為函數重新宣告：新宣告是%select{__device__|__global__|__host__|__host__ __device__}0 函數，舊宣告是%select{__device__|__global__|__host__|__host__ __device__}1 函數'
+H48B3A7876AE7: '基於目標屬性的函數多載不受NVCC支援，將視為函數重新宣告：新宣告是 %select{__device__|__global__|__host__|__host__ __device__}0 函數，舊宣告是 %select{__device__|__global__|__host__|__host__ __device__}1 函數'
 # 'tbd'
 H1D9C8AC0B205: 'tbd'
 # 'template %0 has no definition and no %select{|viable }1deduction guides for deduction of template arguments'
@@ -27073,7 +27073,7 @@ HF7C463216541: '非類型模板參數的模板參數被視為函數類型 %0'
 # 'template argument for non-type template parameter must be an expression'
 HA6F518CB9F6F: '非類型模板參數的模板參數必須是運算式'
 # 'template argument for template template parameter must be a class template%select{| or type alias template}0'
-H4605CB1853A3: '模板模板參數的模板參數必須是類別模板%select{|或類型別名模板}0'
+H4605CB1853A3: '模板模板參數的模板參數必須是類別模板 %select{|或類型別名模板}0'
 # 'template argument for template type parameter must be a type'
 H9FFBB255FD4F: '模板類型參數的模板參數必須是類型'
 # "template argument for template type parameter must be a type; did you forget 'typename'?"
@@ -27095,7 +27095,7 @@ H8B583108C6ED: '模板在此處宣告'
 # 'template name refers to non-type template %0'
 HD8E4D2A7EC89: '模板名稱引用非類型模板 %0'
 # 'template non-type parameter has a different type %0 in template %select{|template parameter }1redeclaration'
-H29D49A380D2B: '模板的非類型參數在模板%select{|模板參數 }1重新宣告中有不同的類型 %0'
+H29D49A380D2B: '模板的非類型參數在模板 %select{|模板參數 }1重新宣告中有不同的類型 %0'
 # 'template non-type parameter has a different type %0 in template argument'
 H83C8844C296B: '模板的非類型參數在模板參數中具有不同的類型 %0'
 # "template parameter '%0' is already documented"
@@ -27109,7 +27109,7 @@ H6440E4D1834B: '模板參數的預設參數與先前定義不一致'
 # 'template parameter from hidden source: %0'
 HE652270F3F6D: '隱藏來源的模板參數：%0'
 # 'template parameter has a different kind in template %select{|template parameter }0redeclaration'
-HBF82CEEA37C8: '模板參數在模板%select{|模板參數 }0重新宣告中有不同的種類'
+HBF82CEEA37C8: '模板參數在模板 %select{|模板參數 }0重新宣告中有不同的種類'
 # 'template parameter has a different kind in template argument'
 H8F8F50E907A1: '模板參數在模板參數中具有不同的種類'
 # 'template parameter has different kinds in different translation units'
@@ -27141,7 +27141,7 @@ HA8ECAC04AF8C: '模板特化宣告不能是友元'
 # 'template specialization or definition requires a template parameter list corresponding to the nested type %0'
 HC868EA3957FF: '模板特化或定義需要對應至嵌套類型 %0 的模板參數清單'
 # "template specialization requires 'template<>'"
-H1ADEE7A736DF: "模板特化需要使用'template<>'"
+H1ADEE7A736DF: "模板特化需要使用 'template<>'"
 # 'template template argument %0 is more constrained than template template parameter %1'
 HE3F8D9BFA908: '模板模板參數 %0 比模板模板參數 %1 更受限'
 # 'template template argument has different template parameters than its corresponding template template parameter'
@@ -27187,21 +27187,21 @@ H3AA824360E4A: '類型 %0 無法用於宣告結構或共用體的成員'
 # 'the %select{1st|2nd|3rd}1 template parameter of %0 needs to be %select{a type|an integer or enum value}2'
 HC15D25E5BA46: '模板 %0 的%select{第 1 個|第 2 個|第 3 個}1參數需要是%select{類型|整數或枚舉值}2'
 # 'the %select{function or variable|function}0 specified in an %select{alias|ifunc}1 must refer to its mangled name'
-H2A963C3F164E: '在%select{別名|ifunc}1中指定的%select{函數或變數|函數}0必須引用其裝飾名稱'
+H2A963C3F164E: '在%select{別名|ifunc}1 中指定的%select{函數或變數|函數}0必須引用其裝飾名稱'
 # "the %select{message|string}0 object in %select{this static assertion|this asm operand}0 is missing %select{a 'size()' member function|a 'data()' member function|'data()' and 'size()' member functions}1"
-HF8EFF7FCD3A1: "在%select{此靜態斷言|此組合語言操作數}0中的%select{訊息|字串}0物件缺少%select{具名為'size()'的成員函數|具名為'data()'的成員函數|具名為'data()'和'size()'的成員函數}1"
+HF8EFF7FCD3A1: "在%select{此靜態斷言|此組合語言操作數}0中的%select{訊息|字串}0物件缺少%select{具名為 'size()' 的成員函數|具名為 'data()' 的成員函數|具名為 'data()' 和 'size()' 的成員函數}1"
 # "the '%0' unit is not supported with this instruction set"
-H66612647AED8: "指令集不支援'%0'單元"
+H66612647AED8: "指令集不支援 '%0' 單元"
 # "the '%select{&|*|->}0' operator is unsupported in HLSL"
-H831B25ED6E8C: "在HLSL中不支援'%select{&|*|->}0'運算子"
+H831B25ED6E8C: "在HLSL中不支援 '%select{&|*|->}0' 運算子"
 # "the '[[_Noreturn]]' attribute spelling is deprecated in C23; use '[[noreturn]]' instead"
-H584C1C164ECE: "在C23中，'[[_Noreturn]]'屬性拼寫已棄用；請改用'[[noreturn]]'"
+H584C1C164ECE: "在C23中，'[[_Noreturn]]' 屬性拼寫已棄用；請改用 '[[noreturn]]'"
 # "the 'copyprivate' clause must not be used with the 'nowait' clause"
 H026F61D558F6: "不能將 'copyprivate' 子句與 'nowait' 子句一起使用"
 # "the 'static' modifier for the array size is not legal in new expressions"
 H285525BB6E11: "在new運算式中，陣列大小的 'static' 修飾符不合法"
 # "the ApplicationExtensionSafe flag does not match: '%0' (provided) vs '%1' (found)"
-H74ECAC68920E: "ApplicationExtensionSafe旗標不相符：提供的'%0'對比找到的'%1'"
+H74ECAC68920E: "ApplicationExtensionSafe旗標不相符：提供的 '%0' 對比找到的 '%1'"
 # 'the GNU address of label extension is not allowed in coroutines'
 HEE9FFF3C021C: '在協程中不允許使用GNU標籤位址擴充功能'
 # "the NotForDyldSharedCache flag does not match: '%0' (provided) vs '%1' (found)"
@@ -27325,7 +27325,7 @@ HA6A6824B2746: "代理初始化調用的結果必須立即返回或賦值給 'se
 # 'the resulting value is always non-negative after implicit conversion'
 H9908ECBF3885: '隱式轉換後的結果值始終為非負數'
 # "the second argument of '-fpatchable-function-entry' must be smaller than the first argument"
-HEC0EC1D581E8: "'-fpatchable-function-entry'的第二個參數必須小於第一個參數"
+HEC0EC1D581E8: "'-fpatchable-function-entry' 的第二個參數必須小於第一個參數"
 # "the selected code is not a part of a function's / method's body"
 H09129ED39DF9: '所選的程式碼段並非函數/方法主體的一部分'
 # 'the selected expression cannot be extracted'
@@ -27341,21 +27341,21 @@ H327A107A2A90: '指定的比較器類型未提供有效的const呼叫運算子'
 # 'the specified hash functor does not provide a viable const call operator'
 H7B4F603F77A3: '指定的哈希函數未提供有效的const呼叫運算子'
 # "the statement for '#pragma omp %0' must be a compound statement"
-H8597FC2B3D8A: "'#pragma omp %0'的語句必須是複合語句"
+H8597FC2B3D8A: "'#pragma omp %0' 的語句必須是複合語句"
 # "the statement for 'atomic capture' must be a compound statement of form '{v = x; x binop= expr;}', '{x binop= expr; v = x;}', '{v = x; x = x binop expr;}', '{v = x; x = expr binop x;}', '{x = x binop expr; v = x;}', '{x = expr binop x; v = x;}' or '{v = x; x = expr;}', '{v = x; x++;}', '{v = x; ++x;}', '{++x; v = x;}', '{x++; v = x;}', '{v = x; x--;}', '{v = x; --x;}', '{--x; v = x;}', '{x--; v = x;}' where x is an lvalue expression with scalar type"
-H0E1E5BD56218: "'atomic capture'的語句必須是符合以下形式的複合語句：'{v = x; x binop= expr;}'、'{x binop= expr; v = x;}'、'{v = x; x = x binop expr;}'、'{v = x; x = expr binop x;}'、'{x = x binop expr; v = x;}'、'{x = expr binop x; v = x;}' 或 '{v = x; x = expr;}'、'{v = x; x++;}'、'{v = x; ++x;}'、'{++x; v = x;}'、'{x++; v = x;}'、'{v = x; x--;}'、'{v = x; --x;}'、'{--x; v = x;}'、'{x--; v = x;}'，其中x是具有純量類型的左值運算式"
+H0E1E5BD56218: "'atomic capture' 的語句必須是符合以下形式的複合語句：'{v = x; x binop= expr;}'、'{x binop= expr; v = x;}'、'{v = x; x = x binop expr;}'、'{v = x; x = expr binop x;}'、'{x = x binop expr; v = x;}'、'{x = expr binop x; v = x;}' 或 '{v = x; x = expr;}'、'{v = x; x++;}'、'{v = x; ++x;}'、'{++x; v = x;}'、'{x++; v = x;}'、'{v = x; x--;}'、'{v = x; --x;}'、'{--x; v = x;}'、'{x--; v = x;}'，其中x是具有純量類型的左值運算式"
 # "the statement for 'atomic capture' must be an expression statement of form 'v = ++x;', 'v = --x;', 'v = x++;', 'v = x--;', 'v = x binop= expr;', 'v = x = x binop expr' or 'v = x = expr binop x', where x and v are both lvalue expressions with scalar type"
-H47D428195CE9: "'atomic capture'的語句必須是符合以下形式的表示式語句：'v = ++x;'、'v = --x;'、'v = x++;'、'v = x--;'、'v = x binop= expr;'、'v = x = x binop expr' 或 'v = x = expr binop x'，其中x和v都是具有純量類型的左值運算式"
+H47D428195CE9: "'atomic capture' 的語句必須是符合以下形式的表示式語句：'v = ++x;'、'v = --x;'、'v = x++;'、'v = x--;'、'v = x binop= expr;'、'v = x = x binop expr' 或 'v = x = expr binop x'，其中x和v都是具有純量類型的左值運算式"
 # "the statement for 'atomic compare capture' must be a compound statement of form '{v = x; cond-up-stmt}', ''{cond-up-stmt v = x;}', '{if(x == e) {x = d;} else {v = x;}}', '{r = x == e; if(r) {x = d;}}', or '{r = x == e; if(r) {x = d;} else {v = x;}}', where 'cond-update-stmt' can have one of the following forms: 'if(expr ordop x) {x = expr;}', 'if(x ordop expr) {x = expr;}', 'if(x == e) {x = d;}', or 'if(e == x) {x = d;}' where 'x', 'r', and 'v' are lvalue expressions with scalar type, 'expr', 'e', and 'd' are expressions with scalar type, and 'ordop' is one of '<' or '>'"
-H09C6A6DB560B: "'atomic compare capture'的語句必須是符合以下形式的複合語句：'{v = x; cond-up-stmt}'、''{cond-up-stmt v = x;}'、'{if(x == e) {x = d;} else {v = x;}}'、'{r = x == e; if(r) {x = d;}}' 或 '{r = x == e; if(r) {x = d;} else {v = x;}}'，其中'cond-update-stmt'可以是以下其中一種形式：'if(expr ordop x) {x = expr;}'、'if(x ordop expr) {x = expr;}'、'if(x == e) {x = d;}' 或 'if(e == x) {x = d;}'，其中 'x'、'r'、'v' 是具有純量類型的左值運算式，'expr'、'e'、'd' 是具有純量類型的運算式，且 'ordop' 是'<'或'>'中的一種"
+H09C6A6DB560B: "'atomic compare capture' 的語句必須是符合以下形式的複合語句：'{v = x; cond-up-stmt}'、''{cond-up-stmt v = x;}'、'{if(x == e) {x = d;} else {v = x;}}'、'{r = x == e; if(r) {x = d;}}' 或 '{r = x == e; if(r) {x = d;} else {v = x;}}'，其中 'cond-update-stmt' 可以是以下其中一種形式：'if(expr ordop x) {x = expr;}'、'if(x ordop expr) {x = expr;}'、'if(x == e) {x = d;}' 或 'if(e == x) {x = d;}'，其中 'x'、'r'、'v' 是具有純量類型的左值運算式，'expr'、'e'、'd' 是具有純量類型的運算式，且 'ordop' 是 '<' 或 '>' 中的一種"
 # "the statement for 'atomic compare' must be a compound statement of form '{x = expr ordop x ? expr : x;}', '{x = x ordop expr? expr : x;}', '{x = x == e ? d : x;}', '{x = e == x ? d : x;}', or 'if(expr ordop x) {x = expr;}', 'if(x ordop expr) {x = expr;}', 'if(x == e) {x = d;}', 'if(e == x) {x = d;}' where 'x' is an lvalue expression with scalar type, 'expr', 'e', and 'd' are expressions with scalar type, and 'ordop' is one of '<' or '>'"
-H4091D9BED6D2: "'atomic compare'的語句必須是符合以下形式的複合語句：'{x = expr ordop x ? expr : x;}'、'{x = x ordop expr? expr : x;}'、'{x = x == e ? d : x;}'、'{x = e == x ? d : x;}'、'if(expr ordop x) {x = expr;}'、'if(x ordop expr) {x = expr;}'、'if(x == e) {x = d;}' 或 'if(e == x) {x = d;}'，其中 'x' 是具有純量類型的左值運算式，'expr'、'e'、'd' 是具有純量類型的運算式，且 'ordop' 是'<'或'>'中的一種"
+H4091D9BED6D2: "'atomic compare' 的語句必須是符合以下形式的複合語句：'{x = expr ordop x ? expr : x;}'、'{x = x ordop expr? expr : x;}'、'{x = x == e ? d : x;}'、'{x = e == x ? d : x;}'、'if(expr ordop x) {x = expr;}'、'if(x ordop expr) {x = expr;}'、'if(x == e) {x = d;}' 或 'if(e == x) {x = d;}'，其中 'x' 是具有純量類型的左值運算式，'expr'、'e'、'd' 是具有純量類型的運算式，且 'ordop' 是 '<' 或 '>' 中的一種"
 # "the statement for 'atomic read' must be an expression statement of form 'v = x;', where v and x are both lvalue expressions with scalar type"
-HDAD21CA5AD66: "'atomic read'的語句必須是符合以下形式的表示式語句：'v = x;'，其中v和x都是具有純量類型的左值運算式"
+HDAD21CA5AD66: "'atomic read' 的語句必須是符合以下形式的表示式語句：'v = x;'，其中v和x都是具有純量類型的左值運算式"
 # "the statement for 'atomic update' must be an expression statement of form '++x;', '--x;', 'x++;', 'x--;', 'x binop= expr;', 'x = x binop expr' or 'x = expr binop x', where x is an lvalue expression with scalar type"
-H106E8810ABCE: "'atomic update'的語句必須是符合以下形式的表示式語句：'++x;'、'--x;'、'x++;'、'x--;'、'x binop= expr;'、'x = x binop expr' 或 'x = expr binop x'，其中x是具有純量類型的左值運算式"
+H106E8810ABCE: "'atomic update' 的語句必須是符合以下形式的表示式語句：'++x;'、'--x;'、'x++;'、'x--;'、'x binop= expr;'、'x = x binop expr' 或 'x = expr binop x'，其中x是具有純量類型的左值運算式"
 # "the statement for 'atomic write' must be an expression statement of form 'x = expr;', where x is a lvalue expression with scalar type"
-HAEE051C701D8: "'atomic write'的語句必須是符合以下形式的表示式語句：'x = expr;'，其中x是具有純量類型的左值運算式"
+HAEE051C701D8: "'atomic write' 的語句必須是符合以下形式的表示式語句：'x = expr;'，其中x是具有純量類型的左值運算式"
 # "the statement for 'atomic' must be an expression statement of form '++x;', '--x;', 'x++;', 'x--;', 'x binop= expr;', 'x = x binop expr' or 'x = expr binop x', where x is an lvalue expression with scalar type"
 H182C909CFBBD: "'atomic' 的語法必須是形如 '++x;'、'--x;'、'x++;'、'x--;'、'x binop= expr;'、'x = x binop expr' 或 'x = expr binop x' 的運算式語句，其中 x 是標量類型的左值運算式"
 # "the target architecture '%0' is not supported by the target '%1'"
@@ -27515,9 +27515,9 @@ H90F884ECB318: '%select{|||執行配置 }0%select{|非物件 }3參數過多，%s
 # 'too many %select{|||execution configuration }0%select{|non-object }3arguments to %select{function|block|method|kernel function}0 call, expected %1, have %2; did you mean %4?'
 HCA745DFE1FDF: '%select{|||執行配置 }0%select{|非物件 }3參數過多，%select{函式|區塊|方法|核心函式}0 呼叫需要 %1 個參數，目前有 %2 個；是否要使用 %4？'
 # 'too many %select{|||execution configuration }0%select{|non-object }3arguments to %select{function|block|method|kernel function}0 call, expected at most %1, have %2'
-H94A2619722A2: '呼叫 %select{函數|區塊|方法|核心函數}0 時%select{|||執行配置 }0%select{|非物件 }3參數超過最大數量 %1，實際有 %2 個'
+H94A2619722A2: '呼叫 %select{函數|區塊|方法|核心函數}0 時 %select{|||執行配置 }0%select{|非物件 }3參數超過最大數量 %1，實際有 %2 個'
 # 'too many %select{|||execution configuration }0%select{|non-object }3arguments to %select{function|block|method|kernel function}0 call, expected at most %1, have %2; did you mean %4?'
-HE9A38EF19888: '呼叫 %select{函數|區塊|方法|核心函數}0 時%select{|||執行配置 }0%select{|非物件 }3參數超過最大數量 %1，實際有 %2 個；是否要改為 %4？'
+HE9A38EF19888: '呼叫 %select{函數|區塊|方法|核心函數}0 時 %select{|||執行配置 }0%select{|非物件 }3參數超過最大數量 %1，實際有 %2 個；是否要改為 %4？'
 # 'too many %select{|||execution configuration }0%select{|non-object }3arguments to %select{function|block|method|kernel function}0 call, expected single argument %1, have %2 arguments'
 HDBD2C1E2CE61: '%select{|||執行配置 }0%select{|非物件 }3參數過多，%select{函式|區塊|方法|核心函式}0 呼叫需要單一 %1 參數，但有 %2 個參數'
 # 'too many %select{|||execution configuration }0arguments to %select{function|block|method|kernel function}0 call, expected at most single %select{|non-object }3argument %1, have %2%select{|non-object}3 arguments'
@@ -27525,7 +27525,7 @@ HDAC13624D426: '%select{|||執行配置 }0參數過多，%select{函式|區塊|�
 # 'too many arguments provided to function-like macro invocation'
 HBB5E8EFBFD08: '函數式宏調用提供的參數過多'
 # 'too many braces around %select{scalar |}0initializer'
-H5C95D607138A: '初始值設定項前的括號過多（%select{純量 |}0初始值設定項）'
+H5C95D607138A: '初始值設定項前的括號過多（%select{純量 |}0 初始值設定項）'
 # 'too many errors emitted, stopping now'
 H208E3BCCF078: '發出的錯誤訊息過多，現停止處理'
 # 'too many function parameters; subsequent parameters will be ignored'
@@ -27683,9 +27683,9 @@ H9BCBB335F47F: '類型名稱需要指定修飾符或限定符'
 # 'type nullability specifier %0 is a Clang extension'
 HFDBD8198839C: '類型空值安全性修飾符 %0 是 Clang 的擴充功能'
 # 'type of %ordinal0 parameter of local declaration does not match definition%diff{ ($ vs $)|}1,2'
-HC35F751A0E20: '本地宣告的第%ordinal0個參數類型與定義%diff{ ($ vs $)|}1,2不相符'
+HC35F751A0E20: '本地宣告的第%ordinal0個參數類型與定義%diff{ ($ vs $)|}1,2 不相符'
 # 'type of %ordinal0 parameter of member declaration does not match definition%diff{ ($ vs $)|}1,2'
-H6D265791AD7D: '成員宣告的第%ordinal0個參數類型與定義%diff{ ($ vs $)|}1,2不相符'
+H6D265791AD7D: '成員宣告的第%ordinal0個參數類型與定義%diff{ ($ vs $)|}1,2 不相符'
 # 'type of UTF-8 string literal will change from array of char to array of char8_t in C23'
 HDD96729D3F80: 'UTF-8 字元串字面值的類型在 C23 中將從 char 陣列變更為 char8_t 陣列'
 # 'type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20'
@@ -27719,7 +27719,7 @@ H4B268E82A57A: "類型指定項遺失，預設為 'int'"
 # "type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int"
 H8CEE1B0F6CB9: "類型指定者遺失，預設為 'int'; ISO C99 及更新版本不支援隱式 int"
 # 'type trait requires %0%select{| or more}1 argument%select{|s}2; have %3 argument%s3'
-H5F2DEBC2DD6F: '類型特性需要 %0%select{|或更多}1 個參數%select{|s}2; 獲得 %3 個參數'
+H5F2DEBC2DD6F: '類型特性需要 %0%select{|或更多}1 個參數 %select{|s}2; 獲得 %3 個參數'
 # 'type was declared read-only here'
 HAFE8C580C1C1: '類型在此處被宣告為唯讀'
 # 'type-id cannot have a name'
@@ -27883,7 +27883,7 @@ H1C5752C27ACF: "在 OpenMP 指令 '#pragma omp %1' 中發現不支援的子句 '
 # "unexpected OpenMP directive %select{|'#pragma omp %1'}0"
 HEF8086A19118: "意外的 OpenMP 指令 %select{|'#pragma omp %1'}0"
 # "unexpected argument '%0' to '#pragma %1'%select{|; expected %3}2"
-HB8C385DE07A5: "#pragma %1 的參數 '%0' 不正確%select{|；期望 %3}2"
+HB8C385DE07A5: "#pragma %1 的參數 '%0' 不正確 %select{|；期望 %3}2"
 # "unexpected argument '%0' to '#pragma clang attribute'; expected 'push' or 'pop'"
 H3133E5143B09: "#pragma clang attribute 的參數 '%0' 不正確；期望 'push' 或 'pop'"
 # "unexpected argument '%0' to '#pragma clang fp %1'; expected %select{'fast' or 'on' or 'off'|'on' or 'off'|'on' or 'off'|'ignore', 'maytrap' or 'strict'|'source', 'double' or 'extended'}2"
@@ -28127,7 +28127,7 @@ H2798CD78D9FC: '未支援的組合：CC_PRINT_HEADERS_FORMAT=%0 和 CC_PRINT_HEA
 # 'unsupported expression with unknown type'
 H3F334416D50C: '不支援未知類型的運算式'
 # 'unsupported inline asm: input with type %diff{$ matching output with type $|}0,1'
-HA68AF7F61C41: '不支援的內嵌組裝語言：具有類型%diff{$ 匹配輸出類型 $|}0,1的輸入'
+HA68AF7F61C41: '不支援的內嵌組裝語言：具有類型 %diff{$ 匹配輸出類型 $|}0,1 的輸入'
 # 'unsupported non-standard concatenation of string literals'
 H5B7E63184569: '不支援非標準字串文字的連接'
 # "unsupported option '%0'"
@@ -28355,13 +28355,13 @@ H1B2603FEAF82: '不支援在Objective-C容器內部的函數中使用Objective-C
 # 'use of __private_extern__ on a declaration may not produce external symbol private to the linkage unit and is deprecated'
 HC7A56E0EB4D2: '__private_extern__在宣告上的使用可能無法產生連結單位私有外部符號，且已被棄用'
 # "use of a '#%select{<BUG IF SEEN>|elifdef|elifndef}0' directive is a C++23 extension"
-H6A5DD5BE1302: "使用'#%select{<BUG IF SEEN>|elifdef|elifndef}0'指令是C++23擴充功能"
+H6A5DD5BE1302: "使用 '#%select{<BUG IF SEEN>|elifdef|elifndef}0' 指令是C++23擴充功能"
 # "use of a '#%select{<BUG IF SEEN>|elifdef|elifndef}0' directive is a C23 extension"
-H0BF82439932C: "使用'#%select{<BUG IF SEEN>|elifdef|elifndef}0'指令是C23擴充功能"
+H0BF82439932C: "使用 '#%select{<BUG IF SEEN>|elifdef|elifndef}0' 指令是C23擴充功能"
 # "use of a '#%select{<BUG IF SEEN>|elifdef|elifndef}0' directive is incompatible with C standards before C23"
-HDFCC088F181F: "使用'#%select{<BUG IF SEEN>|elifdef|elifndef}0'指令與C23之前標準不相容"
+HDFCC088F181F: "使用 '#%select{<BUG IF SEEN>|elifdef|elifndef}0' 指令與C23之前標準不相容"
 # "use of a '#%select{<BUG IF SEEN>|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23"
-H16A663A66375: "使用'#%select{<BUG IF SEEN>|elifdef|elifndef}0'指令與C++23之前標準不相容"
+H16A663A66375: "使用 '#%select{<BUG IF SEEN>|elifdef|elifndef}0' 指令與C++23之前標準不相容"
 # 'use of address-of-label extension outside of a function body'
 HEBDAFDF05EDA: '在函數本體外使用address-of-label擴充功能'
 # 'use of an empty initializer is a C23 extension'
@@ -28507,9 +28507,9 @@ HCD053F3A5F86: '在需要整數類型的地方使用了類型 %0'
 # 'used type %0 where integer or floating point type is required'
 H46DF1623ED73: '在需要整數或浮點類型的地方使用了類型 %0'
 # 'used%select{| in pointer arithmetic| in buffer access}0 here'
-H2D0FA9F859F9: '在此處%select{|在指標運算|在緩衝區存取}0使用'
+H2D0FA9F859F9: '在此處 %select{|在指標運算|在緩衝區存取}0使用'
 # "user-defined literal suffixes %select{<ERROR>|not starting with '_'|containing '__'}0 are reserved%select{; no literal will invoke this operator|}1"
-H414028466FC2: '用戶定義的字面量後綴%select{<ERROR>|未以 "_" 開頭|包含 "__"}0被保留%select{；沒有字面量會調用此運算符|}1'
+H414028466FC2: '用戶定義的字面量後綴 %select{<ERROR>|未以 "_" 開頭|包含 "__"}0 被保留%select{；沒有字面量會調用此運算符|}1'
 # 'using'
 H92BD75EBD8FD: '使用'
 # 'using %0 directive in %select{NSString|CFString}1 which is being passed as a formatting argument to the formatting %select{method|CFfunction}2'
@@ -28519,7 +28519,7 @@ HA26F40AA0176: '與字面量一起使用 %0 是冗餘的'
 # 'using %select{integer|floating point|complex}1 absolute value function %0 when argument is of %select{integer|floating point|complex}2 type'
 H2A1C61EF88A1: '當參數為%select{整數|浮點|複數}2類型時，使用%select{整數|浮點|複數}1絕對值函數 %0'
 # "using '%%P' format specifier with an Objective-C pointer results in dumping runtime object structure, not object value"
-H513C1ECC12E7: "在Objective-C指針中使用'%%P'格式說明符將會傾印執行階段物件結構，而不是物件值"
+H513C1ECC12E7: "在Objective-C指針中使用 '%%P' 格式說明符將會傾印執行階段物件結構，而不是物件值"
 # "using '%%P' format specifier without precision"
 HE89A56274479: "在不指定精確度的情況下使用 '%%P' 格式指定項"
 # "using '%0' format specifier annotation outside of os_log()/os_trace()"
@@ -28569,13 +28569,13 @@ HCAD96DA2A48D: "在ISO C中不支援在轉換指定項 '%1' 使用長度修飾�
 # 'using namespace directive in global context in header'
 HDFF3F4F00DD3: '在標頭檔案的全域範圍中使用using命名空間指令'
 # "using sysroot for '%0' but targeting '%1'"
-H23CBFE9436FA: "正在使用'%0'的sysroot，但目標為'%1'"
+H23CBFE9436FA: "正在使用 '%0' 的sysroot，但目標為 '%1'"
 # 'using the result of an assignment as a condition without parentheses'
 HD808A1E3A9FB: '在條件中使用賦值運算的結果但未使用括號'
 # 'using the undeclared type %0 as a default template argument is a Microsoft extension'
 H9BAAEE7535FA: '將未宣告的類型 %0 用作預設模板參數是Microsoft擴充功能'
 # 'using unversioned Android target directory %0 for target %1; unversioned directories will not be used in Clang 19 -- provide a versioned directory for the target version or lower instead'
-H120D3110B47A: '為目標 %1 使用未指定版本的Android目標目錄 %0；Clang 19將不再使用未指定版本的目錄——請為目標版本提供已指定版本的目錄或使用較低版本'
+H120D3110B47A: '為目標 %1 使用未指定版本的Android目標目錄 %0；Clang 19 將不再使用未指定版本的目錄——請為目標版本提供已指定版本的目錄或使用較低版本'
 # 'using-enum cannot name a dependent type'
 H3DC57F2168E8: 'using-enum不能命名依賴類型'
 # 'usual LSP protocol'
@@ -28593,7 +28593,7 @@ H76B206381D68: '值 %0 超出類型 %1 可表示的範圍'
 # 'value %1 cannot be represented in type %0'
 H0FCCEC09B538: '值 %1 無法以類型 %0 表示'
 # "value '%0' out of range for constraint '%1'"
-H2964C78586A1: "值'%0'超出約束'%1'的範圍"
+H2964C78586A1: "值 '%0' 超出約束 '%1' 的範圍"
 # 'value is not an integer: %0'
 HDF6724275715: '值不是整數：%0'
 # 'value of #pragma pack(show) == %0'
@@ -28801,7 +28801,7 @@ H77E12186A8E0: '向量大小不是元件大小的整數倍數'
 # "vectorize_width loop hint malformed; use vectorize_width(X, fixed) or vectorize_width(X, scalable) where X is an integer, or vectorize_width('fixed' or 'scalable')"
 H52976DB4C3C0: "vectorize_width循環提示格式錯誤；請使用vectorize_width(X, fixed)或vectorize_width(X, scalable)，其中X為整數，或vectorize_width('fixed' 或 'scalable')"
 # "vendor '%0' is not supported: '%1'"
-HEF7F8EFDE1D2: "供應商'%0'不受支援：%1"
+HEF7F8EFDE1D2: "供應商 '%0' 不受支援：%1"
 # 'verbose'
 H3F73A838273F: '詳細模式'
 # 'verify structure of the log'
@@ -28811,7 +28811,7 @@ H94E54A437791: '每個pass後驗證CFG結構'
 # 'verify-uselistorder Options'
 HBF754C1F763D: '驗證使用清單順序選項'
 # "version '%0' in target triple '%1' is invalid"
-H638A2A1C27BA: "目標三元組'%1'中的版本'%0'無效"
+H638A2A1C27BA: "目標三元組 '%1' 中的版本 '%0' 無效"
 # 'version 1'
 H58A74A7AA4A0: '版本 1'
 # 'version 2'
@@ -28821,7 +28821,7 @@ HA54E81A648CA: '版本 3'
 # 'version control conflict marker in file'
 H58D6C666A33F: '文件中存在版本控制衝突標記'
 # "version for '%0' already specified"
-HD1955B4EAF6D: "'%0'的版本已指定"
+HD1955B4EAF6D: "'%0' 的版本已指定"
 # 'version list contains duplicate entries'
 HDC1A5F99BC1B: '版本列表包含重複條目'
 # "version list contains entries that don't impact code generation"
@@ -28835,7 +28835,7 @@ H2738AB0FED80: '在此處宣告虛基類'
 # 'virtual constexpr functions are incompatible with C++ standards before C++20'
 H0CA73C06B6D5: '虛constexpr函數與C++20之前的C++標準不相容'
 # "virtual destructor requires an unambiguous, accessible 'operator delete'"
-H23281750E023: "虛析構函數需要明確且可存取的'operator delete'"
+H23281750E023: "虛析構函數需要明確且可存取的 'operator delete'"
 # "virtual filesystem overlay file '%0' not found"
 H26F74FB8B8C2: "虛擬檔案系統覆寫檔 '%0' 未找到"
 # 'virtual function %0 has a different return type %diff{($) than the function it overrides (which has return type $)|than the function it overrides}1,2'
@@ -28937,13 +28937,13 @@ H19BE8EB0741D: '在檢查模板 %0 的約束滿足情況時，需要在此處'
 # "while checking constraint satisfaction for variable template partial specialization '%0' required here"
 HD73CEE0E62DB: '在檢查變數模板部分特化 %0 的約束滿足情況時，需要在此處'
 # "while checking implicit 'delete this' for virtual destructor"
-H738DE49AA679: "在檢查虛函數析構函數的隱含'delete this'時"
+H738DE49AA679: "在檢查虛函數析構函數的隱含 'delete this' 時"
 # "while checking the satisfaction of concept '%0' requested here"
 HE2FF74B26A28: '在檢查在此處請求的概念 %0 的滿足情況時'
 # 'while checking the satisfaction of nested requirement requested here'
 HE3D634694184: '在檢查在此處請求的嵌套需求的滿足情況時'
 # "while declaring the corresponding implicit 'operator==' for this defaulted 'operator<=>'"
-H332A7297AC58: "在為此預設的'operator<=>'宣告對應的隱含'operator=='時"
+H332A7297AC58: "在為此預設的 'operator<=>' 宣告對應的隱含 'operator==' 時"
 # 'while declaring the implicit %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}1 for %0'
 HAC5877F575DC: '在為 %0 宣告隱含的%select{預設建構函數|複製建構函數|移動建構函數|複製指定運算子|移動指定運算子|析構函數}1時'
 # 'while loop has empty body'
@@ -28953,7 +28953,7 @@ HAB96332E82A6: '函式外部的while迴圈'
 # 'while printing functions output dyno-stats and skip instructions'
 HF414286E0A36: '在列印函式時輸出dyno-stats並跳過指令'
 # "while rewriting comparison as call to 'operator<=>' declared here"
-H9A478A9E2AA1: "在將比較重寫為對在此處宣告的'operator<=>'的呼叫時"
+H9A478A9E2AA1: "在將比較重寫為對在此處宣告的 'operator<=>' 的呼叫時"
 # 'while substituting deduced template arguments into function template %0 %1'
 H4E16912522F9: '在將推導出的模板參數替換到函數模板 %0 %1 時'
 # 'while substituting explicitly-specified template arguments into function template %0 %1'
@@ -28977,7 +28977,7 @@ HD1698255B212: '將此欄位擴展到 %0 位以存儲 %1 的所有值'
 # 'width of bit-field %0 (%1 bits) exceeds the width of its type; value will be truncated to %2 bit%s2'
 H8896C13CC6D9: '位段 %0 的位數 (%1 位) 超過其類型的寬度；值將被截斷為 %2 位'
 # 'width of%select{ anonymous|}0 bit-field%select{| %1}0 (%2 bits) exceeds the %select{width|size}3 of its type (%4 bit%s4)'
-H02B50746D7D1: '%select{匿名|}0 位段%select{| %1}0 的寬度 (%2 位) 超過其類型的%select{寬度|大小}3 (%4 位)'
+H02B50746D7D1: '%select{匿名|}0 位段 %select{| %1}0 的寬度 (%2 位) 超過其類型的%select{寬度|大小}3 (%4 位)'
 # 'with jt-footprint-reduction, only process PIC jumptables and turn off other transformations that increase code size'
 H3BB007DE5DDB: '在啟用 jt-footprint-reduction 時，僅處理 PIC jumptables 並關閉其他會增加代碼大小的轉換'
 # 'within field of type %0 declared here'
@@ -29013,4 +29013,4 @@ H49512BBF0CE4: '零長度陣列是擴充功能'
 # "zero-length array section is not allowed in 'depend' clause"
 HC5FAF4CE6159: "在 'depend' 子句中不允許使用零長度陣列區段"
 # 'zero-length arrays are not permitted in %select{C++|SYCL device code|HIP device code}0'
-H2F083F032372: '在%select{C++|SYCL裝置代碼|HIP裝置代碼}0中不允許使用零長度陣列'
+H2F083F032372: '在 %select{C++|SYCL裝置代碼|HIP裝置代碼}0中不允許使用零長度陣列'

--- a/i18n/zh_TW.yml
+++ b/i18n/zh_TW.yml
@@ -171,7 +171,7 @@ H63E9059C2A3F: '%0 屬性只能用於 ARM、HLSL 或 RISC-V 內建函數'
 # '%0 attribute can only be applied to instance variables or properties'
 H30E90B5958C9: '%0 屬性只能用於實例變數或屬性'
 # "%0 attribute cannot be applied to %select{a function parameter|a variable with 'register' storage class|a 'catch' variable|a bit-field|an enumeration}1"
-HD202D2E58321: "%0 屬性不能用於%select{函數參數|具有'register'存儲類別的變數|'catch'變數|位段|枚舉}1"
+HD202D2E58321: "%0 屬性不能用於%select{函數參數|具有 'register' 存儲類別的變數|'catch' 變數|位段|枚舉}1"
 # '%0 attribute cannot be applied to %select{methods in protocols|dealloc}1'
 HC18046C82752: '%0 屬性不能用於%select{協定中的方法|dealloc}1'
 # '%0 attribute cannot be applied to a %select{function|method}1 with no parameters'
@@ -287,27 +287,27 @@ HB94334A9F06D: '%0 屬性參數 %1 為負數且將被忽略'
 # '%0 attribute parameter %1 is out of bounds'
 H9C7D1C19F9DB: '%0 屬性參數 %1 超出範圍'
 # '%0 attribute parameter %1 is out of bounds: %plural{0:no parameters to index into|1:can only be 1, since there is one parameter|:must be between 1 and %2}2'
-HF05125794562: '%0 屬性參數 %1 超出範圍：%plural{0:無參數可供索引|1:只能是1，因為只有一個參數|:必須介於1和%2之間}2'
+HF05125794562: '%0 屬性參數 %1 超出範圍：%plural{0:無參數可供索引|1:只能是 1，因為只有一個參數|:必須介於 1 和 %2 之間}2'
 # '%0 attribute parameter types do not match: parameter %1 of function %2 has type %3, but parameter %4 of function %5 has type %6'
-H4FBE5E81E84C: '%0 屬性參數類型不匹配：函數%2的第%1個參數類型為%3，但函數%5的第%4個參數類型為%6'
+H4FBE5E81E84C: '%0 屬性參數類型不匹配：函數 %2 的第 %1 個參數類型為 %3，但函數 %5 的第 %4 個參數類型為 %6'
 # '%0 attribute parameters do not match the previous declaration'
 HBB1E6D667EEA: '%0 屬性參數與先前宣告不符'
 # '%0 attribute references function %1, which %plural{0:takes no arguments|1:takes one argument|:takes exactly %2 arguments}2'
-HC6916839EF90: '%0 屬性引用函數%1，該函數%plural{0:沒有參數|1:有一個參數|:恰好有%2個參數}2'
+HC6916839EF90: '%0 屬性引用函數 %1，該函數%plural{0:沒有參數|1:有一個參數|:恰好有 %2 個參數}2'
 # '%0 attribute references parameter %1, but the function %2 has only %3 parameters'
-H95C6EBBF3D05: '%0 屬性引用參數%1，但函數%2僅有%3個參數'
+H95C6EBBF3D05: '%0 屬性引用參數 %1，但函數 %2 僅有 %3 個參數'
 # '%0 attribute requires %select{int or bool|an integer constant|a string|an identifier}1'
 H4D660FD4970F: '%0 屬性需要%select{整數或布林值|整數常數|字串|識別符}1'
 # '%0 attribute requires a %select{positive|non-negative}1 integral compile time constant expression'
 H88B2A4A1C6F1: '%0 屬性需要%select{正|非負}1整數編譯時常數運算式'
 # '%0 attribute requires an integer argument which is a constant power of two between %1 and %2 inclusive; provided argument was %3'
-HBE3281153430: '%0 屬性需要介於%1和%2（含）之間的整數常數次方；提供的參數為%3'
+HBE3281153430: '%0 屬性需要介於 %1 和 %2（含）之間的整數常數次方；提供的參數為 %3'
 # "%0 attribute requires arguments whose type is annotated with 'capability' attribute; type here is %1"
-H6A637254187D: "%0 屬性需要類型標註為'capability'屬性的類型；這裡的類型是%1"
+H6A637254187D: "%0 屬性需要類型標註為 'capability' 屬性的類型；這裡的類型是 %1"
 # '%0 attribute requires integer constant between %1 and %2 inclusive'
-HEAC447E72E0E: '%0 属性需要介於%1和%2（含）之間的整數常數'
+HEAC447E72E0E: '%0 属性需要介於 %1 和 %2（含）之間的整數常數'
 # '%0 attribute requires parameter %1 to be %select{int or bool|an integer constant|a string|an identifier|a constant expression|a builtin function}2'
-H410FC41452B2: '%0 屬性需要參數%1為%select{整數或布林值|整數常數|字串|識別符|常數運算式|內建函數}2'
+H410FC41452B2: '%0 屬性需要參數 %1 為%select{整數或布林值|整數常數|字串|識別符|常數運算式|內建函數}2'
 # '%0 attribute requires that both caller and callee functions have a prototype'
 H16EEA1808E57: '%0 屬性需要呼叫端與被呼叫函數都具有原型宣告'
 # '%0 attribute requires that the return value is the result of a function call'
@@ -705,9 +705,9 @@ H45C12381C633: '%0%select{ 屬性|}1 僅適用於 %2'
 # '%0%select{ attribute|}1 only applies to %select{functions|unions|variables and functions|functions and methods|functions, methods and blocks|functions, methods, and parameters|variables|variables and fields|variables, data members and tag types|types and namespaces|variables, functions and classes|kernel functions|non-K&R-style functions|for loop statements|virtual functions|parameters and implicit object parameters|non-member functions|functions, classes, or enumerations|classes|typedefs}2'
 H9D37840D3CB2: '%0%select{ 屬性|}1 只能套用於 %select{函數|聯合|變數與函數|函數與方法|函數、方法與區塊|函數、方法和參數|變數|變數與成員|變數、資料成員與標記類型|類型與命名空間|變數、函數與類別|核心函數|非K&R式函數|for迴圈陳述式|虛函數|參數與隱含物件參數|非成員函數|函數、類別或列舉|類別|typedef}2'
 # "%0%select{| following the 'template' keyword}1 cannot refer to a dependent template"
-HA18DA36B7236: "%0%select{| 在'template'關鍵字後面}1 不能引用依賴型模板"
+HA18DA36B7236: "%0%select{| 在 'template' 關鍵字後面}1 不能引用依賴型模板"
 # "%0%select{| following the 'template' keyword}1 does not refer to a template"
-HCADF8F759262: "%0%select{| 在'template'關鍵字後面}1 不是模板"
+HCADF8F759262: "%0%select{| 在 'template' 關鍵字後面}1 不是模板"
 # "%0: '%1' input unused in cpp mode"
 HF14789F9D841: "%0: '%1' 輸入在cpp模式下未被使用"
 # "%0: '%1' input unused%select{ when '%3' is present|}2"
@@ -719,13 +719,13 @@ H1EB52EB9DA3B: "%0: 之前預處理的輸入%select{ 當存在'%2'時未被使�
 # "%0; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop or by providing the compiler option '-ffast-math'"
 H50F1AE498158: "%0; 允許重新排序可透過在迴圈前指定'#pragma clang loop vectorize(enable)' 或提供編譯器選項'-ffast-math'"
 # "%0; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop; if the arrays will always be independent, specify '#pragma clang loop vectorize(assume_safety)' before the loop or provide the '__restrict__' qualifier with the independent array arguments -- erroneous results will occur if these options are incorrectly applied"
-H696063533F0E: "%0; 允許重新排序可透過在迴圈前指定'#pragma clang loop vectorize(enable)'；若陣列始終獨立，可指定'#pragma clang loop vectorize(assume_safety)' 或在獨立陣列參數上使用'__restrict__'限定詞 -- 若錯誤套用這些選項將導致結果錯誤"
+H696063533F0E: "%0; 允許重新排序可透過在迴圈前指定'#pragma clang loop vectorize(enable)'；若陣列始終獨立，可指定'#pragma clang loop vectorize(assume_safety)' 或在獨立陣列參數上使用 '__restrict__' 限定詞 -- 若錯誤套用這些選項將導致結果錯誤"
 # '%0B (%human0B) in local locations, %1B (%human1B) in locations loaded from AST files, for a total of %2B (%human2B) (%3%% of available space)'
-H9B3C5907D274: '%0B（%human0B）在本地位置，%1B（%human1B）在從AST文件載入的位置，總共%2B（%human2B）（佔用可用空間的%3%%）'
+H9B3C5907D274: '%0B（%human0B）在本地位置，%1B（%human1B）在從AST文件載入的位置，總共 %2B（%human2B）（佔用可用空間的 %3%%）'
 # '%1 %0 is hidden by a non-type declaration of %0 here'
-HC05432050C69: '%1 %0 被非類型宣告的%0隱藏在此處'
+HC05432050C69: '%1 %0 被非類型宣告的 %0 隱藏在此處'
 # '%1 is a %select{private|protected}0 member of %3'
-H4162E2E8D4C1: '%1 是%3的%select{私有|受保護}0 成員'
+H4162E2E8D4C1: '%1 是 %3 的%select{私有|受保護}0 成員'
 # '%2 defined as %select{a struct|an interface|a class}0%select{| template}1 here but previously declared as %select{a struct|an interface|a class}3%select{| template}1; this is valid, but may result in linker errors under the Microsoft C++ ABI'
 H65DDB76661CA: '%2 被定義為%select{結構|介面|類別}0%select{|模板}1，但先前宣告為%select{結構|介面|類別}3%select{|模板}1；此符合語法，但可能在Microsoft C++ ABI下導致連結器錯誤'
 # '%diff{$ and $ are not pointers to compatible types|pointers to incompatible types}0,1'
@@ -735,7 +735,7 @@ HBE91EA4F0CCD: '%diff{ K&R函數參數的提升類型$與參數類型$不兼容 
 # '%diff{return type $ must match previous return type $|return type must match previous return type}0,1 when %select{block literal|lambda expression}2 has unspecified explicit return type'
 H503B0717AF47: '%diff{返回類型 $ 必須與先前的返回類型 $ 一致|返回類型必須與先前的返回類型一致}1,0 當 %select{區塊iteral|lambda運算式}2 具有未指定的明確返回類型時'
 # "%ordinal0 argument must be a %select{|scalar|vector|matrix|vector of|scalar or vector of}1%plural{[2,3]:%plural{0:|:%plural{0:|:,}2}3|:}1%plural{0:|: }1%select{|integer|signed integer|unsigned integer|'int'|pointer to a valid matrix element}2%plural{0:|: }2%plural{0:|:%plural{0:|:or }2}3%select{|floating-point}3%plural{0:|: }3%plural{[0,3]:type|:types}1 (was %4)"
-HEE73BAE75429: '%ordinal0參數必須是%select{|純量|向量|矩陣|向量的|純量或向量的}1%plural{[2,3]:%plural{0:|:%plural{0:|:,}2}3|:}1%plural{0:|: }1%select{|整數|帶符號整數|無符號整數|int類型|指向有效矩陣元素的指標}2%plural{0:|: }2%plural{0:|:%plural{0:|:或 }2}3%select{|浮點數}3%plural{0:|: }3%plural{[0,3]:類型|:類型}1（實際是%4）'
+HEE73BAE75429: '%ordinal0參數必須是%select{|純量|向量|矩陣|向量的|純量或向量的}1%plural{[2,3]:%plural{0:|:%plural{0:|:,}2}3|:}1%plural{0:|: }1%select{|整數|帶符號整數|無符號整數|int類型|指向有效矩陣元素的指標}2%plural{0:|: }2%plural{0:|:%plural{0:|:或 }2}3%select{|浮點數}3%plural{0:|: }3%plural{[0,3]:類型|:類型}1（實際是 %4）'
 # '%ordinal0 argument must be a WebAssembly table'
 HF0E3AF42C5DD: '%ordinal0參數必須是WebAssembly表'
 # '%ordinal0 argument must be an integer'
@@ -743,11 +743,11 @@ HB74677AB0CCF: '%ordinal0參數必須是整數'
 # '%ordinal0 argument must match the element type of the WebAssembly table in the %ordinal1 argument'
 HCC6BF06B970F: '%ordinal0參數必須與%ordinal1參數中的WebAssembly表的元素類型相符'
 # '%plural{1:enumeration value %1 not explicitly handled in switch|2:enumeration values %1 and %2 not explicitly handled in switch|3:enumeration values %1, %2, and %3 not explicitly handled in switch|:%0 enumeration values not explicitly handled in switch: %1, %2, %3...}0'
-HE8DAC9A52D87: '%plural{1:列舉值%1在switch中未明確處理|2:列舉值%1和%2在switch中未明確處理|3:列舉值%1、%2和%3在switch中未明確處理|:%0列舉值在switch中未明確處理：%1、%2、%3...}0'
+HE8DAC9A52D87: '%plural{1:列舉值 %1 在switch中未明確處理|2:列舉值 %1 和 %2 在switch中未明確處理|3:列舉值 %1、%2 和 %3 在switch中未明確處理|:%0 列舉值在switch中未明確處理：%1、%2、%3...}0'
 # '%plural{1:enumeration value %1 not handled in switch|2:enumeration values %1 and %2 not handled in switch|3:enumeration values %1, %2, and %3 not handled in switch|:%0 enumeration values not handled in switch: %1, %2, %3...}0'
-H0E3F79F6C010: '%plural{1:列舉值%1在switch中未處理|2:列舉值%1和%2在switch中未處理|3:列舉值%1、%2和%3在switch中未處理|:%0列舉值在switch中未處理：%1、%2、%3...}0'
+H0E3F79F6C010: '%plural{1:列舉值 %1 在switch中未處理|2:列舉值 %1 和 %2 在switch中未處理|3:列舉值 %1、%2 和 %3 在switch中未處理|:%0 列舉值在switch中未處理：%1、%2、%3...}0'
 # "%plural{2:'delete' used to delete pointer to object allocated with 'std::allocator<...>::allocate'|:%select{non-array delete|array delete|'std::allocator<...>::deallocate'}0 used to delete pointer to %select{array object of type %2|non-array object of type %2|object allocated with 'new'}0}1"
-H1294E54BD6EF: "%plural{2:'delete'用於刪除以'std::allocator<...>::allocate'分配的物件指標|:%select{非陣列delete|陣列delete|'std::allocator<...>::deallocate'}0用於刪除%select{陣列物件類型%2|非陣列物件類型%2|以'new'分配的物件}0}1"
+H1294E54BD6EF: "%plural{2:'delete' 用於刪除以'std::allocator<...>::allocate'分配的物件指標|:%select{非陣列delete|陣列delete|'std::allocator<...>::deallocate'}0用於刪除%select{陣列物件類型 %2|非陣列物件類型 %2|以 'new' 分配的物件}0}1"
 # '%plural{[0,2]:must use a qualified name when declaring|3:cannot declare}0 a %select{constructor|destructor|conversion operator|deduction guide}0 as a friend'
 H180E877A4B1E: '%plural{[0,2]:宣告時必須使用合格名稱|3:無法宣告}0 %select{建構函數|解構函數|轉換運算子|推論指引}0 作為友元'
 # "%q0 %select{with definition in module '%2'|defined here}1 has different definitions in different modules; first difference is this %select{||||static assert|field|method|type alias|typedef|data member|friend declaration|function template|method|instance variable|property|unexpected decl}3"
@@ -759,7 +759,7 @@ H9DF776E318FF: "%q0 來自模組 '%1' 的內容未出現在 %q2%select{ 模組 '
 # "%q0 has different definitions in different modules; %select{definition in module '%2' is here|defined here}1"
 HB3D6EB7685C3: "%q0 在不同模組中有不同的定義；%select{模組'%2'中的定義在此|在此處定義}1"
 # "%q0 has different definitions in different modules; %select{definition in module '%2'|defined here}1 first difference is %select{enum that is %select{not scoped|scoped}4|enum scoped with keyword %select{struct|class}4|enum %select{without|with}4 specified type|enum with specified type %4|enum with %4 element%s4|%ordinal4 element has name %5|%ordinal4 element %5 %select{has|does not have}6 an initializer|%ordinal4 element %5 has an initializer|}3"
-H39CEC8B6DBEB: "%q0 在不同模組中有不同的定義；%select{模組'%2'中的定義在此|在此處定義}1 第一個差異是%select{列舉%select{未指定為作用域|指定為作用域}4|列舉以關鍵字%select{struct|class}4指定為作用域|列舉%select{無|有}4指定類型|列舉具有指定類型%4|列舉具有%4個元素|%ordinal4個元素名稱為%5|%ordinal4個元素%5 %select{有|沒有}6 初始值|%ordinal4個元素%5有初始值|}3"
+H39CEC8B6DBEB: "%q0 在不同模組中有不同的定義；%select{模組'%2'中的定義在此|在此處定義}1 第一個差異是%select{列舉%select{未指定為作用域|指定為作用域}4|列舉以關鍵字 %select{struct|class}4 指定為作用域|列舉%select{無|有}4指定類型|列舉具有指定類型 %4|列舉具有 %4 個元素|%ordinal4個元素名稱為 %5|%ordinal4個元素 %5 %select{有|沒有}6 初始值|%ordinal4個元素 %5 有初始值|}3"
 # "%q0 has different definitions in different modules; %select{definition in module '%2'|defined here}1 first difference is %select{return type is %4|%ordinal4 parameter with name %5|%ordinal4 parameter with type %5%select{| decayed from %7}6|%ordinal4 parameter with%select{out|}5 a default argument|%ordinal4 parameter with a default argument|function body}3"
 H68AA8A549FAA: "%q0 在不同模組中具有不同的定義；%select{模組 '%2' 中的定義|在此處定義}1 第一個差異是 %select{返回類型為 %4|%ordinal4 參數具有名稱 %5|%ordinal4 參數具有類型 %5%select{| 退化自 %7}6|%ordinal4 參數具有%select{out|}5 預設參數|%ordinal4 參數具有預設參數|函數主體}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{%4 base %plural{1:class|:classes}4|%4 virtual base %plural{1:class|:classes}4|%ordinal4 base class with type %5|%ordinal4 %select{non-virtual|virtual}5 base class %6|%ordinal4 base class %5 with %select{public|protected|private|no}6 access specifier}3"
@@ -771,7 +771,7 @@ HA17814A91726: "%q0 在不同模組中具有不同的定義；第一個差異是
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{%select{typedef|type alias}4 name %5|%select{typedef|type alias}4 %5 with underlying type %6}3"
 H290AB6198D53: "%q0 在不同模組中具有不同的定義；第一個差異是 %select{模組 '%2' 中的定義|在此處定義}1 發現 %select{%select{類型別名|typedef}4 名稱 %5|%select{類型別名|typedef}4 %5 具有基礎類型 %6}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{data member with name %4|data member %4 with type %5|data member %4 with%select{out|}5 an initializer|data member %4 with an initializer|data member %4 %select{is constexpr|is not constexpr}5}3"
-H3C6A067820A4: "%q0 在不同模組中具有不同的定義；第一個差異是 %select{模組 '%2' 中的定義|在此處定義}1 發現 %select{資料成員名稱 %4|資料成員 %4 具有類型 %5|資料成員 %4 具有%select{out|}5 初始化式|資料成員 %4 具有初始化式|資料成員 %4 %select{是 constexpr|不是 constexpr}5}3"
+H3C6A067820A4: "%q0 在不同模組中具有不同的定義；第一個差異是 %select{模組 '%2' 中的定義|在此處定義}1 發現 %select{資料成員名稱 %4|資料成員 %4 具有類型 %5|資料成員 %4 具有 %select{out|}5 初始化式|資料成員 %4 具有初始化式|資料成員 %4 %select{是 constexpr|不是 constexpr}5}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{end of class|public access specifier|private access specifier|protected access specifier|static assert|field|method|type alias|typedef|data member|friend declaration|function template|method|instance variable|property}3"
 HC7FCD2470FA2: "%q0 在不同模組中具有不同的定義；第一個差異是 %select{模組 '%2' 中的定義|在此處定義}1 發現 %select{類別結束|公開存取修飾符|私有存取修飾符|受保護存取修飾符|static assert|資料成員|方法|類型別名|typedef|資料成員|朋友宣告|函數範本|方法|實體變數|屬性}3"
 # "%q0 has different definitions in different modules; first difference is %select{definition in module '%2'|defined here}1 found %select{field %4|field %4 with type %5|%select{non-|}5bit-field %4|bit-field %4 with one width expression|%select{non-|}5mutable field %4|field %4 with %select{no|an}5 initializer|field %4 with an initializer}3"
@@ -923,7 +923,7 @@ HA87D7335D9EB: "%select{且|因為}0 '%1' 可能擲出例外"
 # "%select{and|because}0 '%1' would be invalid"
 HAD3CC48247E5: "%select{且|因為}0 '%1' 會無效"
 # "%select{and|because}0 '%1' would be invalid%2"
-HEF46AC24BE27: "%select{且|因為}0 '%1' 會無效%2"
+HEF46AC24BE27: "%select{且|因為}0 '%1' 會無效 %2"
 # "%select{and|because}0 '%1' would be invalid: %2"
 HD3831227C190: "%select{且|因為}0 '%1' 會無效: %2"
 # "%select{and|because}0 type constraint '%1' was not satisfied:"
@@ -953,7 +953,7 @@ H4DA493B4F5FF: '%select{調用非靜態成員函數|使用非靜態資料成員}
 # '%select{cannot assign to return value because function %1 returns a const value|cannot assign to variable %1 with const-qualified type %2|cannot assign to %select{non-|}1static data member %2 with const-qualified type %3|cannot assign to non-static data member within const member function %1|cannot assign to %select{variable %2|non-static data member %2|lvalue}1 with %select{|nested }3const-qualified data member %4|read-only variable is not assignable}0'
 H957C121C1C4E: '%select{無法對返回值進行賦值，因為函數 %1 返回了 const 值|無法對 const 限定類型 %2 的變數 %1 進行賦值|無法對 %select{非-|}1靜態資料成員 %2 具有 const 限定類型 %3 進行賦值|無法在 const 成員函數 %1 內對非靜態資料成員進行賦值|無法對 %select{變數 %2|非靜態資料成員 %2|左值}1 具有 %select{|嵌套 }3const 限定資料成員 %4 進行賦值|唯讀變數無法進行賦值}0'
 # "%select{case value|enumerator value|non-type template argument|non-type parameter of template template parameter|array size|explicit specifier argument|noexcept specifier argument|call to 'size()'|call to 'data()'}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1"
-HECF4733C9DA0: "%select{case值|枚舉值|非類型模板參數|匿名聯結體成員|陣列大小|顯式指定參數|noexcept指定參數|調用'size()'|調用'data()'}0 %select{不能從類型%2窄化為%3|評估為%2，這不能窄化為類型%3}1"
+HECF4733C9DA0: "%select{case值|枚舉值|非類型模板參數|匿名聯結體成員|陣列大小|顯式指定參數|noexcept指定參數|調用'size()'|調用'data()'}0 %select{不能從類型 %2 窄化為 %3|評估為 %2，這不能窄化為類型 %3}1"
 # "%select{case value|enumerator value|non-type template argument|non-type parameter of template template parameter|array size|explicit specifier argument|noexcept specifier argument|call to 'size()'|call to 'data()'}0 is not a constant expression"
 HFB41B693F137: "%select{case 值|枚舉值|非類型模板參數|非類型參數的模板模板參數|陣列大小|顯示指定參數|noexcept 指定參數|調用 'size()'|調用 'data()'}0 不是常量表達式"
 # '%select{cast|implicit conversion}0 of %select{Objective-C|block|C}1 pointer type %2 to %select{Objective-C|block|C}3 pointer type %4 requires a bridged cast'
@@ -1013,11 +1013,11 @@ H56EB9B5EABD1: '%select{const_cast|static_cast|reinterpret_cast|dynamic_cast|C-s
 # '%select{const_cast|static_cast|reinterpret_cast|dynamic_cast|C-style cast|functional-style cast|}0 from %1 to %2, which are not related by inheritance, is not allowed'
 HC3DB71EF3442: '%select{const_cast|static_cast|reinterpret_cast|dynamic_cast|C-style cast|functional-style cast|}0 從 %1 到 %2 不具繼承關係，不被允許'
 # '%select{const_cast|static_cast|reinterpret_cast|dynamic_cast|C-style cast|functional-style cast|}0 from bit-field lvalue to reference type %2'
-H1DAD5B4DA5AC: '%select{const_cast|static_cast|reinterpret_cast|dynamic_cast|C-style cast|函數式cast|}0 將位段左值轉換為引用類型%2'
+H1DAD5B4DA5AC: '%select{const_cast|static_cast|reinterpret_cast|dynamic_cast|C-style cast|函數式cast|}0 將位段左值轉換為引用類型 %2'
 # '%select{const_cast||||C-style cast|functional-style cast|}0 to %2, which is not a reference, pointer-to-object, or pointer-to-data-member'
 H2773305E9004: '%select{const_cast||||C-style cast|functional-style cast|}0 從位段左值轉換為引用類型 %2'
 # "%select{constexpr|consteval}0 function's return type %1 is not a literal type"
-H8C05F94E8F5F: '%select{constexpr|consteval}0 函數的傳回類型%1 不是字面類型'
+H8C05F94E8F5F: '%select{constexpr|consteval}0 函數的傳回類型 %1 不是字面類型'
 # '%select{constexpr|consteval}1 %select{function|constructor}0 never produces a constant expression'
 H022CBA14DE42: '%select{constexpr|consteval}1 %select{函數|建構函式}0 永不產生常量運算式'
 # "%select{constexpr|consteval}2 %select{function|constructor}1's %ordinal0 parameter type %3 is not a literal type"
@@ -1051,7 +1051,7 @@ H690477FDDE60: '%select{宣告|定義}0 的 %select{struct|interface|union|class
 # '%select{decremented|incremented}0 here'
 HD8461A402F1F: '%select{遞減|遞增}0 此處'
 # '%select{decrement|increment}0 of object of volatile-qualified type %1 is deprecated'
-H57C759966E48: '%select{遞減|遞增}0 %1型態的volatile修飾物件是已棄用的'
+H57C759966E48: '%select{遞減|遞增}0 %1 型態的volatile修飾物件是已棄用的'
 # '%select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20'
 H3C92D92BB26F: '%select{預設建構|指派}0 lambda與C++20之前的C++標準不相容'
 # '%select{default constructor of|constructor inherited by}0 %1 is implicitly deleted because all %select{data members|data members of an anonymous union member}2 are const-qualified'
@@ -1059,9 +1059,9 @@ HF80E1E94C448: '%select{物件的預設建構函數|由物件繼承的建構函�
 # '%select{default constructor of|constructor inherited by}0 %1 is implicitly deleted because field %2 of %select{reference|const-qualified}4 type %3 would not be initialized'
 H3F45472DFCD6: '%select{具有|由...繼承的}0 %1 類別的預設建構函式被隱式刪除，因為其成員 %2 的 %select{引用|const限定}4 類型 %3 未被初始化'
 # '%select{default constructor of|copy constructor of|move constructor of|copy assignment operator of|move assignment operator of|destructor of|constructor inherited by}0 %1 is implicitly deleted because %select{base class %3|%select{||||variant }4field %3}2 %select{has %select{no|a deleted|multiple|an inaccessible|a non-trivial}4 %select{%select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor|%select{default|corresponding|default|default|default}4 constructor}0|destructor}5%select{||s||}4|is an ObjC pointer}6'
-H1BB10C6BA0EA: '%select{物件的預設建構函數|物件的複製建構函數|物件的移動建構函數|物件的複製賦值運算子|物件的移動賦值運算子|物件的解構函數|物件的繼承建構函數}0 %1 被隱式刪除，因為%select{基類%3|%select{||||variant }4成員%3}2 %select{有%select{無|被刪除|多個|無法存取|非平凡}4 %select{%select{預設建構函數|複製建構函數|移動建構函數|複製賦值運算子|移動賦值運算子|解構函數|%select{預設|對應|預設|預設|預設}4 建構函數}0|解構函數}5%select{||s||}4|是ObjC指標}6'
+H1BB10C6BA0EA: '%select{物件的預設建構函數|物件的複製建構函數|物件的移動建構函數|物件的複製賦值運算子|物件的移動賦值運算子|物件的解構函數|物件的繼承建構函數}0 %1 被隱式刪除，因為%select{基類 %3|%select{||||variant }4成員 %3}2 %select{有%select{無|被刪除|多個|無法存取|非平凡}4 %select{%select{預設建構函數|複製建構函數|移動建構函數|複製賦值運算子|移動賦值運算子|解構函數|%select{預設|對應|預設|預設|預設}4 建構函數}0|解構函數}5%select{||s||}4|是ObjC指標}6'
 # "%select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}0 cannot be 'constexpr' in a class with virtual base class"
-HAA0AD1F4C5AC: "%select{預設建構函數|複製建構函數|移動建構函數|複製指派運算子|移動指派運算子|析構函數}0 在具有虛基類的類別中不能是'constexpr'"
+HAA0AD1F4C5AC: "%select{預設建構函數|複製建構函數|移動建構函數|複製指派運算子|移動指派運算子|析構函數}0 在具有虛基類的類別中不能是 'constexpr'"
 # '%select{defaulted|deleted}0 function definitions are a C++11 extension'
 H2588FE2C83FF: '%select{預設|刪除}0 函數定義是C++11擴展'
 # '%select{defaulted|deleted}0 function definitions are incompatible with C++98'
@@ -1069,11 +1069,11 @@ HE7CB963644EA: '%select{預設|刪除}0 函數定義與C++98不相容'
 # "%select{definition|#undef}0 of configuration macro '%1' has no effect on the import of '%2'; pass '%select{-D%1=...|-U%1}0' on the command line to configure the module"
 H20DEB068BA86: "%select{定義|#undef}0 配置巨集'%1'對'%2'的匯入無效；使用'%select{-D%1=...|-U%1}0'指令列參數進行配置"
 # '%select{delete|destructor}0 called on %1 that is abstract but has non-virtual destructor'
-HD3B2B405330A: '%select{delete|析構函數}0 被呼叫於具有虛基類但非虛析構函數的abstract類別%1'
+HD3B2B405330A: '%select{delete|析構函數}0 被呼叫於具有虛基類但非虛析構函數的abstract類別 %1'
 # '%select{delete|destructor}0 called on non-final %1 that has virtual functions but non-virtual destructor'
-HD186820BFF8C: '%select{delete|析構函數}0 被呼叫於非final的%1，該類別具有虛函數但無虛析構函數'
+HD186820BFF8C: '%select{delete|析構函數}0 被呼叫於非final的 %1，該類別具有虛函數但無虛析構函數'
 # '%select{delimited|named}0 escape sequences are a %select{C++23|C2y|Clang}1 extension'
-HDBE05BE4D14B: '%select{限定|命名}0 轉義序列是%select{C++23|C2y|Clang}1擴展'
+HDBE05BE4D14B: '%select{限定|命名}0 轉義序列是 %select{C++23|C2y|Clang}1 擴展'
 # '%select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23'
 HFB62920439FF: '%select{限定|命名}0 轉義序列與C++23之前的標準不相容'
 # '%select{destination for|source of|first operand of|second operand of}0 this %1 call is a pointer to %select{|class containing a }2dynamic class %3; vtable pointer will be %select{overwritten|copied|moved|compared}4'
@@ -1085,7 +1085,7 @@ HEE4DB03498AC: '%select{此調用的目標是|此調用的來源是}0 %1 的指�
 # '%select{destructor|deallocator}0 has a %select{non-throwing|implicit non-throwing}1 exception specification'
 H78E56ACB6245: '%select{析構函數|deallocators}0 具有%select{不拋出例外|隱式不拋出例外}1例外規格'
 # '%select{dictionary|array}1 subscript base type %0 is not an Objective-C object'
-HE2828D54BB1B: '%select{字典|陣列}1 索引運算基底類型%0 非Objective-C物件'
+HE2828D54BB1B: '%select{字典|陣列}1 索引運算基底類型 %0 非Objective-C物件'
 # '%select{equality|inequality|relational|three-way}0 comparison result unused'
 H69C6598EFBD9: '%select{等同|不等|關係|三向}0 比較結果未被使用'
 # '%select{expected an expression statement|expected built-in assignment operator|expected expression of scalar type|expected lvalue expression}0'
@@ -1117,11 +1117,11 @@ HF5B9D5CD8E73: "%select{第一個|第二個|環境|平台特定資料}0 個 'mai
 # '%select{first|second|third}0 parameter has unexpected type %1 (should be %2)'
 HB94305DC6AD8: '%select{第一個|第二個|第三個}0 個參數具有不正確的類型 %1（應為 %2）'
 # '%select{first|second}0 operand was implicitly converted to type %1'
-HBF77ADC8F095: '%select{第一|第二}0 運算元隱式轉換為類型%1'
+HBF77ADC8F095: '%select{第一|第二}0 運算元隱式轉換為類型 %1'
 # '%select{forward class declaration|class definition|category|extension}0 has too %select{few|many}1 type parameters (expected %2, have %3)'
 HF027D432E158: '%select{類別前向宣告|類別定義|分類|擴充}0 的類型參數數目 %select{過少|過多}1（期望 %2，目前 %3）'
 # '%select{function %1 which returns const-qualified type %2 declared here|variable %1 declared const here|%select{non-|}1static data member %2 declared const here|member function %q1 is declared const here|%select{|nested }1data member %2 declared const here}0'
-HA9209A7005BD: '%select{返回const限定類型%2的函數%1宣告在此處|在此處宣告的const變數%1|%select{非-|}1靜態資料成員%2在此處宣告為const|此成員函數%q1在此處宣告為const|%select{|巢狀 }1資料成員%2在此處宣告為const}0'
+HA9209A7005BD: '%select{返回const限定類型 %2 的函數 %1 宣告在此處|在此處宣告的const變數 %1|%select{非-|}1靜態資料成員 %2 在此處宣告為const|此成員函數%q1在此處宣告為const|%select{|巢狀 }1資料成員 %2 在此處宣告為const}0'
 # '%select{function parameter|typedef}0 cannot be %select{<ERROR>|constexpr|consteval|constinit}1'
 H86C3A8B0C257: '%select{函數參數|typedef宣告}0 無法是%select{<ERROR>|constexpr|consteval|constinit}1'
 # '%select{function template|class template|variable template|type alias template|template template parameter}0 %1 declared here'
@@ -1131,7 +1131,7 @@ HA1CB6C2DD073: '%select{具有推論傳回型別的函數|具有尾端傳回型�
 # "%select{function|block|lambda|coroutine}0 declared 'noreturn' should not return"
 HBB674CBF2E79: '%select{函數|區塊|lambda|coroutine}0 被宣告為noreturn，不應返回值'
 # "%select{function|class|variable}0 cannot be defined in an explicit instantiation; if this declaration is meant to be a %select{function|class|variable}0 definition, remove the 'template' keyword"
-HF2F19E25243A: "%select{函數|類別|變數}0 不能在顯式實體化中定義；若此宣告是%select{函數|類別|變數}0 的定義，請移除'template'關鍵字"
+HF2F19E25243A: "%select{函數|類別|變數}0 不能在顯式實體化中定義；若此宣告是%select{函數|類別|變數}0 的定義，請移除 'template' 關鍵字"
 # "%select{function|constructor|destructor|lambda|block|member initializer of constructor}0 with '%1' attribute must not %select{allocate or deallocate memory|throw or catch exceptions|have static local variables|use thread-local variables|access ObjC methods or properties}2"
 H8DE43E9D40B0: "%select{函數|建構函數|析構函數|lambda|block|建構函數的成員初始值設定}0 具有 '%1' 屬性不得 %select{分配或釋放記憶體|擲出或捕捉例外|具有靜態局部變數|使用執行緒局部變數|存取_ObjC 方法或屬性}2"
 # "%select{function|constructor|destructor|lambda|block|member initializer of constructor}0 with '%1' attribute must not call non-'%1' %select{function|constructor|destructor|lambda|block}2 '%3'"
@@ -1171,7 +1171,7 @@ H2BE56E173B04: '%select{隱式轉換|型別轉換}0 將 %select{%2|非Objective-
 # '%select{implicit conversion|cast}0 of weak-unavailable object of type %1 to a __weak object of type %2'
 H5E0A61E4DC2C: '%select{隱式轉換|型別轉換}0 將無法存取的弱引用物件 %1 轉換為__weak物件 %2'
 # '%select{implicitly |}2captured%select{| by reference}3%select{%select{ due to use|}2 here| via initialization of lambda capture %0}1'
-H0BA3D7D599E5: '%select{隱式|}2捕獲%select{|通過引用}3%select{%select{ 由於此處的使用|}2 |通過lambda捕獲%0的初始化}1'
+H0BA3D7D599E5: '%select{隱式|}2捕獲%select{|通過引用}3%select{%select{ 由於此處的使用|}2 |通過lambda捕獲 %0 的初始化}1'
 # '%select{implicit|explicit}0 instantiation first required here'
 HB12903FE55DA: '%select{隱式|明確}0 實體化首次在此需要'
 # '%select{implicit|explicit}0 instantiation of template %1 within its own definition'
@@ -1187,7 +1187,7 @@ H113C6B0985AF: '%select{實例|類}1 方法 %0 未找到；是否指 %2？'
 # '%select{integer|integral}1 constant expression must have %select{integer|integral or unscoped enumeration}1 type, not %0'
 H07847569345A: '%select{整數|整數或無作用域列舉}1 常數運算式必須具有 %select{整數|整數或無作用域列舉}1 類型，而非 %0'
 # "%select{interrupt service routine|function with attribute 'no_caller_saved_registers'}0 should only call a function with attribute 'no_caller_saved_registers' or be compiled with '-mgeneral-regs-only'"
-HE2C243372C8E: "%select{中斷服務常式|具有'no_caller_saved_registers'屬性的函數}0 應僅呼叫具有'no_caller_saved_registers'屬性的函數，或使用'-mgeneral-regs-only'編譯"
+HE2C243372C8E: "%select{中斷服務常式|具有 'no_caller_saved_registers' 屬性的函數}0 應僅呼叫具有 'no_caller_saved_registers' 屬性的函數，或使用'-mgeneral-regs-only'編譯"
 # "%select{invalid use of|unknown}2 attribute subject matcher sub-rule '%0'; '%1' matcher %select{does not support sub-rules|supports the following sub-rules: %3}2"
 H8BFF482F0D6A: "%select{無效的|%s}2屬性主體匹配規則子規則'%0'；'%1'匹配器 %select{不支援子規則|支援以下子規則：%3}2"
 # "%select{invalid value '%0'; must be positive|value '%0' is too large}1"
@@ -1253,7 +1253,7 @@ HDF54FE517944: "%select{未提供|超出}0 整數表達式參數給 OpenACC 'num
 # "%select{orphaned 'omp section' directives are prohibited, it|'omp section' directive}0 must be closely nested to a sections region%select{|, not a %1 region}0"
 HF07F4A64D372: "%select{孤兒 'omp section' 指令不被允許，它|'omp section' 指令}0 必須緊密巢狀在 sections 區域%select{|，而非 %1 區域}0"
 # "%select{overridden|current}0 method is explicitly declared 'instancetype'%select{| and is expected to return an instance of its class type}0"
-HB89C11914779: "%select{覆寫|目前}0 方法明確宣告為'instancetype'%select{|，並期望返回其類別的實例}0"
+HB89C11914779: "%select{覆寫|目前}0 方法明確宣告為 'instancetype'%select{|，並期望返回其類別的實例}0"
 # "%select{overridden|current}0 method is part of the '%select{|alloc|copy|init|mutableCopy|new|autorelease|dealloc|finalize|release|retain|retainCount|self}1' method family%select{| and is expected to return an instance of its class type}0"
 HB76B1E081BAA: "%select{覆寫|目前}0 方法是 '%select{|alloc|copy|init|mutableCopy|new|autorelease|dealloc|finalize|release|retain|retainCount|self}1' 方法家族的成員%select{|，並期望返回其類別的實例}0"
 # '%select{parameters|function return value}0 cannot have __fp16 type; did you forget * ?'
@@ -1315,27 +1315,27 @@ H5DD079C28614: '%select{讀取|讀取|賦值給|遞增|遞減|成員呼叫|dynam
 # '%select{read of|read of|assignment to|increment of|decrement of|member call on|dynamic_cast of|typeid applied to|construction of|destruction of|read of}0 heap allocated object that has been deleted'
 H0F4326DA1EA9: '%select{讀取|讀取|賦值給|遞增|遞減|成員呼叫|dynamic_cast|對...應用typeid|建構|銷毀|讀取}0 已經被delete的堆上物件'
 # '%select{read of|read of|assignment to|increment of|decrement of|member call on|dynamic_cast of|typeid applied to|construction of|destruction of|read of}0 mutable member %1 is not allowed in a constant expression'
-H08EBC2661AFA: '%select{讀取|讀取|賦值給|遞增|遞減|成員呼叫|dynamic_cast|對...應用typeid|建構|銷毀|讀取}0 可變更成員%1 在常數運算式中非法'
+H08EBC2661AFA: '%select{讀取|讀取|賦值給|遞增|遞減|成員呼叫|dynamic_cast|對...應用typeid|建構|銷毀|讀取}0 可變更成員 %1 在常數運算式中非法'
 # "%select{read of|read of|assignment to|increment of|decrement of|member call on|dynamic_cast of|typeid applied to|construction of|destruction of|read of}0 object '%1' whose value is not known"
 H2547ED9973E0: "%select{讀取|讀取|賦值給|遞增|遞減|成員呼叫|dynamic_cast|對...應用typeid|建構|銷毀|讀取}0 值未知的物件'%1'"
 # '%select{read of|read of|assignment to|increment of|decrement of|member call on|dynamic_cast of|typeid applied to|construction of|destruction of|read of}0 temporary is not allowed in a constant expression outside the expression that created the temporary'
 H1A04D5C0C6D4: '%select{讀取|讀取|賦值給|遞增|遞減|成員呼叫|dynamic_cast|對...應用typeid|建構|銷毀|讀取}0 非創建運算式中的臨時物件在常數運算式中非法'
 # '%select{reading|writing}1 the value pointed to by %0 requires holding %select{any mutex|any mutex exclusively}1'
-H20B2C79559EA: '%select{讀取|寫入}1 指標%0 所指向的值需要持有%select{任何鎖定|獨佔鎖定}1'
+H20B2C79559EA: '%select{讀取|寫入}1 指標 %0 所指向的值需要持有%select{任何鎖定|獨佔鎖定}1'
 # '%select{reading|writing}1 variable %0 requires holding %select{any mutex|any mutex exclusively}1'
-HAB41C50F5547: '%select{讀取|寫入}1 變數%0 需要持有%select{任何鎖定|獨佔鎖定}1'
+HAB41C50F5547: '%select{讀取|寫入}1 變數 %0 需要持有%select{任何鎖定|獨佔鎖定}1'
 # "%select{reading|writing}3 the value pointed to by %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
 HA3CF53D5D321: "%select{讀取|寫入}3 由 %1 指向的值需要持有 %0 %select{'%2'|'%2' 獨佔地}3"
 # "%select{reading|writing}3 variable %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
 HBF61FE4FFCA3: "%select{讀取|寫入}3 變數 %1 需要持有 %0 %select{'%2'|'%2' 獨佔地}3"
 # "%select{reference|backing array for 'std::initializer_list'}2 %select{|subobject of }1member %0 %select{binds to|is}2 a temporary object whose lifetime is shorter than the lifetime of the constructed object"
-H31A36503387B: '%select{參考|std::initializer_list的基礎陣列}2 %select{|子物件的 }1成員%0 %select{綁定到|是}2 寿命短於建構物件的臨時物件'
+H31A36503387B: '%select{參考|std::initializer_list的基礎陣列}2 %select{|子物件的 }1成員 %0 %select{綁定到|是}2 寿命短於建構物件的臨時物件'
 # "%select{reference|backing array for 'std::initializer_list'}2 %select{|subobject of }1member %0 %select{binds to|is}2 a temporary object whose lifetime would be shorter than the lifetime of the constructed object"
-H54C5751F42B3: '%select{參考|std::initializer_list的基礎陣列}2 %select{|子物件的 }1成員%0 %select{綁定到|是}2 寿命會短於建構物件的臨時物件'
+H54C5751F42B3: '%select{參考|std::initializer_list的基礎陣列}2 %select{|子物件的 }1成員 %0 %select{綁定到|是}2 寿命會短於建構物件的臨時物件'
 # '%select{reference|pointer}0 member declared here'
 H8AC5A0A64CFD: '%select{參考|指標}0 成員在此處宣告'
 # '%select{reinterpret_cast|C-style cast}0 from %1 to %2 changes address space of nested pointers'
-HDAB148B74E30: '%select{reinterpret_cast|C型式轉換}0 從%1到%2 改變巢狀指標的地址空間'
+HDAB148B74E30: '%select{reinterpret_cast|C型式轉換}0 從 %1 到 %2 改變巢狀指標的地址空間'
 # '%select{reinterpret_cast|dynamic_cast|%select{this conversion|cast that performs the conversions of a reinterpret_cast}1|cast from %1}0 is not allowed in a constant expression%select{| in C++ standards before C++20||}0'
 H1688ED0E5178: '%select{reinterpret_cast|dynamic_cast|%select{this conversion|cast that performs the conversions of a reinterpret_cast}1|cast from %1}0 不允許在常數運算式中使用%select{|在C++20之前的C++標準中||}0'
 # '%select{remainder|division}0 by zero is undefined'
@@ -1363,7 +1363,7 @@ HB66515AEE2F3: '%select{有符號|無符號}0 _BitInt 的位數大於 %1 的未�
 # "%select{source|destination}2 of '%select{%select{memcpy|wmemcpy}1|%select{memmove|wmemmove}1}0' is %3"
 H752C91AB4DE4: "%select{來源|目標}2 的 '%select{%select{memcpy|wmemcpy}1|%select{memmove|wmemmove}1}0' 是 %3"
 # "%select{statement after '#pragma omp %1' must be a for loop|expected %2 for loops after '#pragma omp %1'%select{|, but found only %4}3}0"
-H5AE78EDFB051: "%select{在'#pragma omp %1'之後的語句必須是for迴圈|期望在'#pragma omp %1'之後有%2個for迴圈%select{|，但僅找到%4}3}0"
+H5AE78EDFB051: "%select{在'#pragma omp %1'之後的語句必須是for迴圈|期望在'#pragma omp %1'之後有 %2 個for迴圈%select{|，但僅找到 %4}3}0"
 # '%select{statement|directive}0 outside teams construct here'
 HCEC20E30EFC9: '%select{語句|指令}0 在這裡的 teams 結構外部'
 # "%select{static data member is predetermined as shared|variable with static storage duration is predetermined as shared|loop iteration variable is predetermined as private|loop iteration variable is predetermined as linear|loop iteration variable is predetermined as lastprivate|constant variable is predetermined as shared|global variable is predetermined as shared|non-shared variable in a task construct is predetermined as firstprivate|variable with automatic storage duration is predetermined as private}0%select{|; perhaps you forget to enclose 'omp %2' directive into a parallel or another task region?}1"
@@ -1407,17 +1407,17 @@ H2FC8E4427754: '%select{模板參數過少|模板參數過多}0 在模板%select
 # '%select{too few|too many}0 template parameters in template template argument'
 HEDDF73011D6C: '%select{模板參數過少|模板參數過多}0 在模板模板參數中'
 # '%select{too many|too few}0 elements in vector %select{initialization|operand}3 (expected %1 elements, have %2)'
-HEB48F48C2E39: '%select{過多|過少}0個元素在向量%select{初始化|運算元}3中（期望%1個，有%2個）'
+HEB48F48C2E39: '%select{過多|過少}0個元素在向量%select{初始化|運算元}3中（期望 %1 個，有 %2 個）'
 # '%select{type tag|argument}0 index %1 is greater than the number of arguments specified'
-H7C0418F179E9: '%select{類型標籤|參數}0索引%1大於指定的參數個數'
+H7C0418F179E9: '%select{類型標籤|參數}0索引 %1 大於指定的參數個數'
 # '%select{typedef|type alias|type alias template}0 redefinition with different types%diff{ ($ vs $)|}1,2'
 H7F72DD3ED811: '%select{typedef|type alias|type alias template}0 重新定義時類型不同%diff{（$與$不同）|}1,2'
 # '%select{uninitialized use occurs|variable is captured by block}0 here'
 H80571A54148A: '%select{未初始化的使用發生於|變數被區塊捕獲}0此處'
 # '%select{unknown|unsupported}0 machine mode %1'
-HB579643BB1CB: '%select{未知|不支援}0機器模式%1'
+HB579643BB1CB: '%select{未知|不支援}0機器模式 %1'
 # '%select{unsafe pointer operation|unsafe pointer arithmetic|unsafe buffer access|function introduces unsafe buffer manipulation|unsafe invocation of %1|field %1 prone to unsafe buffer manipulation}0'
-HD969AD0BDB13: '%select{不安全的指標操作|不安全的指標運算|不安全的緩衝區存取|函數引入不安全的緩衝區操作|對%1的不安全呼叫|成員%1易受不安全緩衝區操作影響}0'
+HD969AD0BDB13: '%select{不安全的指標操作|不安全的指標運算|不安全的緩衝區存取|函數引入不安全的緩衝區操作|對 %1 的不安全呼叫|成員 %1 易受不安全緩衝區操作影響}0'
 # "%select{unsupported|duplicate|unknown}0%select{| CPU| tune CPU}1 '%2' in the '%select{target|target_clones|target_version}3' attribute string;"
 H8412993B41A2: "%select{不支援|重複|未知}0%select{| CPU| 調整後CPU}1 '%2' 在 '%select{目標|目標複製|目標版本}3' 屬性字串中;"
 # "%select{unsupported|duplicate|unknown}0%select{| CPU| tune CPU}1 '%2' in the '%select{target|target_clones|target_version}3' attribute string; '%select{target|target_clones|target_version}3' attribute ignored"
@@ -1429,7 +1429,7 @@ H74FA7B9CE6BC: "%select{型別值|具有基礎型別的枚舉值}2 '%0' 不應�
 # '%select{value|type}0-dependent expression passed as an argument to debug command'
 HF8F02B43BB62: '%select{值|類型}0依賴的運算式被傳遞給除錯命令的引數'
 # '%select{variable|static data member}0 instantiated with function type %1'
-HE6193A7D74C4: '%select{變數|靜態資料成員}0以函式類型%1實體化'
+HE6193A7D74C4: '%select{變數|靜態資料成員}0以函式類型 %1 實體化'
 # '%select{via initialization of|binding reference}0 variable %select{%2 |}1here'
 HB0440A5001E5: '%select{透過初始化|綁定參考}0 變數%select{%2 |}1在此處'
 # "%select{virtual method|function pointer}0 cannot be inferred '%1'"
@@ -1441,13 +1441,13 @@ H917D4EA3DC61: '%select{void函式|void方法|建構子|析構子}1 %0 應不可
 # '%select{wide|Unicode}0 character literals may not contain multiple characters'
 HEBA1B65B6166: '%select{wide|Unicode}0 字元字面值不能包含多個字元'
 # "%select{x86|x86-64}0 'interrupt' attribute only applies to functions that have %select{a 'void' return type|only a pointer parameter optionally followed by an integer parameter|a pointer as the first parameter|a %2 type as the second parameter}1"
-H6EAE552C7EA8: "%select{x86|x86-64}0 'interrupt' 屬性僅適用於返回類型%select{為'void'|具有可選後跟整數參數的指標參數|以指標作為第一個參數|%2類型作為第二個參數}1的函數"
+H6EAE552C7EA8: "%select{x86|x86-64}0 'interrupt' 屬性僅適用於返回類型%select{為 'void'|具有可選後跟整數參數的指標參數|以指標作為第一個參數|%2 類型作為第二個參數}1的函數"
 # "%select{|'%1-%2' }0diagnostics %select{with '%2' severity |}0%select{expected|seen}3 but not %select{seen|expected}3: %4"
 H6E1DC1644300: "%select{|'%1-%2' }0診斷%select{具有'%2'嚴重性 |}0%select{期望|檢測到}3 但未%select{檢測到|期望}3：%4"
 # '%select{|a template declaration|an explicit template specialization|an explicit template instantiation}0 can only %select{|declare|declare|instantiate}0 a single entity'
 HCEE3630F178B: '%select{|模板宣告|明確模板特化|明確模板實體化}0 只能%select{|宣告|宣告|實體化}0 單一實體'
 # "%select{|captured }1%0 parameter marked 'called_once' is never called"
-H5EDD8753404F: "%select{|捕獲的 }1%0 標記為'called_once'的參數從未被調用"
+H5EDD8753404F: "%select{|捕獲的 }1%0 標記為 'called_once' 的參數從未被調用"
 # '%select{|captured }1completion handler is never called'
 H31A1FA39F285: '%select{|被捕獲的 }1完成處理器從未被呼叫'
 # "%select{|change to 'snprintf' for explicit bounds checking | buffer pointer and size may not match|string argument is not guaranteed to be null-terminated|'va_list' is unsafe}0"
@@ -1455,15 +1455,15 @@ H071DEF637982: "%select{|改為使用 'snprintf' 進行明確邊界檢查 |緩�
 # '%select{|direct }0%select{method|property}1 declaration conflicts with previous %select{|direct }2declaration of %select{method|property}1 %3'
 H1D02391D3A58: '%select{|直接 }0%select{方法|屬性}1 宣告與先前%select{|直接 }2宣告的%select{方法|屬性}1 %3 冲突'
 # '%select{|empty }0%select{struct|union}1 has size 0 in C, %select{size 1|non-zero size}2 in C++'
-HEA8D8C4B49F9: '%select{|空的 }0%select{struct|union}1 在C中大小為0，在C++中%select{大小為1|非零大小}2'
+HEA8D8C4B49F9: '%select{|空的 }0%select{struct|union}1 在C中大小為 0，在C++中%select{大小為 1|非零大小}2'
 # "%select{|implicit }0use of 'this' pointer is only allowed within the evaluation of a call to a 'constexpr' member function"
-HE1347141F3D2: "%select{|隱式 }0使用'this'指標僅允許在評估'constexpr'成員函數調用時使用"
+HE1347141F3D2: "%select{|隱式 }0使用 'this' 指標僅允許在評估 'constexpr' 成員函數調用時使用"
 # '%select{|implicitly }1declared %select{private|protected}0 here'
 H8D12655CD9C3: '%select{|隱式宣告的}%select{private|protected}0 在這裡'
 # "%select{|incremented }0enumerator value which exceeds the range of 'int' is a C23 extension (%1 is too %select{small|large}2)"
-H7317CEFA834D: "%select{|遞增的 }0枚舉值超出'int'的範圍是C23擴展（%1 過%select{小|大}2）"
+H7317CEFA834D: "%select{|遞增的 }0枚舉值超出 'int' 的範圍是C23擴展（%1 過%select{小|大}2）"
 # "%select{|incremented }0enumerator value which exceeds the range of 'int' is incompatible with C standards before C23 (%1 is too %select{small|large}2)"
-H02CD4F5E389B: "%select{|遞增的 }0枚舉值超出'int'的範圍與C23之前的標準不相容（%1 過%select{小|大}2）"
+H02CD4F5E389B: "%select{|遞增的 }0枚舉值超出 'int' 的範圍與C23之前的標準不相容（%1 過%select{小|大}2）"
 # '%select{|member|base class}0 %1 declared here'
 H83331E20A1A3: '%select{|成員|基類}0 %1 此處宣告'
 # '%select{|member}0 using declaration %1 instantiates to an empty pack'
@@ -1667,7 +1667,7 @@ H67346CC37DF8: "'%0' 被多次包含，額外包含位置在此處"
 # "'%0' included multiple times, additional include site in header from module '%1'"
 HC2226976DFB3: "'%0' 被多次包含，額外包含位置在模組'%1'的標頭檔中"
 # "'%0' invalid for input of type %1"
-H0F254F5D0DEC: "'%0' 無法轉換為類型%1的輸入"
+H0F254F5D0DEC: "'%0' 無法轉換為類型 %1 的輸入"
 # "'%0' is a C11 extension"
 HACD9CD0EB9B2: "'%0' 是C11擴充"
 # "'%0' is a C2y extension"
@@ -1725,11 +1725,11 @@ HCFDB7E16EAB8: "'%0' 關鍵字與C++98不相容"
 # "'%0' keyword not permitted with interface types"
 HFAA4A308281C: "'%0' 無法用於介面類型"
 # "'%0' may overflow; destination buffer in argument %1 has size %2, but the corresponding specifier may require size %3"
-H45D6462C38BC: "'%0' 可能溢位；第%1個參數的目標緩衝區大小為%2，但對應格式說明可能需要%3大小"
+H45D6462C38BC: "'%0' 可能溢位；第 %1 個參數的目標緩衝區大小為 %2，但對應格式說明可能需要 %3 大小"
 # "'%0' not supported, please use -iquote instead"
 HD03640F49183: "'%0' 未支援，請改用 -iquote"
 # "'%0' only applies to %select{function|pointer|Objective-C object or block pointer}1 types; type here is %2"
-H76B771A1DA3E: "'%0' 只適用於%select{函數|指標|Objective-C物件或區塊指標}1類型；目前類型為%2"
+H76B771A1DA3E: "'%0' 只適用於%select{函數|指標|Objective-C物件或區塊指標}1類型；目前類型為 %2"
 # "'%0' only applies to medium and large code models"
 H2B43B16BADDB: "'%0' 選項僅適用於中等與大型程式碼模型"
 # "'%0' option requires target HLSL Version >= 2018%select{| and shader model >= 6.2}1, but HLSL Version is '%2'%select{| and shader model is '%3'}1"
@@ -1737,7 +1737,7 @@ H73FD169C1664: "'%0' 選項需要HLSL版本≥2018%select{|且著色器模型≥
 # "'%0' parameter can only be used with swiftcall%select{ or swiftasynccall|}1 calling convention%select{|s}1"
 H7F6C0A7A9011: "'%0' 參數只能與swiftcall%select{或swiftasynccall|}1呼叫約定%select{搭配使用|}1"
 # "'%0' parameter must have pointer%select{| to unqualified pointer}1 type; type here is %2"
-HA49C073BB7A8: "'%0' 參數必須是%select{未限定指標|指標}1類型；目前類型為%2"
+HA49C073BB7A8: "'%0' 參數必須是%select{未限定指標|指標}1類型；目前類型為 %2"
 # "'%0' previously encountered here"
 HC082D10D967F: "'%0' 此處先前已出現"
 # "'%0' qualifier is not allowed on a constructor"
@@ -1749,15 +1749,15 @@ HC82C66448381: "'%0' 限定詞不能出現在虛函數指定符'%1'之後"
 # "'%0' qualifier may not be applied to a reference"
 H39DF4A724F57: "'%0' 限定詞不能應用在參考類型上"
 # "'%0' qualifier on function type %1 has no effect"
-HCA4F5C288E32: "函式類型%1上的'%0' 限定詞無效"
+HCA4F5C288E32: "函式類型 %1 上的'%0' 限定詞無效"
 # "'%0' qualifier on function type %1 has no effect and is a Clang extension"
-HA82B1E90695B: "函式類型%1上的'%0' 限定詞無效（此為Clang擴充功能）"
+HA82B1E90695B: "函式類型 %1 上的'%0' 限定詞無效（此為Clang擴充功能）"
 # "'%0' qualifier on omitted return type %1 has no effect"
-H226C520C0A5C: "省略的返回類型%1上的'%0' 限定詞無效"
+H226C520C0A5C: "省略的返回類型 %1 上的'%0' 限定詞無效"
 # "'%0' qualifier on reference type %1 has no effect"
-H9D5F7EA85F79: "參考類型%1上的'%0' 限定詞無效"
+H9D5F7EA85F79: "參考類型 %1 上的'%0' 限定詞無效"
 # "'%0' qualifier%s1 on base class type %2 %plural{1:has|:have}1 no effect"
-HB4BF74C2E9A3: "基底類別類型%2 上的'%0' 限定詞%s1%plural{1:無效|:無效}1"
+HB4BF74C2E9A3: "基底類別類型 %2 上的'%0' 限定詞%s1%plural{1:無效|:無效}1"
 # "'%0' region encountered before requires directive with '%1' clause"
 HAC48A5EE380D: "'%0' 區塊在具有 '%1' 子句的requires指令之前出現"
 # "'%0' required by '%1'"
@@ -1765,7 +1765,7 @@ H149191A7D780: "'%0' 被'%1'所要求"
 # "'%0' required for precompiled header not found"
 HBDA853057C16: "所需的'%0' 預編譯標頭未找到"
 # "'%0' size argument is too large; destination buffer has size %1, but size argument is %2"
-H1B04445BBECB: "'%0' 長度參數過大；目標緩衝區大小為%1，但指定長度為%2"
+H1B04445BBECB: "'%0' 長度參數過大；目標緩衝區大小為 %1，但指定長度為 %2"
 # "'%0' specifier is not allowed outside a class definition"
 H496E8612120E: "'%0' 限定詞不能出現在類別定義之外"
 # "'%0' statement cannot be used in OpenMP for loop"
@@ -1829,7 +1829,7 @@ H9A9CB5F0CECC: "'%select{\\|@}0%1'指令用於未附加至函數或方法宣告�
 # "'%select{\\|@}0%select{classdesign|coclass|dependency|helper|helperclass|helps|instancesize|ownership|performance|security|superclass}1' command should not be used in a comment attached to a non-container declaration"
 H63CA64568B3F: "'%select{\\|@}0%select{classdesign|coclass|dependency|helper|helperclass|helps|instancesize|ownership|performance|security|superclass}1'指令不應用於附加至非容器宣告的註解中"
 # "'%select{\\|@}0%select{class|interface|protocol|struct|union}1' command should not be used in a comment attached to a non-%select{class|interface|protocol|struct|union}2 declaration"
-H2B2D23C85C31: "'%select{\\|@}0%select{class|interface|protocol|struct|union}1'指令不應用於附加至非%select{class|interface|protocol|struct|union}2宣告的註解中"
+H2B2D23C85C31: "'%select{\\|@}0%select{class|interface|protocol|struct|union}1'指令不應用於附加至非 %select{class|interface|protocol|struct|union}2 宣告的註解中"
 # "'%select{\\|@}0%select{function|functiongroup|method|methodgroup|callback}1' command should be used in a comment attached to %select{a function|a function|an Objective-C method|an Objective-C method|a pointer to function}2 declaration"
 H30965075CCD3: "'%select{\\|@}0%select{function|functiongroup|method|methodgroup|callback}1'指令應用於附加至%select{函數|函數|Objective-C方法|Objective-C方法|函數指標}2宣告的註解中"
 # "'%select{\\|@}0param' command used in a comment that is not attached to a function declaration"
@@ -1837,7 +1837,7 @@ HA6D99227D713: "'%select{\\|@}0param'指令用於未附加至函數宣告的註�
 # "'%select{\\|@}0tparam' command used in a comment that is not attached to a template declaration"
 H78D96F6B0A65: "'%select{\\|@}0tparam'指令用於未附加至範型宣告的註解中"
 # "'%select{auto|decltype(auto)}0' in return type deduced as %1 here but deduced as %2 in earlier return statement"
-HDFEF08FDDF8E: "'%select{auto|decltype(auto)}0'在回傳類型中%1在此處被推論，但與先前的return語句中推論為%2產生衝突"
+HDFEF08FDDF8E: "'%select{auto|decltype(auto)}0'在回傳類型中 %1 在此處被推論，但與先前的return語句中推論為 %2 產生衝突"
 # "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' argument cannot refer to a union member"
 HF50BCD9CECE6: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0'參數不能引用共用體成員"
 # "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' argument must be a simple declaration reference"
@@ -1845,17 +1845,17 @@ HF6AC15305460: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null
 # "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' cannot be applied to a union member"
 H01022C27C2BB: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0'不能應用於共用體成員"
 # "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' only applies to pointers%select{ or C99 flexible array members|||}0%select{|; did you mean to use 'counted_by'?}1"
-H077E0A5BF4C4: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0'只能用於指標%select{或C99彈性陣列成員|||}0%select{; 是否應使用'counted_by'?|}1"
+H077E0A5BF4C4: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0'只能用於指標%select{或C99彈性陣列成員|||}0%select{; 是否應使用 'counted_by'?|}1"
 # "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' requires a non-boolean integer type argument"
 H69D52A4DAF87: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0'需要非布林整數類型參數"
 # "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}1' field %0 isn't within the same struct as the annotated %select{pointer|flexible array}2"
-HBD3F5637D173: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}1'標記的%0欄位與被註解的%select{指標|彈性陣列}2不在同一結構體中"
+HBD3F5637D173: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}1'標記的 %0 欄位與被註解的%select{指標|彈性陣列}2不在同一結構體中"
 # "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}4' %select{cannot|should not}3 be applied to %select{a pointer with pointee|an array with element}0 of unknown size because %1 is %select{an incomplete type|a sizeless type|a function type|a struct type with a flexible array member%select{|. This will be an error in a future compiler version}3}2"
 HEFA740A9E276: "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}4' %select{不能|不應}3 應用於 %select{指標所指向的|陣列元素}0 無法確定大小的類型，因為 %1 是 %select{不完整類型|無大小類型|函數類型|包含可調節長度陣列的結構類型%select{|。此處將在未來版本編譯器中成為錯誤}3}2"
 # "'%select{if|switch}0' initialization statements are a C++17 extension"
 HBFF569602D2E: "'%select{if|switch}0' 初始化語句是 C++17 擴充"
 # "'%select{make_unsigned|make_signed}0' is only compatible with non-%select{bool|_BitInt(1)}1 integers and enum types, but was given %2%select{| whose underlying type is %4}3"
-H89BC3FB5059E: "'%select{make_unsigned|make_signed}0' 只與非%select{bool|_BitInt(1)}1 整數及列舉類型兼容，但給定 %2%select{| 其底層類型是 %4}3"
+H89BC3FB5059E: "'%select{make_unsigned|make_signed}0' 只與非 %select{bool|_BitInt(1)}1 整數及列舉類型兼容，但給定 %2%select{| 其底層類型是 %4}3"
 # "'%select{memcpy|wmemcpy}0' between overlapping memory regions"
 HF4936F4E6501: "'%select{memcpy|wmemcpy}0' 在重疊記憶體區域之間複製"
 # "'%select{pure|const}0' attribute on function returning 'void'; attribute ignored"
@@ -1987,13 +1987,13 @@ H202E8786A308: '‘__clang_arm_mve_strict_polymorphism’屬性只能套用到MV
 # "'__declspec' attributes are not enabled; use '-fdeclspec' or '-fms-extensions' to enable support for __declspec attributes"
 H465DF3E43560: '‘__declspec’屬性未啟用；使用‘-fdeclspec’或‘-fms-extensions’來啟用對__declspec屬性的支援'
 # "'__declspec(dllexport)' cannot be applied to more than one default constructor in %0"
-HB67031034443: '‘__declspec(dllexport)’無法套用到%0的超過一個預設建構函數'
+HB67031034443: '‘__declspec(dllexport)’無法套用到 %0 的超過一個預設建構函數'
 # "'__declspec(thread)' applied to variable that already has a thread-local storage specifier"
 HFE6629E646D9: '將‘__declspec(thread)’套用到已經有線程局部存儲指定符的變數'
 # "'__funcref' attribute can only be applied to a function pointer type"
 H5101424932DE: '‘__funcref’屬性只能套用到函數指標類型'
 # "'__kindof' specifier cannot be applied to non-object type %0"
-HBB66D4C1FC38: '‘__kindof’指定符無法套用到非物件類型%0'
+HBB66D4C1FC38: '‘__kindof’指定符無法套用到非物件類型 %0'
 # "'__kindof' type specifier must precede the declarator"
 H111C48694838: '必須在宣告符之前指定__kindof類型'
 # "'__leave' statement not in __try block"
@@ -2241,7 +2241,7 @@ H880BB7F53078: "在根據模組地圖建構模組時發現 'module' 宣告"
 # "'module;' introducing a global module fragment can appear only at the start of the translation unit"
 H617DC2BE71CE: "引進全域模組片段的 'module;' 只能出現在翻譯單位的開頭"
 # "'musttail' attribute for this call is impossible because %select{long calls cannot be tail called on PPC|indirect calls cannot be tail called on PPC|external calls cannot be tail called on PPC}0"
-H14240DA28AAD: "'musttail' 屬性在此呼叫中無法使用，因為%select{PPC架構上無法對長呼叫進行tail called|PPC架構上無法對間接呼叫進行tail called|PPC架構上無法對外部呼叫進行tail called}0"
+H14240DA28AAD: "'musttail' 屬性在此呼叫中無法使用，因為 %select{PPC架構上無法對長呼叫進行tail called|PPC架構上無法對間接呼叫進行tail called|PPC架構上無法對外部呼叫進行tail called}0"
 # "'musttail' attribute is not supported on AIX"
 H92717FE13CEF: "'musttail' 屬性在 AIX 上不受支援"
 # "'mutable' and 'const' cannot be mixed"
@@ -2261,7 +2261,7 @@ H01CEEA4215DD: "'new' 不能分配一個不具顯式所有權的 %0 類型陣列
 # "'new' cannot allocate object of variably modified type %0"
 HB68377C1CB34: "'new' 不能分配變數長度類型 %0 的物件"
 # "'new' cannot allocate objects of type %0 in address space '%1'"
-H8F2EE8209986: "'new' 無法分配地址空間'%1'中的類型%0"
+H8F2EE8209986: "'new' 無法分配地址空間'%1'中的類型 %0"
 # "'new' expression with placement arguments refers to non-placement 'operator delete'"
 H9A938FDFCB36: '帶有置位參數的new運算式引用了非置位的operator delete'
 # "'nocf_check' attribute ignored; use -fcf-protection to enable the attribute"
@@ -2271,11 +2271,11 @@ H265BDBEEC1EC: "'noderef' 只能用於陣列或指標類型"
 # "'noexcept' can only be used in a compound requirement (with '{' '}' around the expression)"
 H88CA64B4E3F6: "'noexcept' 只能在複合需求中使用（需用{}包圍表達式）"
 # "'nonmonotonic' modifier can only be specified with 'dynamic' or 'guided' schedule kind"
-H60F2BCD19874: "'nonmonotonic' 修飾符只能與'dynamic'或'guided'類型的schedule一起使用"
+H60F2BCD19874: "'nonmonotonic' 修飾符只能與 'dynamic' 或 'guided' 類型的schedule一起使用"
 # "'nonnull' attribute applied to function with no pointer arguments"
 H0D4CBB499E30: "'nonnull' 屬性應用於無指標參數的函數"
 # "'nonnull' attribute when used on parameters takes no arguments"
-H8544A5398585: "在參數上使用的'nonnull' 屬性不需要參數"
+H8544A5398585: "在參數上使用的 'nonnull' 屬性不需要參數"
 # "'nothrow' attribute conflicts with exception specification; attribute ignored"
 HA43C7748DBD1: "'nothrow' 屬性與例外規格衝突；屬性被忽略"
 # "'nowait' clause is here"
@@ -2287,7 +2287,7 @@ HA3F1CF3D3055: "'nullptr' 與C++98不相容"
 # "'objc_bridge(id)' is only allowed on structs and typedefs of void pointers"
 H19339C3149E3: "'objc_bridge(id)' 只能用於void指標的結構或typedef"
 # "'objc_class_stub' attribute cannot be specified on a class that does not have the 'objc_subclassing_restricted' attribute"
-H131E98846FD9: "'objc_class_stub' 屬性只能用於具有'objc_subclassing_restricted' 屬性的類別"
+H131E98846FD9: "'objc_class_stub' 屬性只能用於具有 'objc_subclassing_restricted' 屬性的類別"
 # "'objc_designated_initializer' attribute only applies to init methods of interface or class extension declarations"
 H0C4330D28BB6: "'objc_designated_initializer' 屬性僅適用於界面或類別擴展宣告的init方法"
 # "'objc_direct' attribute cannot be applied to %select{methods|properties}0 declared in an Objective-C protocol"
@@ -2333,81 +2333,81 @@ H4981CB6A6643: "'reduction' 子句不允許與 '#pragma omp loop bind(teams)' �
 # "'reduction' clause with 'inscan' modifier is used here"
 HE04EBCC11985: "'reduction' 子句在此處使用帶有 'inscan' 修飾符"
 # "'reduction' clause with 'task' modifier allowed only on non-simd parallel or worksharing constructs"
-HD0FEE7231060: "'reduction'子句加上'task'修飾詞只能用在非simd平行或工作共享結構中"
+HD0FEE7231060: "'reduction' 子句加上 'task' 修飾詞只能用在非simd平行或工作共享結構中"
 # "'register' storage class specifier is deprecated and incompatible with C++17"
-HDBC08F071224: "'register'存儲類別指定詞已棄用且與C++17不相容"
+HDBC08F071224: "'register' 存儲類別指定詞已棄用且與C++17不相容"
 # "'register' storage specifier on @catch parameter will be ignored"
-H4232960B8CCE: "@catch參數上的'register'存儲指定詞將被忽略"
+H4232960B8CCE: "@catch參數上的 'register' 存儲指定詞將被忽略"
 # "'regparm' is not valid on this platform"
-H1E534F14C852: "'regparm'在此平台上無效"
+H1E534F14C852: "'regparm' 在此平台上無效"
 # "'regparm' parameter must be between 0 and %0 inclusive"
-H63349C70781C: "'regparm'參數必須介於0與%0之間"
+H63349C70781C: "'regparm' 參數必須介於 0 與 %0 之間"
 # "'reinterpret_cast' %select{from|to}3 class %0 %select{to|from}3 its %select{virtual base|base at non-zero offset}2 %1 behaves differently from 'static_cast'"
-HF87527FE7FBB: "'reinterpret_cast' %select{從|到}3類%0 %select{到|從}3其%select{虛基|非零偏移基類}2 %1的行為與'static_cast'不同"
+HF87527FE7FBB: "'reinterpret_cast' %select{從|到}3類 %0 %select{到|從}3其%select{虛基|非零偏移基類}2 %1 的行為與 'static_cast' 不同"
 # "'require_constant_initialization' attribute added after initialization of variable"
-HCCF005312D01: "在變數初始化後新增'require_constant_initialization'屬性"
+HCCF005312D01: "在變數初始化後新增 'require_constant_initialization' 屬性"
 # "'restrict' qualifier on an array of pointers is a C23 extension"
-H831A2BF01322: "指標陣列上的'restrict'限定詞是C23擴展"
+H831A2BF01322: "指標陣列上的 'restrict' 限定詞是C23擴展"
 # "'restrict' qualifier on an array of pointers is incompatible with C standards before C23"
-H7AB582A89AF4: "指標陣列上的'restrict'限定詞與C23前的標準不相容"
+H7AB582A89AF4: "指標陣列上的 'restrict' 限定詞與C23前的標準不相容"
 # "'return' will never be executed"
-HF9D8B2478204: "'return'將永遠不會執行"
+HF9D8B2478204: "'return' 將永遠不會執行"
 # "'sealed' keyword is a Microsoft extension"
-H2371564F3064: "'sealed'關鍵字是Microsoft擴展"
+H2371564F3064: "'sealed' 關鍵字是Microsoft擴展"
 # "'selectany' can only be applied to data items with external linkage"
-H0D95115281D5: "'selectany'只能套用在具有外部連結的資料項目"
+H0D95115281D5: "'selectany' 只能套用在具有外部連結的資料項目"
 # "'sentinel' attribute only supported for variadic %select{functions|blocks}0"
-H0C7CDE5CC83E: "'sentinel'屬性僅支援可變參數%select{函數|區塊}0"
+H0C7CDE5CC83E: "'sentinel' 屬性僅支援可變參數%select{函數|區塊}0"
 # "'sentinel' attribute requires named arguments"
-HB4DB8DB54C63: "'sentinel'屬性需要命名參數"
+HB4DB8DB54C63: "'sentinel' 屬性需要命名參數"
 # "'sentinel' parameter 1 less than zero"
-HE854964454A6: "'sentinel'參數1小於零"
+HE854964454A6: "'sentinel' 參數 1 小於零"
 # "'sentinel' parameter 2 not 0 or 1"
-H99541E948450: "'sentinel'參數2不是0或1"
+H99541E948450: "'sentinel' 參數 2 不是 0 或 1"
 # "'size' argument to bzero is '0'"
-H50A840FAEA15: "bzero的'size'參數為'0'"
+H50A840FAEA15: "bzero的 'size' 參數為 '0'"
 # "'size_t' suffix for literals is a C++23 extension"
-HE55B1E186F37: "'size_t'字尾符號是C++23擴展"
+HE55B1E186F37: "'size_t' 字尾符號是C++23擴展"
 # "'size_t' suffix for literals is a C++23 feature"
-HFE4E8B889F8C: "'size_t'字尾符號是C++23功能"
+HFE4E8B889F8C: "'size_t' 字尾符號是C++23功能"
 # "'size_t' suffix for literals is incompatible with C++ standards before C++23"
-H01C26A9D5D7B: "'size_t'字面值的後綴與C++23之前的標準不相容"
+H01C26A9D5D7B: "'size_t' 字面值的後綴與C++23之前的標準不相容"
 # "'static' can only be specified inside the class definition"
-HC2C3574A2AC5: "'static'只能在類定義內部指定"
+HC2C3574A2AC5: "'static' 只能在類定義內部指定"
 # "'static' function %0 declared in header file should be declared 'static inline'"
-HAC6B8325923D: "在標頭檔中宣告的靜態函數%0應宣告為'static inline'"
+HAC6B8325923D: "在標頭檔中宣告的靜態函數 %0 應宣告為'static inline'"
 # "'static' may not be used with an unspecified variable length array size"
-H8C886B8B17D3: "未指定的可變長度陣列大小不能與'static'一起使用"
+H8C886B8B17D3: "未指定的可變長度陣列大小不能與 'static' 一起使用"
 # "'static' may not be used without an array size"
-H3CD973765C05: "使用'static'時必須指定陣列大小"
+H3CD973765C05: "使用 'static' 時必須指定陣列大小"
 # "'static' member function %0 overrides a virtual function in a base class"
-H917973A36E2C: '靜態成員函數%0覆寫基類中的虛函數'
+H917973A36E2C: '靜態成員函數 %0 覆寫基類中的虛函數'
 # "'static_assert' declarations are incompatible with C++98"
-HEBCFD6945359: "'static_assert'宣告與C++98不相容"
+HEBCFD6945359: "'static_assert' 宣告與C++98不相容"
 # "'static_assert' with a user-generated message is a C++26 extension"
-HFCA41F0C6554: "帶有使用者產生的訊息的'static_assert'是C++26的擴充功能"
+HFCA41F0C6554: "帶有使用者產生的訊息的 'static_assert' 是C++26的擴充功能"
 # "'static_assert' with a user-generated message is incompatible with C++ standards before C++26"
-H71F257CCE8FF: "帶有使用者產生的訊息的'static_assert'與C++26之前的標準不相容"
+H71F257CCE8FF: "帶有使用者產生的訊息的 'static_assert' 與C++26之前的標準不相容"
 # "'static_assert' with no message is a C++17 extension"
-H89070CD2F991: "無訊息的'static_assert'是C++17的擴充功能"
+H89070CD2F991: "無訊息的 'static_assert' 是C++17的擴充功能"
 # "'static_assert' with no message is incompatible with C++ standards before C++17"
-HFE8F37E6AE5C: "無訊息的'static_assert'與C++17之前的標準不相容"
+HFE8F37E6AE5C: "無訊息的 'static_assert' 與C++17之前的標準不相容"
 # "'std::allocator<...>::deallocate' used to delete a null pointer"
 HF2B279909DBC: "使用'std::allocator<...>::deallocate'刪除空指標"
 # "'std::source_location::__impl' must be standard-layout and have only two 'const char *' fields '_M_file_name' and '_M_function_name', and two integral fields '_M_line' and '_M_column'"
-HCA27D3915F0B: "'std::source_location::__impl'必須是標準佈局類別，且僅有兩個'const char *'型別的欄位'_M_file_name'和'_M_function_name'，以及兩個整數型別的欄位'_M_line'和'_M_column'"
+HCA27D3915F0B: "'std::source_location::__impl'必須是標準佈局類別，且僅有兩個'const char *'型別的欄位 '_M_file_name' 和 '_M_function_name'，以及兩個整數型別的欄位 '_M_line' 和 '_M_column'"
 # "'std::source_location::__impl' was not found; it must be defined before '__builtin_source_location' is called"
-HD0F806FB73A8: "未找到'std::source_location::__impl'；它必須在呼叫'__builtin_source_location'之前被定義"
+HD0F806FB73A8: "未找到'std::source_location::__impl'；它必須在呼叫 '__builtin_source_location' 之前被定義"
 # "'super' is only valid in a method body"
-HB06D73D4C0E7: "'super'只能在方法主體中使用"
+HB06D73D4C0E7: "'super' 只能在方法主體中使用"
 # "'swift_async' completion handler parameter must have block type returning 'void', type here is %0"
-H9874890FB098: "'swift_async'完成處理器參數必須是回傳'type'的區塊類型，這裡的類型是%0"
+H9874890FB098: "'swift_async' 完成處理器參數必須是回傳 'type' 的區塊類型，這裡的類型是 %0"
 # "'swift_error_result' parameter must follow 'swift_context' parameter"
-HFA5F4F66F83B: "'swift_error_result'參數必須跟在'swift_context'參數之後"
+HFA5F4F66F83B: "'swift_error_result' 參數必須跟在 'swift_context' 參數之後"
 # "'swift_indirect_result' parameters must be first parameters of function"
-H624EF03C7676: "'swift_indirect_result'參數必須是函數的第一個參數"
+H624EF03C7676: "'swift_indirect_result' 參數必須是函數的第一個參數"
 # "'switch' missing 'default' label"
-H855B85E209CE: "'switch'缺少'default'標籤"
+H855B85E209CE: "'switch' 缺少 'default' 標籤"
 # "'sycl_kernel' attribute only applies to a function template with at least two template parameters"
 H5AFFA7408711: "'sycl_kernel' 屬性只能套用在具有至少兩個模板參數的函數模板上"
 # "'sycl_kernel_entry_point' attribute cannot be added to a function after the function is defined"
@@ -2441,7 +2441,7 @@ H3FF5BAF37ECE: "在此處顯式專門化的類別 %0 已宣告，不需要 'temp
 # "'this' argument to member function %0 has type %1, but function is not marked %select{const|restrict|const or restrict|volatile|const or volatile|volatile or restrict|const, volatile, or restrict}2"
 HB5D291C13072: "成員函數 %0 的 'this' 參數類型為 %1，但該函數未標示 %select{const|restrict|const 或 restrict|volatile|const 或 volatile|volatile 或 restrict|const、volatile 或 restrict}2"
 # "'this' argument to member function %0 is an %select{lvalue|rvalue}1, but function has %select{non-const lvalue|rvalue}2 ref-qualifier"
-H0AF4BFFD004C: "成員函數 %0 的 'this' 參數是%select{lvalue|rvalue}1，但函數具有%select{非 const lvalue|rvalue}2 型別限定符"
+H0AF4BFFD004C: "成員函數 %0 的 'this' 參數是 %select{lvalue|rvalue}1，但函數具有%select{非 const lvalue|rvalue}2 型別限定符"
 # "'this' cannot be %select{implicitly |}0captured in this context"
 H0697D44E3441: "'this' 在此語境中無法%select{隱式 |}0被捕獲"
 # "'this' cannot be captured by reference"
@@ -2487,7 +2487,7 @@ H7AC0FC921988: "在捕獲語句中不能使用 '%va_start'"
 # "'va_start' cannot be used outside a function"
 HFCBDF5268E7D: "'va_start' 只能在函數內部使用"
 # "'va_start' used in %select{System V|Win64}0 ABI function"
-HCA2FE8C64692: "'va_start' 在%select{System V|Win64}0 ABI 函數中使用"
+HCA2FE8C64692: "'va_start' 在 %select{System V|Win64}0 ABI 函數中使用"
 # "'va_start' used in function with fixed args"
 HDCEB40407EDC: "'va_start' 在固定參數函數中使用"
 # "'vec_step' requires built-in scalar or vector type, %0 invalid"
@@ -2717,11 +2717,11 @@ H5EABB33684C4: '<安全工具引數>...'
 # '<second file>'
 H59A18696A728: '<第二個檔案>'
 # '<source0> [... <sourceN>]'
-H4D671F64A81C: '<來源0> [... <來源N>]'
+H4D671F64A81C: '<來源 0> [... <來源N>]'
 # '<source>'
 HE6634DF59D09: '<來源>'
 # "<start line>:<end line> - format a range of\nlines (both 1-based).\nMultiple ranges can be formatted by specifying\nseveral -lines arguments.\nCan't be used with -offset and -length.\nCan only be used with one input file."
-HDEA3B9BD2A49: '<起始列>:<結束列> - 格式化一列範圍的列（兩者均以1為起始）。\n可指定多個 -lines 參數來格式化多個區間。\n不能與 -offset 和 -length 一同使用。\n只能用於單一輸入檔案。'
+HDEA3B9BD2A49: '<起始列>:<結束列> - 格式化一列範圍的列（兩者均以 1 為起始）。\n可指定多個 -lines 參數來格式化多個區間。\n不能與 -offset 和 -length 一同使用。\n只能用於單一輸入檔案。'
 # '<symbol-file>'
 H6E5CDBA6FB29: '<符號檔>'
 # '<test profile file>'
@@ -2735,9 +2735,9 @@ HCEE927C66E78: '<權重>,<檔名>'
 # '<xray fdr mode log>'
 H4907FD73C66B: '<XRay FDR 模式紀錄檔>'
 # '<xray log file 1>'
-HB4D281AAED36: '<XRay 紀錄檔1>'
+HB4D281AAED36: '<XRay 紀錄檔 1>'
 # '<xray log file 2>'
-H1C142C095FCF: '<XRay 紀錄檔2>'
+H1C142C095FCF: '<XRay 紀錄檔 2>'
 # '<xray log file>'
 HE9A7E93A5C35: '<XRay 紀錄檔>'
 # '<xray trace>'
@@ -2891,13 +2891,13 @@ H104573A3D1B6: '每個迴圈維度的切割大小，填入 --polly-default-tile-
 # 'A tile size for each loop dimension, filled with --polly-register-tile-size'
 H8DEB87E7711B: '每個迴圈維度的切割大小，填入 --polly-register-tile-size'
 # 'A tool to bundle several input files of the specified type <type> \nreferring to the same source file but different targets into a single \none. The resulting file can also be unbundled into different files by \nthis tool if -unbundle is provided.\n'
-HD409DEDBF7C5: '將同一來源檔案但不同目標的多個輸入檔案<type>捆绑成單一檔案的工具。\n產生的檔案也可透過此工具加上 -unbundle 參數解捆為不同檔案。\n'
+HD409DEDBF7C5: '將同一來源檔案但不同目標的多個輸入檔案 <type> 捆绑成單一檔案的工具。\n產生的檔案也可透過此工具加上 -unbundle 參數解捆為不同檔案。\n'
 # 'A tool to detect the presence of AMDGPU devices on the system. \n\nThe tool will output each detected GPU architecture separated by a\nnewline character. If multiple GPUs of the same architecture are found\na string will be printed for each\n'
 H8EA7CFE7591E: '用於檢測系統上存在的 AMDGPU 裝置的工具。\n\n此工具會輸出每個檢測到的 GPU 架構，以換行符分隔。若發現相同架構的多個 GPU，會為每個裝置輸出字串。\n'
 # 'A tool to detect the presence of NVIDIA devices on the system. \n\nThe tool will output each detected GPU architecture separated by a\nnewline character. If multiple GPUs of the same architecture are found\na string will be printed for each\n'
 H813C62D59D1D: '用於檢測系統上存在的 NVIDIA 裝置的工具。\n\n此工具會輸出每個檢測到的 GPU 架構，以換行符分隔。若發現相同架構的多個 GPU，會為每個裝置輸出字串。\n'
 # 'A tool to format C/C++/Java/JavaScript/JSON/Objective-C/Protobuf/C# code.\n\nIf no arguments are specified, it formats the code from standard input\nand writes the result to the standard output.\nIf <file>s are given, it reformats the files. If -i is specified\ntogether with <file>s, the files are edited in-place. Otherwise, the\nresult is written to the standard output.\n'
-HBD33E3D62435: '用於格式化 C/C++/Java/JavaScript/JSON/Objective-C/Protobuf/C# 程式碼的工具。\n\n若未指定參數，會從標準輸入讀取程式碼並輸出至標準輸出。\n若指定<file>，則重新格式化這些檔案。若同時指定 -i 和<file>，則直接修改原檔；否則輸出至標準輸出。\n'
+HBD33E3D62435: '用於格式化 C/C++/Java/JavaScript/JSON/Objective-C/Protobuf/C# 程式碼的工具。\n\n若未指定參數，會從標準輸入讀取程式碼並輸出至標準輸出。\n若指定 <file>，則重新格式化這些檔案。若同時指定 -i 和 <file>，則直接修改原檔；否則輸出至標準輸出。\n'
 # 'A tool to generate an optimization report from YAML optimization record files.\n'
 HACA86A981224: '用於從 YAML 優化記錄檔生成優化報告的工具。\n'
 # 'A utility for bundling several object files into a single binary.\nThe output binary can then be embedded into the host section table\nto create a fatbinary containing offloading code.\n'
@@ -3217,11 +3217,11 @@ H4E8397371575: '將目錄加入ObjC++語言SYSTEM包含路徑搜索目錄'
 # 'Add directory to the end of the list of include search paths'
 HA9C01D5A6394: '將目錄加入包含路徑搜索目錄列表末端'
 # 'Add directory to the internal system include search path with implicit extern "C" semantics; these are assumed to not be user-provided and are used to model system and standard headers\' paths.'
-HA6F738C6C497: '將目錄加入內部系統包含路徑搜索目錄，並隱含extern "C"語意；這些目錄假設非使用者提供，用於模擬系統與標準標頭路徑'
+HA6F738C6C497: '將目錄加入內部系統包含路徑搜索目錄，並隱含extern "C" 語意；這些目錄假設非使用者提供，用於模擬系統與標準標頭路徑'
 # "Add directory to the internal system include search path; these are assumed to not be user-provided and are used to model system and standard headers' paths."
 H76AF34D02BE9: '將目錄加入內部系統包含路徑搜索目錄；這些目錄假設非使用者提供，用於模擬系統與標準標頭路徑'
 # 'Add dirs in env var <var> to include search path with warnings suppressed'
-HFB17BE810349: '將環境變數<var>中的目錄加入包含路徑搜索目錄並抑制警告'
+HFB17BE810349: '將環境變數 <var> 中的目錄加入包含路徑搜索目錄並抑制警告'
 # 'Add extra TOC register dependencies'
 HB5EA8815333D: '新增額外的TOC寄存器依賴關係'
 # 'Add informational comments to the .ll file'
@@ -3401,13 +3401,13 @@ HD5F8D2C37C5D: '-format 的別名'
 # 'Align ARM NEON spills in prolog and epilog'
 HA6EB49748CD3: '在函數的前序和後序對齊ARM NEON的spills'
 # 'Align branches within 32-byte boundaries to mitigate the performance impact of the Intel JCC erratum.'
-H5A28F46326DE: '在32字節邊界內對齊分支以緩解Intel JCC 處理缺陷的性能影響。'
+H5A28F46326DE: '在 32 字節邊界內對齊分支以緩解Intel JCC 處理缺陷的性能影響。'
 # 'Align constant islands in code'
 H461BA6D2D6E3: '在程式碼中對齊常數島'
 # 'Align doubles to two words in structs (x86 only)'
 HEDC15B5DDF59: '在結構中將雙精度浮點數對齊為兩個字元（僅限x86）'
 # 'Align selected branches (fused, jcc, jmp) within 32-byte boundary'
-H61C864267E04: '在32字節邊界內對齊選擇的分支（融合、jcc、jmp）'
+H61C864267E04: '在 32 字節邊界內對齊選擇的分支（融合、jcc、jmp）'
 # "Align selected instructions to mitigate negative performance impact of Intel's micro code update for errata skx102.  May break assumptions about labels corresponding to particular instructions, and should be used with caution."
 H4F2747860017: '對齊選擇的指令以緩解Intel因skx102缺陷更新微代碼所導致的負面性能影響。可能破壞標籤與特定指令對應的假設，應謹慎使用。'
 # 'Aligned allocation/deallocation functions are unavailable'
@@ -3559,7 +3559,7 @@ H02FFF4B1AF5A: '允許分支使用非仿射條件'
 # 'Allow non affine conditions for loops'
 H7C67DD81E47E: '允許迴圈使用非仿射條件'
 # 'Allow non-power-of-2 vectorization.'
-HA2D0D7F2C7BF: '允許非2的冪次向量化。'
+HA2D0D7F2C7BF: '允許非 2 的冪次向量化。'
 # 'Allow non-solo packetization of volatile memory references'
 H5792B0D4B6CC: '允許將易失性記憶體引用進行非單獨封包化'
 # 'Allow operation with no registered dialects'
@@ -3871,7 +3871,7 @@ HA13DECB16694: '假設例外物件的析構函數不會拋出例外'
 # 'Assume that execution stops at trap instruction'
 HFD7E94900060: '假設在trap指令處會終止執行'
 # 'Assume that externally defined data is in the small data if it meets the -G <size> threshold (MIPS)'
-H79ED681B6E82: '假設外部定義的資料如果符合-G<size>閾值（MIPS），則位於小資料段中'
+H79ED681B6E82: '假設外部定義的資料如果符合-G<size> 閾值（MIPS），則位於小資料段中'
 # 'Assume that kernels are launched with uniform block sizes (default true for CUDA/HIP and false otherwise)'
 HA763A763DA9A: '假設核函數是以統一區塊大小啟動（預設CUDA/HIP為true，其他為false）'
 # 'Assume that no thread in a parallel region will encounter a parallel region.'
@@ -3917,7 +3917,7 @@ H1898E5AD9AA7: '無論大小如何，嘗試將陣列暫存器配置在堆疊上'
 # 'Attempt to drop solution if it is less profitable'
 H339D061FB39B: '如果解決方案獲利較低，則嘗試放棄'
 # 'Attempt to match the ABI of Clang <version>'
-H0603A0819A4F: '嘗試符合Clang <version>的ABI'
+H0603A0819A4F: '嘗試符合Clang <version> 的ABI'
 # 'Attempt to vectorize for this register size in bits'
 HC4E22D3921AE: '嘗試根據暫存器大小（以位元為單位）進行向量化'
 # 'Attempt to vectorize horizontal reductions'
@@ -3931,7 +3931,7 @@ H6A8CFBBE8142: '即使未被任何樣本命中，仍將所有函數的範圍標�
 # 'Auto-generates preprocessed source files and a reproduction script'
 H2B36EB61E3F1: '自動產生預處理來源檔和重現腳本'
 # 'Automatically put hot code on 2MB page(s) (hugify) at runtime. No manual call to hugify is needed in the binary (which is what --hot-text relies on).'
-H0155A65DE424: '在執行階段自動將熱代碼置於2MB頁面（hugify）。在可執行檔中不需要手動呼叫hugify（這是--hot-text所依賴的）。'
+H0155A65DE424: '在執行階段自動將熱代碼置於 2MB頁面（hugify）。在可執行檔中不需要手動呼叫hugify（這是--hot-text所依賴的）。'
 # 'Auxiliary target triple.'
 H7C66B9F24C8E: '輔助目標三元組。'
 # 'Average inst/cycle when no target itinerary exists.'
@@ -4037,7 +4037,7 @@ HE94155328C5F: '立即TLS偏移量的位元大小'
 # 'Bitstream'
 HA8A9704FB47E: '位元流'
 # 'Bitwidth of the index type for the host (warning this should be 64 until the GPU layering is fixed)'
-H1A2F700B75FE: '主機的索引類型位元寬度（警告：在GPU層次結構修復前應設為64）'
+H1A2F700B75FE: '主機的索引類型位元寬度（警告：在GPU層次結構修復前應設為 64）'
 # 'Block Frequency Analysis'
 H0F710FC006A0: '區塊頻率分析'
 # 'Block frequency percentage a loop exit block needs over the original exit to be considered the new exit.'
@@ -4051,7 +4051,7 @@ H394C581D41AA: '自底向上、考量寄存器壓力的清單排程，嘗試平�
 # 'Bottom-up register reduction list scheduling'
 H669DA6589497: '自底向上、減少寄存器使用的清單排程'
 # 'Bound on stack depth while inlining (4 by default)'
-H517AFAFA9D42: '內聯時堆疊深度的限制（預設為4）'
+H517AFAFA9D42: '內聯時堆疊深度的限制（預設為 4）'
 # 'Bound the dependence analysis by a maximal amount of computational steps (0 means no bound)'
 H649A261EB1B0: '依存性分析的計算步驟上限（0 表示無限制）'
 # 'Bound the scheduler by maximal amountof computational steps. '
@@ -4085,7 +4085,7 @@ H55D8DD7267D8: '根據函數名稱分解計數。'
 # 'Bucket number per loop for PPC loop chain common'
 H095EE2A27794: 'PPC迴圈鏈接公用的每個迴圈桶數'
 # 'Buffer the last N characters of debug output until program termination. [default 0 -- immediate print-out]'
-HEA243B6BB971: '緩衝程式終止前的最後N個除錯輸出字元。[預設值0 — 立即輸出]'
+HEA243B6BB971: '緩衝程式終止前的最後N個除錯輸出字元。[預設值 0 — 立即輸出]'
 # "BugPoint Test Pass - Intentionally 'misoptimize' CallInsts"
 H89AAE42B7AE6: 'BugPoint測試pass — 故意「誤優化」CallInsts'
 # 'BugPoint Test Pass - Intentionally crash on CallInsts'
@@ -4199,7 +4199,7 @@ H3E3A7818BD1C: '旁路載入分割的收益模型'
 # 'C does not support default arguments'
 H9634D9BB0DF6: 'C語言不支援預設參數'
 # 'C requires #line number to be less than %0, allowed as extension'
-H2FF7FD761591: 'C語言要求#line行號必須小於%0，但作為擴展允許'
+H2FF7FD761591: 'C語言要求#line行號必須小於 %0，但作為擴展允許'
 # 'C requires a comma prior to the ellipsis in a variadic function type'
 HF2B9DE1954B1: 'C語言要求在可變參數函數類型中的省略號前要有逗號'
 # "C++ ABI '%0' is not supported on target triple '%1'"
@@ -4209,15 +4209,15 @@ H9B471B29FD3A: '要使用的C++ ABI。這將覆蓋目標C++ ABI。'
 # 'C++ implementation file name'
 HE4F416D1C66F: 'C++實作檔名稱'
 # 'C++ operator %0 (aka %1) used as a macro name'
-H2A2A24E029F0: 'C++運算子%0（即%1）被用作預處理宏名稱'
+H2A2A24E029F0: 'C++運算子 %0（即 %1）被用作預處理宏名稱'
 # 'C++ standard library to use'
 HEE4D104DB34B: '使用的C++標準程式庫'
 # 'C++11 only allows consecutive left square brackets when introducing an attribute'
 H2040F8CA0C12: 'C++11僅允許在引入屬性時使用連續的左方括號'
 # 'C++98 requires an accessible copy constructor for class %2 when binding a reference to a temporary; was %select{private|protected}0'
-H89F3A4330FF6: 'C++98在將暫時物件綁定為引用時，要求類別%2具有可存取的複製建構函式；目前為%select{私有|受保護}0'
+H89F3A4330FF6: 'C++98在將暫時物件綁定為引用時，要求類別 %2 具有可存取的複製建構函式；目前為%select{私有|受保護}0'
 # 'C99 forbids casting nonscalar type %0 to the same type'
-H26E6559D43AC: 'C99禁止將非純量類型%0轉換為相同的類型'
+H26E6559D43AC: 'C99禁止將非純量類型 %0 轉換為相同的類型'
 # 'C99 forbids conditional expressions with only one void side'
 HD3A412BC601A: 'C99禁止條件運算式僅有一邊為void類型'
 # 'CF object of type %0 is bridged to %1, which is not an Objective-C class'
@@ -4267,7 +4267,7 @@ H4386F29D7C1C: "CUDA 特殊函數 '%0' 必須具有純量返回類型"
 # 'CUDA version %0 is only partially supported'
 HABB5F3AD45B9: 'CUDA 版本 %0 僅部分支援'
 # 'CUDA version%0 is newer than the latest%select{| partially}1 supported version %2'
-HC8470F3A3C10: 'CUDA 版本%0 比最新%select{| 部分}1支援的版本 %2 更新'
+HC8470F3A3C10: 'CUDA 版本 %0 比最新%select{| 部分}1支援的版本 %2 更新'
 # 'CXX Dump Options'
 HEC70FF6EBB76: 'CXX 輸出選項'
 # 'CXX Map Options'
@@ -4397,7 +4397,7 @@ HCA7AB9E73E1E: '選擇基礎的JIT類型。'
 # 'Chunksize to use by the OpenMP runtime calls'
 H9BE7E3A1146E: 'OpenMP執行時期呼叫使用的區塊大小'
 # "Clang permits use of type 'double' regardless pragma if 'cl_khr_fp64' is supported"
-H36E837B04A86: '若支援"cl_khr_fp64"，Clang允許在無視pragma的情況下使用"double"類型'
+H36E837B04A86: '若支援 "cl_khr_fp64"，Clang允許在無視pragma的情況下使用 "double" 類型'
 # 'Clang-format options'
 H5807AFA36D8E: 'Clang格式選項'
 # 'ClangIR code gen Not Yet Implemented: %0'
@@ -4541,7 +4541,7 @@ H10812CD37717: '比較選項'
 # 'Compare all elements.'
 HD1160DBAE7C6: '比較所有元素。'
 # 'Compare bits 62 and 61 of address (TBI should be disabled)'
-HC1881DEFBF5A: '比較地址的第62和61位元（TBI應被禁用）'
+HC1881DEFBF5A: '比較地址的第 62 和 61位元（TBI應被禁用）'
 # 'Compare with the result of XPAC (requires Armv8.3-a)'
 HBA5A269FECBF: '與XPAC的結果進行比較（需要Armv8.3-a）'
 # 'Compare with the result of XPACLRI'
@@ -4643,7 +4643,7 @@ HE778B3B33793: '控制將memcpy轉換為尾條件循環（WLSTP）'
 # 'Control emission of Swift async extended frame info'
 H02D3442EBA23: '控制Swift異步擴展框架資訊的發射'
 # "Control how the assembler should align branches with NOP. If the boundary's size is not 0, it should be a power of 2 and no less than 32. Branches will be aligned to prevent from being across or against the boundary of specified size. The default value 0 does not align branches."
-H8B5A4A325A23: '控制匯集器如何使用NOP對齊分支。若邊界的大小不為0，則必須是2的冪次且至少為32。分支將被對齊以避免跨過或逆向指定大小的邊界。預設值0不會對齊分支。'
+H8B5A4A325A23: '控制匯集器如何使用NOP對齊分支。若邊界的大小不為 0，則必須是 2 的冪次且至少為 32。分支將被對齊以避免跨過或逆向指定大小的邊界。預設值 0 不會對齊分支。'
 # 'Control jump table emission on Hexagon target'
 H6602FAB1D723: '控制Hexagon目標的跳轉表發射'
 # 'Control lookup table emission on Hexagon target'
@@ -4659,15 +4659,15 @@ H27887A938BFF: '控制要執行的phi節點折疊量（預設值=2）'
 # 'Control the maximal conditional load/store that we are willing to speculatively execute to eliminate conditional branch (default = 6)'
 HEA5F4A80FEFE: '控制願意預測執行的最大條件式載入/儲存指令數以消除條件式跳轉（預設值=6）'
 # 'Control the maximal total instruction cost that we are willing to speculatively execute to fold a 2-entry PHI node into a select (default = 4)'
-H57D2DDD9FD2C: '控制願意預測執行的最大總指令成本以將2項phi節點折疊為選擇式（預設值=4）'
+H57D2DDD9FD2C: '控制願意預測執行的最大總指令成本以將 2 項phi節點折疊為選擇式（預設值=4）'
 # 'Control the number of bonus instructions (default = 1)'
 H7BC9F590620F: '控制獎勵指令的數量（預設值=1）'
 # 'Control the rules which are enabled. These options all take a comma separated list of rules to disable and may be specified by number or number range (e.g. 1-10).'
-H7704451C821B: '控制啟用的規則。這些選項接受以逗號分隔的要禁用規則清單，並可透過數字或數字範圍指定（例如1-10）。'
+H7704451C821B: '控制啟用的規則。這些選項接受以逗號分隔的要禁用規則清單，並可透過數字或數字範圍指定（例如 1-10）。'
 # 'Control the use of vectorisation using tail-folding for SVE where the option is specified in the form (Initial)[+(Flag1|Flag2|...)]:\ndisabled      (Initial) No loop types will vectorize using tail-folding\ndefault       (Initial) Uses the default tail-folding settings for the target CPU\nall           (Initial) All legal loop types will vectorize using tail-folding\nsimple        (Initial) Use tail-folding for simple loops (not reductions or recurrences)\nreductions    Use tail-folding for loops containing reductions\nnoreductions  Inverse of above\nrecurrences   Use tail-folding for loops containing fixed order recurrences\nnorecurrences Inverse of above\nreverse       Use tail-folding for loops requiring reversed predicates\nnoreverse     Inverse of above'
 H48B9B6BA5047: '控制SVE向量化時使用尾部折疊的規則，其格式為(初始)[+(Flag1|Flag2|...)]:\ndisabled      (初始) 不會使用尾部折疊向量化任何迴圈類型\ndefault       (初始) 使用目標CPU的預設尾部折疊設定\nall           (初始) 所有合法迴圈類型將使用尾部折疊向量化\nsimple        (初始) 對簡單迴圈(不含約束或遞迴)使用尾部折疊\nreductions    對含約束的迴圈使用尾部折疊\nnoreductions  反向設定\nrecurrences   對含固定順序遞迴的迴圈使用尾部折疊\nnorecurrences 反向設定\nreverse       對需要反向述詞的迴圈使用尾部折疊\nnoreverse     反向設定'
 # "Control use of approximate reciprocal and reciprocal square root instructions followed by <n> iterations of Newton-Raphson refinement. <value> = ( ['!'] ['vec-'] ('rcp'|'sqrt') [('h'|'s'|'d')] [':'<n>] ) | 'all' | 'default' | 'none'"
-HC7E65C6B3833: "控制近似倒數及平方根倒數指令後跟<n>次牛頓-拉弗森修訂。<value> = ( ['!'] ['vec-'] ('rcp'|'sqrt') [('h'|'s'|'d')] [':'<n>] ) | 'all' | 'default' | 'none'"
+HC7E65C6B3833: "控制近似倒數及平方根倒數指令後跟 <n> 次牛頓-拉弗森修訂。<value> = ( ['!'] ['vec-'] ('rcp'|'sqrt') [('h'|'s'|'d')] [':'<n>] ) | 'all' | 'default' | 'none'"
 # 'Control vtordisp placement'
 HE1318392829D: '控制vtordisp的放置位置'
 # 'Control vtordisp placement on win32 targets'
@@ -4683,7 +4683,7 @@ H08542ADEE520: '控制InstCombine pass中的Negator轉換'
 # 'Controls how scalar integer arguments are extended in calls to unprototyped and varargs functions'
 H7A8FE1AC1071: '控制在呼叫未原型化及可變參數函數時，純量整數參數的擴展方式。'
 # 'Controls the backend parallelism of -flto=thin (default of 0 means the number of threads will be derived from the number of CPUs detected)'
-H6966D13FD63C: '控制-flto=thin的後端並行處理（預設值為0表示執行緒數量將根據偵測到的CPU數量決定）。'
+H6966D13FD63C: '控制-flto=thin的後端並行處理（預設值為 0 表示執行緒數量將根據偵測到的CPU數量決定）。'
 # 'Controls the semantics of floating-point calculations.'
 H71E38C97DF72: '控制浮點運算的語義。'
 # 'Controls transformations in div-rem-pairs pass'
@@ -4803,7 +4803,7 @@ H01E9364CFCA0: '建立帶有圖形變更的網站'
 # 'Create a website with graphical changes in quiet mode'
 H70CA1F4FAB9C: '在安靜模式下建立帶有圖形變更的網站'
 # 'Create cfi directives that assume the code might be more than 2gb away'
-H558862C2332B: '建立假設代碼可能超過2GB的CFI指令'
+H558862C2332B: '建立假設代碼可能超過 2GB的CFI指令'
 # 'Create debug DLL'
 H983B4E5552B9: '建立除錯DLL'
 # 'Create empty files if bundles are missing when unbundling.\n'
@@ -4837,7 +4837,7 @@ HF9A83C7746B5: '在記憶體等待時消除危害'
 # 'Cutoff for generating "extract" instructions'
 HF67D76A2F279: '生成「extract」指令的閾值'
 # 'Cutoff percentages (times 10000) for generating detailed summary'
-HF12B62925337: '生成詳細摘要的閾值百分比（乘以10000）'
+HF12B62925337: '生成詳細摘要的閾值百分比（乘以 10000）'
 # 'Cutoff value about how many symbols in profile symbol list will be used. This is very useful for performance debugging'
 H866011BDFA50: '剖析符號清單中使用的符號數量的截止值。這對性能除錯非常有用'
 # 'Cycle Info Analysis'
@@ -4973,7 +4973,7 @@ H0675076F20CF: '平台和JIT類型預設值'
 # 'Default max threads per block for kernel launch bounds for HIP'
 HDE6E6DE6B0D5: 'HIP核函數啟動邊界中每個區塊的最大執行緒數預設值'
 # 'Default mispredict rate (initialized to 25%).'
-HA90859109DC8: '預設誤測率（初始值設為25%）'
+HA90859109DC8: '預設誤測率（初始值設為 25%）'
 # 'Default register allocator'
 HF2112AFDE4A0: '預設的記憶體寄存器分配器'
 # 'Default threshold (max size of unrolled loop), used in all but O3 optimizations'
@@ -4983,9 +4983,9 @@ H7E06B3502FFA: '預設類型可見性'
 # 'Defer host/device related diagnostic messages for CUDA/HIP'
 HD7B0D94624F9: '延遲CUDA/HIP主機/裝置相關的診斷訊息'
 # "Define '__STDC__' to '1' in MSVC Compatibility mode"
-HE12E4DC30513: "在MSVC相容模式下將'__STDC__'定義為'1'"
+HE12E4DC30513: "在MSVC相容模式下將 '__STDC__' 定義為 '1'"
 # 'Define <macro> to <value> (or 1 if <value> omitted)'
-HC9C0FAB29C48: '將<macro>定義為<value>（若省略<value>則定義為1）'
+HC9C0FAB29C48: '將 <macro> 定義為 <value>（若省略 <value> 則定義為 1）'
 # 'Define __STDC__'
 H403D03CBAA5E: '定義__STDC__'
 # 'Define a value for a symbol'
@@ -5527,7 +5527,7 @@ H1147057C0FDD: '停用合併至combine中'
 # 'Disable merging of globals'
 H0911384E3022: '停用全域變數的合併'
 # 'Disable minimum alignment of 1 for arguments passed by value on stack'
-HAF9C1AF67E2F: '停用以堆疊傳遞的值參數的1最小對齊'
+HAF9C1AF67E2F: '停用以堆疊傳遞的值參數的 1 最小對齊'
 # 'Disable mitigations for Load Value Injection (LVI)'
 HE89F1385E864: '停用對Load Value Injection (LVI)的緩解措施'
 # 'Disable module-based external API notes support'
@@ -5555,7 +5555,7 @@ HBB8A633ECC4C: "停用省略'dls lr, lr'指令"
 # 'Disable on-demand initialization of thread-local variables'
 HD53AA5AC4AC6: '停用按需初始化的執行緒局部變數'
 # 'Disable one or more combiner rules temporarily in '
-HD45ADA00F46A: '暫時停用中的1或多個組合規則'
+HD45ADA00F46A: '暫時停用中的 1 或多個組合規則'
 # 'Disable optimization'
 HD31C9965E766: '停用優化'
 # 'Disable optimizations based on strict aliasing rules'
@@ -5591,7 +5591,7 @@ HA85F69F96408: '禁用預定義和命令列預編譯器宏'
 # 'Disable predefined and command line preprocessor macros'
 HB44C3311DC89: '禁用預定義目標作業系統宏'
 # 'Disable predefined target OS macros'
-H55CEC6079E93: "禁用顯示'ready'提示"
+H55CEC6079E93: "禁用顯示 'ready' 提示"
 # "Disable printing the 'ready' prompt"
 H60B484C23636: '禁用機率驅動的區塊放置'
 # 'Disable probability-driven block placement'
@@ -5707,7 +5707,7 @@ H9E100408BFFF: '停用發射組件器偽指令'
 # 'Disable the expand reduction intrinsics pass from running'
 H040AA8C3CBF5: '停用執行展開reduction intrinsic的pass'
 # 'Disable the generation of 4-operand madd.s, madd.d and related instructions.'
-HB91438C02652: '停用生成4個操作元的madd.s、madd.d及相關指令'
+HB91438C02652: '停用生成 4 個操作元的madd.s、madd.d及相關指令'
 # 'Disable the generation of low-overhead loops'
 H1104A5C142EF: '停用生成低開銷循環'
 # 'Disable the integrated assembler'
@@ -6017,7 +6017,7 @@ H1F6F59A37FC5: '不假設C++運算子new不會傳回NULL'
 # 'Do not assume that any loop is finite.'
 H5580E1E87EBF: '不假設任何迴圈都是有限的'
 # 'Do not assume that externally defined data is in the small data if it meets the -G <size> threshold (MIPS)'
-HAD54547B8D0E: '不將符合-G<size>門檻的外部定義資料視為小資料（MIPS）'
+HAD54547B8D0E: '不將符合-G<size> 門檻的外部定義資料視為小資料（MIPS）'
 # 'Do not automatically generate or update the global module index'
 H6DB4D9D7E3EF: '不自動產生或更新全域模組索引'
 # 'Do not automatically import modules for error recovery'
@@ -6069,7 +6069,7 @@ HB04F2AC6377B: '不要為已定義但未使用的類型發出除錯資訊'
 # 'Do not emit RTTI data'
 H0669AFF65C8F: '不要發出RTTI資料'
 # "Do not emit a trap instruction for 'unreachable' IR instructions after noreturn calls, even if --trap-unreachable is set."
-HB71318F0BBDA: "即使設定了--trap-unreachable，也不要對noreturn呼叫後的'unreachable' IR指令發出陷阱指令。"
+HB71318F0BBDA: "即使設定了--trap-unreachable，也不要對noreturn呼叫後的 'unreachable' IR指令發出陷阱指令。"
 # 'Do not emit code that uses the red zone.'
 H4923C3F307F8: '不產生使用紅區的程式碼。'
 # 'Do not emit code to make initialization of local statics thread safe'
@@ -6461,13 +6461,13 @@ HE1A69C7730A8: '如果模組在本次建置階段已成功驗證或載入，則�
 # "Don't verify that MIR is fully legal between GlobalISel passes"
 H2547A49B1E5F: '不要驗證GlobalISel passes之間的MIR是否完全合法'
 # "Don't work around Cortex-A57 Erratum 1742098 (ARM only)"
-H3E4B9BDEA672: '不要應對Cortex-A57錯誤修正1742098（僅限ARM）'
+H3E4B9BDEA672: '不要應對Cortex-A57錯誤修正 1742098（僅限ARM）'
 # "Don't work around Cortex-A72 Erratum 1655431 (ARM only)"
-HBBA28409C8FE: '不要應對Cortex-A72錯誤修正1655431（僅限ARM）'
+HBBA28409C8FE: '不要應對Cortex-A72錯誤修正 1655431（僅限ARM）'
 # "Don't work around VLLDM erratum CVE-2021-35465 (ARM only)"
 H2D48982037C5: '不要應對VLLDM錯誤修正CVE-2021-35465（僅限ARM）'
 # "Don't workaround Cortex-A53 erratum 835769 (AArch64 only)"
-H674F1B2934BD: '不要應對Cortex-A53錯誤修正835769（僅限AArch64）'
+H674F1B2934BD: '不要應對Cortex-A53錯誤修正 835769（僅限AArch64）'
 # "Don't write fields with default values"
 HDC62F7F06017: '不要寫入具有預設值的欄位'
 # "Dot-separated value representing the Microsoft compiler version number to report in _MSC_VER (0 = don't define it (default))"
@@ -6569,7 +6569,7 @@ H01B54D632FED: '傾印映像區段標頭'
 # 'Dump input on failure'
 H6F31E933D50C: '在失敗時傾印輸入'
 # "Dump input to stderr, adding annotations representing\ncurrently enabled diagnostics.  When there are multiple\noccurrences of this option, the <value> that appears earliest\nin the list below has precedence.  The default is 'fail'.\n"
-H768FAF2A8E36: '將輸入傾印至標準錯誤輸出，並附加代表目前啟用診斷的註解。當此選項出現多次時，清單中最先出現的<value>優先。預設值為「fail」。\n'
+H768FAF2A8E36: '將輸入傾印至標準錯誤輸出，並附加代表目前啟用診斷的註解。當此選項出現多次時，清單中最先出現的 <value> 優先。預設值為「fail」。\n'
 # 'Dump list of actions to perform'
 HD3BA4698DD33: '傾印要執行的動作清單'
 # 'Dump low level bitcode trace'
@@ -6631,9 +6631,9 @@ H91B777999917: '傾印由降階產生的 FIR 結構並退出'
 # 'Dump the HLFIR created by lowering and exit'
 H2BFC1CB7ACAA: '傾印由降階產生的 HLFIR 結構並退出'
 # 'Dump the IPI Stream (Stream 5)'
-H0EC59D4B528C: '傾印IPI資料流（資料流5）'
+H0EC59D4B528C: '傾印IPI資料流（資料流 5）'
 # 'Dump the PDB Stream (Stream 1)'
-H4577B257A885: '傾印PDB資料流（資料流1）'
+H4577B257A885: '傾印PDB資料流（資料流 1）'
 # 'Dump the PDB String Table'
 H46D5A974F1C3: '傾印PDB字串表'
 # 'Dump the Publics Stream'
@@ -6641,7 +6641,7 @@ H9A8FF0F8500C: '傾印Publics資料流'
 # "Dump the SCCs in the ThinLTO index's callgraph"
 H05F63DC7879B: '傾印ThinLTO索引調用圖中的強連通組成分'
 # 'Dump the TPI Stream (Stream 3)'
-H838873B9AC8D: '傾印TPI資料流（資料流3）'
+H838873B9AC8D: '傾印TPI資料流（資料流 3）'
 # 'Dump the compiler configuration options'
 H3D1A24CE8D0E: '傾印編譯器配置選項'
 # 'Dump the cooked character stream in -E mode'
@@ -6697,9 +6697,9 @@ HE0360B0DDF0D: '動態連結sanitizer執行階段程式庫'
 # 'EABI GNU'
 H7E2A3B789B36: 'EABI GNU版本'
 # 'EABI version 4'
-H3C615C59EEA1: 'EABI版本4'
+H3C615C59EEA1: 'EABI版本 4'
 # 'EABI version 5'
-HDD2C36FB7B3F: 'EABI版本5'
+HDD2C36FB7B3F: 'EABI版本 5'
 # 'Eagerly compute live intervals for all physreg units.'
 H8BDCB87E4D2E: '積極計算所有實體寄存器單元的存活區間。'
 # 'Eagerly invalidate more analyses in default pipelines'
@@ -7007,7 +7007,7 @@ H2EC78B18E661: '在 Global ISel 中啟用 / 禁用可擴展向量（SVE）'
 # 'Enable / disable promotion of unnamed_addr constants into constant pools'
 HFAE28EE53BD3: '啟用 / 禁用將無名址常量提升至常量池'
 # 'Enable 16-bit types and disable min precision types.Available in HLSL 2018 and shader model 6.2.'
-HAAC77E9561C2: '啟用16位元類型並禁用最小精度類型。適用於HLSL 2018和著色器模型6.2。'
+HAAC77E9561C2: '啟用 16 位元類型並禁用最小精度類型。適用於HLSL 2018和著色器模型 6.2。'
 # 'Enable <feature> in module map requires declarations'
 H5C8DA92AFFD8: '在 module map 的 requires 宣告中啟用 <feature>'
 # 'Enable AArch64 SME memory operations to lower to librt functions'
@@ -7023,7 +7023,7 @@ H9BDDE4ABB4D1: '啟用 AMDGPUAttributorPass'
 # 'Enable ARC-style weak references in Objective-C'
 H9B793CE9E824: '在 Objective-C 中啟用 ARC 樣式的弱引用'
 # 'Enable ARM 2-addr to 3-addr conv'
-HFA9A2110C825: '啟用ARM 2-地址到3-地址轉換'
+HFA9A2110C825: '啟用ARM 2-地址到 3-地址轉換'
 # 'Enable ARM load/store optimization pass'
 HF1C1057F91DB: '啟用ARM載入/儲存優化pass'
 # 'Enable AddressSanitizer'
@@ -7131,9 +7131,9 @@ H98BCB50602AD: '啟用KernelMemorySanitizer插樿'
 # 'Enable LSR phi elimination'
 H6F6B88180DCF: '啟用LSR phi消除'
 # "Enable LTO in 'full' mode"
-HDE2B72E90D39: "以'full'模式啟用LTO"
+HDE2B72E90D39: "以 'full' 模式啟用LTO"
 # "Enable LTO in 'full' mode for offload compilation"
-H1AD130930D3D: "為卸載編譯以'full'模式啟用LTO"
+H1AD130930D3D: "為卸載編譯以 'full' 模式啟用LTO"
 # 'Enable Loongson Advanced SIMD Extension (LASX).'
 H8708BF686447: '啟用Loongson Advanced SIMD Extension (LASX).'
 # 'Enable Loongson SIMD Extension (LSX).'
@@ -7207,7 +7207,7 @@ H4E40230CBB89: '啟用ThinLTO快取機制。'
 # 'Enable Unroll And Jam Pass'
 HC78C6B520033: '啟用Unroll And Jam Pass'
 # 'Enable V8+ mode, allowing use of 64-bit V9 instructions in 32-bit code'
-H51CF3B974577: '啟用V8+模式，允許在32位程式碼中使用64位V9指令'
+H51CF3B974577: '啟用V8+模式，允許在 32 位程式碼中使用 64 位V9指令'
 # 'Enable VGPR liverange optimizations for if-else structure'
 H7A56B298E40B: '啟用VGPR活範圍優化，針對if-else結構'
 # 'Enable VOPD, dual issue of VALU in wave32'
@@ -7789,7 +7789,7 @@ H4AAD4C1AF839: '為所有函數啟用堆疊保護器'
 # 'Enable stack protectors for some functions vulnerable to stack smashing. Compared to -fstack-protector, this uses a stronger heuristic that includes functions containing arrays of any size (and any type), as well as any calls to alloca or the taking of an address from a local variable'
 H01F993B30A66: '為部分易受堆疊溢位攻擊的函數啟用堆疊保護器。與-fstack-protector相比，此選項採用更嚴格的_heuristic_，包含所有包含任意大小（或任意類型）陣列的函數，以及任何呼叫alloca或取得局部變數位址的函數'
 # "Enable stack protectors for some functions vulnerable to stack smashing. This uses a loose heuristic which considers functions vulnerable if they contain a char (or 8bit integer) array or constant sized calls to alloca , which are of greater size than ssp-buffer-size (default: 8 bytes). All variable sized calls to alloca are considered vulnerable. A function with a stack protector has a guard value added to the stack frame that is checked on function exit. The guard value must be positioned in the stack frame such that a buffer overflow from a vulnerable variable will overwrite the guard value before overwriting the function's return address. The reference stack guard value is stored in a global variable."
-H216044E73536: '為部分易受堆疊溢位攻擊的函數啟用堆疊保護器。此選項使用寬鬆_heuristic_，若函數包含大小超過_ssp-buffer-size_（預設：8字節）的_char_（或8位元整數）陣列，或固定大小的alloca呼叫，則視為有風險。所有變數大小的alloca呼叫均視為有風險。具有堆疊保護器的函數會在堆疊框架中新增檢查值，該值在函數結束時會被驗證。檢查值必須位於堆疊框架中，使得易受攻擊的變數的緩衝區溢位會先覆寫檢查值，而非函數的返回位址。參考堆疊檢查值存放在全域變數中。'
+H216044E73536: '為部分易受堆疊溢位攻擊的函數啟用堆疊保護器。此選項使用寬鬆_heuristic_，若函數包含大小超過_ssp-buffer-size_（預設：8字節）的_char_（或 8 位元整數）陣列，或固定大小的alloca呼叫，則視為有風險。所有變數大小的alloca呼叫均視為有風險。具有堆疊保護器的函數會在堆疊框架中新增檢查值，該值在函數結束時會被驗證。檢查值必須位於堆疊框架中，使得易受攻擊的變數的緩衝區溢位會先覆寫檢查值，而非函數的返回位址。參考堆疊檢查值存放在全域變數中。'
 # 'Enable static hinting of branches on ppc'
 H1318D7CF750E: '在ppc上啟用分支的靜態提示'
 # 'Enable statistics output from program (available with Asserts)'
@@ -7831,9 +7831,9 @@ HB827608C6F32: '啟用"快速"指令選擇器'
 # 'Enable the "global" instruction selector'
 HC28B60B42675: '啟用"全域"指令選擇器'
 # "Enable the 'blocks' language feature"
-H8A0F69B5F85C: "啟用'blocks'語言功能"
+H8A0F69B5F85C: "啟用 'blocks' 語言功能"
 # "Enable the 'modules' language feature"
-H047278B48AFB: "啟用'modules'語言功能"
+H047278B48AFB: "啟用 'modules' 語言功能"
 # 'Enable the AArch64 branch target pass'
 H288D5F3BECED: '啟用AArch64分支目標pass'
 # 'Enable the AIX Extended Altivec ABI.'
@@ -8071,7 +8071,7 @@ H19C598762536: '啟用vtune 剖析支援'
 # 'Enable warnings for deprecated constructs and define __DEPRECATED'
 H141A6A5BBE2F: '啟用對已棄用結構的警告並定義 __DEPRECATED'
 # 'Enable warnings for undefined macros with a prefix in the comma separated list <arg>'
-HCD611C0CC9C3: '為帶有逗號分隔清單<arg>中前綴的未定義宏啟用警告'
+HCD611C0CC9C3: '為帶有逗號分隔清單 <arg> 中前綴的未定義宏啟用警告'
 # 'Enable whole program visibility'
 HED7D14DA2E46: '啟用整體程式能見度'
 # 'Enable whole program visibility during LTO'
@@ -8211,7 +8211,7 @@ HE55B6BA9D8DC: '透過正則表達式排除編譯單元'
 # 'Exclude functions matching the filter from the output.'
 H1D0BAA0AC132: '排除符合篩選條件的函數輸出。'
 # 'Exclude sanitization for the top hottest code responsible for the given fraction of PGO counters (0.0 [default] = skip none; 1.0 = skip all). Argument format: <sanitizer1>=<value1>,<sanitizer2>=<value2>,...'
-H7D028CB3230B: '根據給定的PGO計數器百分比，排除配置文件引導型優化(PGO)中最高熱點代碼的檢查(0.0[預設]=不跳過；1.0=跳過全部)。參數格式：<檢查器1>=<值1>,<檢查器2>=<值2>,...'
+H7D028CB3230B: '根據給定的PGO計數器百分比，排除配置文件引導型優化(PGO)中最高熱點代碼的檢查(0.0[預設]=不跳過；1.0=跳過全部)。參數格式：<檢查器 1>=<值 1>,<檢查器 2>=<值 2>,...'
 # 'Exclude symbols by regular expression'
 H599455B9067B: '排除符合正則表達式之符號'
 # 'Exclude types by regular expression'
@@ -8237,7 +8237,7 @@ H1F5EDB8C4566: '當不可預測的值來自同一迴圈時提前終止'
 # 'Exit with an error when an instruction is unsupported for any reason (default)'
 HDA0C7DD7EA63: '當任何原因導致指令不支援時以錯誤終止（預設）'
 # 'Expand 64-bit division in AMDGPUCodeGenPrepare'
-HEA34070476C9: '在AMDGPUCodeGenPrepare中展開64位元除法'
+HEA34070476C9: '在AMDGPUCodeGenPrepare中展開 64 位元除法'
 # 'Expand Atomic instructions'
 H30D3E9ACF190: '展開原子指令'
 # 'Expand certain fp instructions'
@@ -8333,7 +8333,7 @@ HF76D682A9D15: '將HwModes特定指令提取至新的DecoderTables，大幅減�
 # 'Extract at most one loop into a new function'
 H2D39B07FBC4D: '最多將一個迴圈提取至新函數'
 # 'Extract from <file>.'
-H4A68D5BEAE14: '從<file>中提取。'
+H4A68D5BEAE14: '從 <file> 中提取。'
 # 'Extract loops into new functions'
 H053EB2868DBF: '將迴圈提取至新函數'
 # 'FAILURE'
@@ -8353,7 +8353,7 @@ H3E3C2FB702A6: 'FIX-IT在宏中無法套用建議的程式碼變更'
 # 'Factor for the unroll threshold to account for code simplifications still taking place'
 HBD6D5665E545: '用於考慮仍在進行的程式碼簡化的展開閾值因素'
 # 'Factor to apply to what qualifies as a long branch to reserve a pair of scalar registers. If this value is 0 the long branch registers are never reserved. As this value grows the greater chance the branch distance will fall within the threshold and the registers will be marked to be reserved. We lean towards always reserving a register for  long jumps'
-H106A273943F9: '用於判斷何種長跳轉分支需要保留一對標量寄存器的係數。若此值為0，則長跳轉寄存器永遠不會被保留。當此值增加時，跳轉距離落入閾值範圍內的機率越高，寄存器將被標記為保留。我們傾向於始終保留一個寄存器用於長跳轉'
+H106A273943F9: '用於判斷何種長跳轉分支需要保留一對標量寄存器的係數。若此值為 0，則長跳轉寄存器永遠不會被保留。當此值增加時，跳轉距離落入閾值範圍內的機率越高，寄存器將被標記為保留。我們傾向於始終保留一個寄存器用於長跳轉'
 # "Fail if an object couldn't be found for a binary ID in the profile"
 H4235E7E596D5: '若剖析中的二進位ID無法找到對應物件時失敗'
 # 'Fail if any profile is invalid.'
@@ -8583,7 +8583,7 @@ H8477BA8471BC: '強制所有向量記憶體存取對齊（僅限RISC-V）'
 # 'Force all waitcnt instrs to be emitted as s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)'
 H687C328A88F2: '強制所有waitcnt指令發出為s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)'
 # 'Force all waitcnt load counters to wait until 0'
-H896788DC2080: '強制所有waitcnt載入計數器等待至0'
+H896788DC2080: '強制所有waitcnt載入計數器等待至 0'
 # 'Force allowance of nested hardware loops'
 HAD8E45F66910: '強制允許巢狀硬體迴圈'
 # 'Force analysis to continue in the presence of unsupported instructions'
@@ -8603,7 +8603,7 @@ H5694C07468F1: '強制codegen假設捨入模式可能動態改變'
 # 'Force disable the lazy-loading on-demand of metadata when loading bitcode for importing.'
 H2329A45D867C: '強制禁用載入用於匯入的bitcode時的metadata惰性載入'
 # 'Force double to be <n> bits'
-H6A3CAE57D5DB: '強制將double設為<n>位元'
+H6A3CAE57D5DB: '強制將double設為 <n> 位元'
 # 'Force each unsigned fixed point type to have an extra bit of padding to align their scales with those of signed fixed point types'
 H2DB086248971: '強制每個無符號固定點類型額外有一個填充位元以使其尺度與有符號固定點類型對齊'
 # 'Force emit s_waitcnt expcnt(0) instrs'
@@ -8635,11 +8635,11 @@ HE0B08266ED91: '強制使用解釋模式：停用JIT'
 # 'Force linking the clang builtins runtime library'
 H602A2DB51D2C: '強制連結clang內建執行時期函式庫'
 # 'Force long double to be 128 bits'
-HF5330D6B0F62: '強制long double為128位元'
+HF5330D6B0F62: '強制long double為 128 位元'
 # 'Force long double to be 64 bits'
-HF1CEF43473D8: '強制long double為64位元'
+HF1CEF43473D8: '強制long double為 64 位元'
 # 'Force long double to be 80 bits, padded to 128 bits for storage'
-H2FBC78A0A1C7: '強制long double為80位元，並填充至128位元以進行儲存'
+H2FBC78A0A1C7: '強制long double為 80 位元，並填充至 128 位元以進行儲存'
 # 'Force machine combiner to use a specific strategy for machine trace metrics evaluation.'
 H8D7274D95AD0: '強制機器組合器使用特定策略進行機器跡象指標評估。'
 # 'Force matrix instruction fusion even if not profitable.'
@@ -8661,11 +8661,11 @@ H7A397BF735D5: '無論目標查詢結果如何，強制進行存儲分割。'
 # 'Force the (profiled-guided) size optimizations. '
 HA4B424DB2FF9: '強制執行（配置文件引導型）大小優化。'
 # 'Force the alignment of all blocks in the function in log2 format (e.g 4 means align on 16B boundaries).'
-HB1C496FAEC2F: '以log2格式強制對齊函數內的所有區塊（例如4表示對齊到16B邊界）。'
+HB1C496FAEC2F: '以log2格式強制對齊函數內的所有區塊（例如 4 表示對齊到 16B邊界）。'
 # "Force the alignment of all blocks that have no fall-through predecessors (i.e. don't add nops that are executed). In log2 format (e.g 4 means align on 16B boundaries)."
-HEC173CEDA264: '強制對齊所有沒有跳轉前驅節點的區塊（即不添加執行時的nops）。以log2格式（例如4表示對齊到16B邊界）。'
+HEC173CEDA264: '強制對齊所有沒有跳轉前驅節點的區塊（即不添加執行時的nops）。以log2格式（例如 4 表示對齊到 16B邊界）。'
 # 'Force the alignment of all functions in log2 format (e.g. 4 means align on 16B boundaries).'
-HAC694582BD7C: '以log2格式強制對齊所有函數（例如4表示對齊到16B邊界）。'
+HAC694582BD7C: '以log2格式強制對齊所有函數（例如 4 表示對齊到 16B邊界）。'
 # 'Force the interpretation of -stream as a string, even if it is a valid integer'
 HD1DE45392158: '即使-stream是有效的整數，也強制將其解析為字串。'
 # 'Force the static analyzer to analyze functions defined in header files'
@@ -8733,7 +8733,7 @@ H0E5969703D2A: '將選項轉送給鏈接器'
 # 'Forward switch condition to phi ops (default = false)'
 HB7C76B2E6FA2: '轉送switch條件到phi操作（預設值=false）'
 # 'Four-byte version string for gcov files.'
-H32782AC0D44C: 'gcov檔案的4字節版本字串。'
+H32782AC0D44C: 'gcov檔案的 4 字節版本字串。'
 # 'Frame Data (DEBUG_S_FRAMEDATA subsection)'
 H4EACA6AC6ABA: '框架資料（DEBUG_S_FRAMEDATA子區段）'
 # 'Fuchsia API Level prohibits specifying a minor or sub-minor version'
@@ -8937,7 +8937,7 @@ H86F657FC95B7: '生成包含參數資訊的常規關鍵字屬性清單'
 # 'Generate a partial profile (only meaningful for -extbinary)'
 H8B3C403992F1: '生成部分剖析（僅對-extbinary有意義）'
 # 'Generate a pch file for all code up to and including <filename>'
-H3A6818A5EE16: '生成包含所有程式碼直至指定<filename>的pch檔案'
+H3A6818A5EE16: '生成包含所有程式碼直至指定 <filename> 的pch檔案'
 # 'Generate a recursive AST visitor for clang attributes'
 HD2CD27931B90: '生成clang屬性遞迴AST訪問器'
 # 'Generate a sparse profile (only meaningful for -instr)'
@@ -9059,7 +9059,7 @@ HE7EB6B773956: '為從此模組建構的物件檔中的類型生成除錯資訊�
 # 'Generate debug info with external references to clang modules or precompiled headers'
 HAD4093E5621B: '為包含clang模組或預編譯標頭的外部引用生成除錯資訊'
 # 'Generate debugging info in the 64-bit DWARF format'
-H70C04792FFA2: '以64位元DWARF格式生成除錯資訊'
+H70C04792FFA2: '以 64 位元DWARF格式生成除錯資訊'
 # 'Generate declarations for Offload API implementation functions'
 H36074FE5A628: '為Offload API實作函數生成宣告'
 # 'Generate definitions of Clang Syntax Tree node clasess'
@@ -9087,7 +9087,7 @@ HABD4DCD38172: '生成提取指令'
 # 'Generate function to translate named character references to UTF-8 sequences'
 H2212027837CC: '生成將命名字符參考轉換為UTF-8序列的函數'
 # 'Generate hot text symbols. Apply this option to a precompiled binary that manually calls into hugify, such that at runtime hugify call will put hot code into 2M pages. This requires relocation.'
-HE07FCEA6613B: '生成熱文本符號。將此選項用於手動調用hugify的預編譯二進位檔，以便在執行階段hugify調用將熱代碼放入2M頁面。此需要重新定位。'
+HE07FCEA6613B: '生成熱文本符號。將此選項用於手動調用hugify的預編譯二進位檔，以便在執行階段hugify調用將熱代碼放入 2M頁面。此需要重新定位。'
 # 'Generate instrumented code to collect context sensitive execution counts into <directory>/default.profraw (overridden by LLVM_PROFILE_FILE env var)'
 H10A2DF54F49A: '生成插樁代碼以收集上下文敏感執行計數到目錄/<directory>/default.profraw（可被LLVM_PROFILE_FILE環境變數覆寫）'
 # 'Generate instrumented code to collect context sensitive execution counts into default.profraw (overridden by LLVM_PROFILE_FILE env var)'
@@ -9099,7 +9099,7 @@ H40F8D1777D6C: '生成插樁代碼以收集冷函數的覆蓋資訊到default.pr
 # 'Generate instrumented code to collect execution counts into <directory>/default.profraw (overridden by LLVM_PROFILE_FILE env var)'
 H884AE4DB8A23: '生成插樁代碼以收集執行計數到目錄/<directory>/default.profraw（可被LLVM_PROFILE_FILE環境變數覆寫）'
 # 'Generate instrumented code to collect execution counts into <file> (overridden by LLVM_PROFILE_FILE env var)'
-HF1CDB71BC3BA: '生成插樁代碼以收集執行計數到<file>（可被LLVM_PROFILE_FILE環境變數覆寫）'
+HF1CDB71BC3BA: '生成插樁代碼以收集執行計數到 <file>（可被LLVM_PROFILE_FILE環境變數覆寫）'
 # 'Generate instrumented code to collect execution counts into default.profraw (overridden by LLVM_PROFILE_FILE env var)'
 HEDA64E6D9E58: '生成插樁代碼以收集執行計數到default.profraw（可被LLVM_PROFILE_FILE環境變數覆寫）'
 # "Generate instrumented code to collect execution counts into default.profraw file (overridden by '=' form of option or LLVM_PROFILE_FILE env var)"
@@ -9177,13 +9177,13 @@ H05167BC54E72: '生成軟體浮點庫調用'
 # 'Generate source-level debug information'
 HAEF3BF8D74CD: '生成來源層級除錯資訊'
 # 'Generate source-level debug information with dwarf version 2'
-HD2B80CB88FC9: '使用DWARF版本2生成來源層級除錯資訊'
+HD2B80CB88FC9: '使用DWARF版本 2 生成來源層級除錯資訊'
 # 'Generate source-level debug information with dwarf version 3'
-HA4075062488F: '使用DWARF版本3生成來源層級除錯資訊'
+HA4075062488F: '使用DWARF版本 3 生成來源層級除錯資訊'
 # 'Generate source-level debug information with dwarf version 4'
-H248AE385BE0D: '使用DWARF版本4生成來源層級除錯資訊'
+H248AE385BE0D: '使用DWARF版本 4 生成來源層級除錯資訊'
 # 'Generate source-level debug information with dwarf version 5'
-HE4BA3B14D0D7: '使用DWARF版本5生成來源層級除錯資訊'
+HE4BA3B14D0D7: '使用DWARF版本 5 生成來源層級除錯資訊'
 # 'Generate source-level debug information with the default dwarf version'
 H938AF5B9960A: '使用預設的DWARF版本生成來源層級除錯資訊'
 # 'Generate the clang parsed attribute helpers'
@@ -9215,13 +9215,13 @@ H5EEF255AAE70: '通用選項'
 # 'Generic memory optimizations'
 H800F1622EB9A: '通用記憶體最佳化'
 # 'Get the symbol definition from <line> <start-column> <end-column>'
-H9C96E5C80114: '從<line> <start-column> <end-column>取得符號定義'
+H9C96E5C80114: '從 <line> <start-column> <end-column>取得符號定義'
 # 'Give each function an independent TBAA tree (default)'
 H7A952E99A7FC: '為每個函數提供獨立的TBAA樹（預設值）'
 # 'Give global C++ operator new and delete declarations hidden visibility'
 HAD504B33021E: '為全域C++運算式new和delete宣告指定隱藏可見性'
 # "Give global types 'default' visibility and global functions and variables 'hidden' visibility by default"
-H095BFBCE25DF: "預設為全域類型指定'default'可見性，以及全域函數和變數指定'hidden'可見性"
+H095BFBCE25DF: "預設為全域類型指定 'default' 可見性，以及全域函數和變數指定 'hidden' 可見性"
 # 'Give inline C++ member functions hidden visibility by default'
 HAF1CF839FC8A: '預設為內聯C++成員函數指定隱藏可見性'
 # 'Give the maximum number of instructions that we will use for creating a floating-point immediate value'
@@ -9233,7 +9233,7 @@ HE9E6E34AE2B8: '為每個基本區塊區段指定唯一名稱'
 # 'Give unique names to every section'
 HAE1CB86AEAE6: '為每個區段指定唯一名稱'
 # 'Global Pointer Addressing Size.  The default size is 8.'
-H7DA66DD4C059: '全域指標位址大小。預設值為8。'
+H7DA66DD4C059: '全域指標位址大小。預設值為 8。'
 # 'Global Value Numbering'
 H7BB46D78F883: '全域值編號'
 # 'Global merge function pass'
@@ -9315,7 +9315,7 @@ H9EF1510D3F11: '跨程序間通過在函數高位元堆疊指標中傳遞狀態�
 # 'Harden interprocedurally by passing our state in and out of functions in the high bits of the stack pointer.'
 HD67DA497275B: '跨程序間通過在函數高位元堆疊指標中傳遞狀態，強化間接跳轉與呼叫的安全性以防止利用預測性寫入的攻擊者控制位址。此設計旨在緩解 Spectre v1.2 類型攻擊。'
 # 'Harden the value loaded *after* it is loaded by flushing the loaded bits to 1. This is hard to do in general but can be done easily for GPRs.'
-HC7A0E024F604: '強化載入後的值（在載入後）通過將載入的位元設置為1。這在一般情況下很難做到，但對GPRs來說很容易。'
+HC7A0E024F604: '強化載入後的值（在載入後）通過將載入的位元設置為 1。這在一般情況下很難做到，但對GPRs來說很容易。'
 # 'Hardware Loop Insertion'
 HD9C10B054698: '硬體迴圈插入'
 # 'Hardware multiplier use mode for MSP430'
@@ -9385,9 +9385,9 @@ H1C0F5065601C: 'Hexagon 常數擴展優化'
 # 'Hexagon early if conversion'
 H5C9514E28A85: 'Hexagon 提早if轉換'
 # 'Hexagon generate "extract" instructions'
-H7636CC8F55F3: 'Hexagon 生成"extract"指令'
+H7636CC8F55F3: 'Hexagon 生成 "extract" 指令'
 # 'Hexagon generate "insert" instructions'
-H3778EAC02853: 'Hexagon 生成"insert"指令'
+H3778EAC02853: 'Hexagon 生成 "insert" 指令'
 # 'Hexagon generate mux instructions'
 H5C45CA2F85F2: 'Hexagon 生成多路選擇指令'
 # 'Hexagon generate predicate operations'
@@ -9583,7 +9583,7 @@ H11412975A779: '若設置，則不會實際進行格式化修改'
 # "If set, don't error out on the specified warning type."
 H94EED0D743F6: '若設置，則對指定的警告類型不會導致錯誤終止'
 # 'If set, fail with exit code 1 on incomplete format.'
-H3940587B501D: '若設置，則在格式不完整時終止並返回錯誤代碼1。'
+H3940587B501D: '若設置，則在格式不完整時終止並返回錯誤代碼 1。'
 # 'If set, overrides the include sorting behavior\ndetermined by the SortIncludes style flag'
 HA0F9A020C51D: '若設置，則覆蓋由SortIncludes格式旗標決定的include排序行為'
 # 'If set, overrides the qualifier alignment style\ndetermined by the QualifierAlignment style flag'
@@ -9723,15 +9723,15 @@ H4B98027DD134: '在Lint pass中，遇到錯誤時終止。'
 # 'In the OpenMP data clauses treat `a(N)` as `a(N:N)`.'
 H1CA9E31B3F5D: '在OpenMP資料子句中，將`a(N)`視為`a(N:N)`處理。'
 # 'In the dump requested by -dump-input, print <N> input lines\nbefore and <N> input lines after any lines specified by\n-dump-input-filter.  When there are multiple occurrences of\nthis option, the largest specified <N> has precedence.  The\ndefault is 5.\n'
-HEB48ED43B50E: '在由-dump-input請求的傾印中，為任何被-dump-input-filter指定的行列前後各輸出<N>行輸入內容。若此選項被多次指定，則取最大的<N>值為優先。預設值為5。\n'
+HEB48ED43B50E: '在由-dump-input請求的傾印中，為任何被-dump-input-filter指定的行列前後各輸出 <N> 行輸入內容。若此選項被多次指定，則取最大的 <N> 值為優先。預設值為 5。\n'
 # "In the dump requested by -dump-input, print only input lines of\nkind <value> plus any context specified by -dump-input-context.\nWhen there are multiple occurrences of this option, the <value>\nthat appears earliest in the list below has precedence.  The\ndefault is 'error' when -dump-input=fail, and it's 'all' when\n-dump-input=always.\n"
-H9104E1DEC417: '在由-dump-input請求的傾印中，僅輸出指定類型<value>的行，以及由-dump-input-context指定的上下文內容。若此選項被多次指定，則列表中最早出現的<value>值為優先。當-dump-input=fail時預設值為"error"，而-dump-input=always時預設值為"all"。\n'
+H9104E1DEC417: '在由-dump-input請求的傾印中，僅輸出指定類型 <value> 的行，以及由-dump-input-context指定的上下文內容。若此選項被多次指定，則列表中最早出現的 <value> 值為優先。當-dump-input=fail時預設值為 "error"，而-dump-input=always時預設值為 "all"。\n'
 # 'In the report, sort the timers in each group in wall clock time order'
 H2F13A69F022D: '在報告中，按牆面時間順序對每個計時器組的計時器進行排序'
 # 'Include BLOCKINFO details in low level dump'
 H27C5E3DE841C: '在低階傾印中包含BLOCKINFO詳細資料'
 # "Include PTX for the following GPU architecture (e.g. sm_35) or 'all'. May be specified more than once."
-H2031AC36E8FB: '為下列GPU架構（如sm_35）包含PTX，或指定"all"。此選項可指定多於一次。'
+H2031AC36E8FB: '為下列GPU架構（如sm_35）包含PTX，或指定 "all"。此選項可指定多於一次。'
 # 'Include Parameters in templates.'
 H8654E7CEAC51: '包含模板中的參數。'
 # 'Include all attributes.'
@@ -9809,7 +9809,7 @@ H9EE07FA9B2FD: '抑制A15上S->D寄存器存取的優化'
 # 'Init Undef Pass'
 HA592C8476F8C: '初始化Undef Pass'
 # "Initialize trivial automatic stack variables. Defaults to 'uninitialized'"
-H413F6C855E54: "初始化簡單的自動堆疊變數。預設值為'uninitialized'"
+H413F6C855E54: "初始化簡單的自動堆疊變數。預設值為 'uninitialized'"
 # 'Inject absolute symbol definitions (syntax: <name>=<addr>)'
 HD553F9022403: '注入絕對符號定義（語法：<name>=<addr>）'
 # 'Inject symbol aliases (syntax: <alias-name>=<aliasee>)'
@@ -10167,7 +10167,7 @@ H7F636BA87B45: '詞法作用域層級（File=0，Compile Unit=1）。'
 # 'Libraries to link dynamically'
 H9E0097DC803F: '動態連結的程式庫'
 # "Like 'ExecutorNative' if ORC runtime provided, otherwise like 'GenericIR'"
-H4792AD158E44: '若提供ORC執行階段則類似"ExecutorNative"，否則類似"GenericIR"'
+H4792AD158E44: '若提供ORC執行階段則類似 "ExecutorNative"，否則類似 "GenericIR"'
 # 'Like -MD, but also implies -E and writes to stdout by default'
 H09E4A86636C3: '類似-MD，但同時隱含-E，並預設寫入stdout'
 # 'Like -MMD, but also implies -E and writes to stdout by default'
@@ -10233,7 +10233,7 @@ HEAF5A10A6293: '每區塊限制 SLP 排程區域的大小'
 # 'Limit the size of the seed bundle to cap compilation time.'
 H4DFB40A73CC1: '限制種子包的大小以限制編譯時間。'
 # 'Limits the range of tokens in -check file on which various features are tested. Example --check-lines=3-7 restricts testing to lines 3 to 7 (inclusive) or --check-lines=5 to restrict to one line. Default is testing entire file.'
-H2A6188976AA0: '限制在-check文件中測試各項功能的token範圍。例如--check-lines=3-7將測試範圍限制在第3到7行（包含），或--check-lines=5限制到單一行。預設是測試整個檔案。'
+H2A6188976AA0: '限制在-check文件中測試各項功能的token範圍。例如--check-lines=3-7將測試範圍限制在第 3 到 7行（包含），或--check-lines=5限制到單一行。預設是測試整個檔案。'
 # 'Linalg ODS Gen from YAML'
 H78D204B7569D: '從YAML生成Linalg ODS'
 # 'Line kind to use when printing lines.'
@@ -10297,7 +10297,7 @@ H7F26F6260A72: '用於輔助模式的編譯或模組化問題的檔案清單。�
 # 'List of functions to print disassembly for. Accept demangled names only. Only work with show-disassembly-only'
 H3054F37FF6EE: '需要列印反組譯的函數清單。僅接受解裝飾名稱。僅與show-disassembly-only一起使用'
 # "List of key and value arguments. Required keywords are 'file' and 'triple'."
-H45A6C5D3DB8C: "關鍵字和值參數清單。必要關鍵字為'file'和'triple'。"
+H45A6C5D3DB8C: "關鍵字和值參數清單。必要關鍵字為 'file' 和 'triple'。"
 # 'List of modes to link in by default into XRay instrumented binaries.'
 HA0397880FB9D: '預設連結到XRay插樁二進位檔的模式清單。'
 # 'List of symbols to export from the resulting object file'
@@ -10621,7 +10621,7 @@ H346589ED29E7: '將x8寄存器設為呼叫後保留（僅限AArch64）'
 # 'Make the x9 register call-saved (AArch64 only)'
 H2A86BF8B5845: '將x9寄存器設為呼叫後保留（僅限AArch64）'
 # 'Make time trace capture verbose event details (e.g. source filenames). This can increase the size of the output by 2-3 times'
-HAFFB278A14B8: '在時間追蹤捕獲中包含詳細事件資訊（例如原始檔名稱）。這可能會使輸出大小增加2-3倍'
+HAFFB278A14B8: '在時間追蹤捕獲中包含詳細事件資訊（例如原始檔名稱）。這可能會使輸出大小增加 2-3倍'
 # 'Mangling number exceeds limit (65535)'
 HB23269E224B2: '裝飾符號編號超過限制（65535）'
 # 'Manifest Attributor internal string attributes.'
@@ -10785,7 +10785,7 @@ H85D97309D239: '用於內聯成本計算的alloca最大大小'
 # 'Maximum allowed iterations to unroll under pragma unroll full.'
 H369A26E92574: 'pragma unroll full指令下的最大展開次數'
 # 'Maximum amount of memory to use. 0 disables check. Defaults to 400MB (800MB under valgrind, 0 with sanitizers).'
-HD9F29E050069: '最大可用記憶體容量。0表示禁用檢查。預設值為400MB（valgrind環境下為800MB，使用檢查器時設為0）。'
+HD9F29E050069: '最大可用記憶體容量。0表示禁用檢查。預設值為 400MB（valgrind環境下為 800MB，使用檢查器時設為 0）。'
 # 'Maximum amount of nodes to process while searching SCEVUnknown Phi strongly connected components'
 H733D2DA20417: '在搜尋SCEVUnknown Phi強連通分量時要處理的最大節點數'
 # 'Maximum amount of shared memory to use.'
@@ -11069,13 +11069,13 @@ H78B91828296F: '要保留區塊所需的最小執行次數。'
 # "Minimum priority, runs on idle CPUs. May leave 'performance' cores unused."
 H2308F82368EA: '最低優先級，運行於空閒的CPU。可能導致『效能』核心閒置。'
 # "Minimum profile count required for an optimization remark to be output. Use 'auto' to apply the threshold from profile summary"
-H3D2B4D99467F: "需要輸出優化註記的最小剖析計數。使用'auto'以從剖析摘要應用門檻值。"
+H3D2B4D99467F: "需要輸出優化註記的最小剖析計數。使用 'auto' 以從剖析摘要應用門檻值。"
 # "Minimum profile count required for an optimization remark to be output. Use 'auto' to apply the threshold from profile summary."
-H05750FA1DE8F: "需要輸出優化註記的最小剖析計數。使用'auto'以從剖析摘要應用門檻值。"
+H05750FA1DE8F: "需要輸出優化註記的最小剖析計數。使用 'auto' 以從剖析摘要應用門檻值。"
 # 'Minimum ratio comparing relative sizes of each outline candidate and original function'
 H4C5E36FE2F68: '比較每個提綱候選與原始函數相對大小的最小比率。'
 # 'Minimum relative gain per loop threshold (1/X). Defaults to 12.5%'
-H2DECB545864A: '每個迴圈的最小相對增益閾值（1/X）。預設為12.5%。'
+H2DECB545864A: '每個迴圈的最小相對增益閾值（1/X）。預設為 12.5%。'
 # 'Minimum time granularity (in microseconds) traced by time profiler'
 H82ABB54FDFA0: '時間剖析器追蹤的最小時間粒度（以微秒為單位）。'
 # 'Minimum type size in bits for breaking large PHI nodes'
@@ -11137,7 +11137,7 @@ HEC0DF6B1AD3C: '必須指定至少 '
 # 'My Pass Name'
 H68A400666676: '我的Pass名稱'
 # 'N must be a power of two. Align loops to the boundary'
-H2A7AB317ED00: 'N必須是2的冪次方。將迴圈對齊到邊界'
+H2A7AB317ED00: 'N必須是 2 的冪次方。將迴圈對齊到邊界'
 # 'NVPTX Address space based Alias Analysis'
 H9D1213E22820: 'NVPTX基於位址空間的別名分析'
 # 'NVPTX Address space based Alias Analysis Wrapper'
@@ -11243,7 +11243,7 @@ H24AE7DC3B6A4: '無解構函式'
 # 'No effect'
 H7ED12CB7B709: '無效'
 # 'No extract instruction with offset 0'
-HEB2933468549: '無位移為0的extract指令'
+HEB2933468549: '無位移為 0 的extract指令'
 # 'No implicit externals allowed'
 H6CDA41F7B635: '禁止隱式外部符號'
 # 'No implicit typing allowed unless overridden by IMPLICIT statements'
@@ -11267,7 +11267,7 @@ H9A9707BE07DA: '無。'
 # 'Normalize integers in CFI indirect call type signature checks'
 H47F05B50721C: '在CFI間接呼叫類型簽章檢查中標準化整數'
 # "Not emit the visibility attribute for asm in AIX OS or give all symbols 'unspecified' visibility in XCOFF object file"
-H98251062C447: '在AIX作業系統中不發出asm的可見性屬性，或在XCOFF物件檔中將所有符號的可見性設為"unspecified"'
+H98251062C447: '在AIX作業系統中不發出asm的可見性屬性，或在XCOFF物件檔中將所有符號的可見性設為 "unspecified"'
 # 'Number limit for gluing ld/st of memcpy.'
 HD8077326B9B0: 'memcpy的ld/st連接數量上限'
 # 'Number of addresses from which to enable MIMG NSA.'
@@ -11309,13 +11309,13 @@ HEC293753B227: '要使用的平行完整LTO程式碼生成分割數，僅限ld.l
 # 'Number of registers to limit to when printing regmask operands in IR dumps. unlimited = -1'
 H0373C047E939: '在IR轉儲時列印regmask操作數所限制的寄存器數量。無限 = -1'
 # 'Number of seconds program is allowed to run before it is killed (default is 300s), 0 disables timeout'
-HE6EB2161F536: '允許程式執行的秒數，在此之後程序將被終止（預設值為300秒），0 表示禁用超時'
+HE6EB2161F536: '允許程式執行的秒數，在此之後程序將被終止（預設值為 300 秒），0 表示禁用超時'
 # "Number of threads in the 'x' dimension"
-H07DD57A90CC5: "'x'維度的執行緒數量"
+H07DD57A90CC5: "'x' 維度的執行緒數量"
 # "Number of threads in the 'y' dimension"
-H986B3D9F34E9: "'y'維度的執行緒數量"
+H986B3D9F34E9: "'y' 維度的執行緒數量"
 # "Number of threads in the 'z' dimension"
-HFC9646CFE097: "'z'維度的執行緒數量"
+HFC9646CFE097: "'z' 維度的執行緒數量"
 # 'Number of threads to use (0 = auto)'
 H9A06154F2AD2: '要使用的執行緒數量（0 = 自動）'
 # 'Number of times to divide chunks prior to first test'
@@ -11327,13 +11327,13 @@ HEBDA566F30F3: '打亂並驗證使用清單的次數'
 # 'Number of tracked SGPRs before initiating hazard cull on memory wait'
 H34DB613CB239: '在記憶體等待時啟動危害篩選前追蹤的SGPR數量'
 # "Number of triangle-shaped-CFG's that need to be in a row for the triangle tail duplication heuristic to kick in. 0 to disable."
-HAF152F5B6E3F: '需要連續的三角形形狀控制流圖數量，以便啟動三角形尾部複製的启发式演算法。設0可禁用。'
+HAF152F5B6E3F: '需要連續的三角形形狀控制流圖數量，以便啟動三角形尾部複製的启发式演算法。設 0 可禁用。'
 # 'Number of unswitch candidates that are ignored when calculating cost multiplier.'
 H4873CA41A98E: '在計算成本倍數時被忽略的unswitch候選項數量'
 # 'Number of uses of a base pointer to check before it is no longer considered for post-indexing.'
 H02421600E168: '在不再將基址指標考慮進後索引前，要檢查的基址指標使用次數'
 # 'OBJECT_MODE setting %0 is not recognized and is not a valid setting'
-HEC8A063EC23B: 'OBJECT_MODE設定%0未被識別且不是有效設定'
+HEC8A063EC23B: 'OBJECT_MODE設定 %0 未被識別且不是有效設定'
 # 'ODS output filename'
 H1E3A5BE01485: 'ODS輸出檔名'
 # 'OPTIONS:\n'
@@ -11473,7 +11473,7 @@ H8C18E65FDB94: '僅包含在生成的最佳化紀錄中符合指定正則表達�
 # 'Only inline functions explicitly or implicitly marked inline'
 H4FB05EC4AB48: '僅內聯明確或隱式標記為inline的函數'
 # 'Only instrument 1 of N groups'
-HE6DD6434319A: '僅對N組中的1組進行插樁'
+HE6DD6434319A: '僅對N組中的 1 組進行插樁'
 # 'Only keep the intrinsics with the specified substring in their record name'
 HCC2CC4639600: '僅保留其名稱中包含指定子字串的內建函數'
 # 'Only lfence before groups of terminators where at least one branch instruction has an input to the addressing mode that is a register other than %rip.'
@@ -11535,7 +11535,7 @@ H159246FC6C6B: '僅分割大小小於或等於JumpTableSizeThreshold的跳躍表
 # 'Only supported on AArch64, PowerPC, RISC-V, SPARC, SystemZ, and X86'
 H6BC9222A7886: '僅支援AArch64、PowerPC、RISC-V、SPARC、SystemZ和X86架構'
 # 'Only try to inject loop invariant conditions and unswitch on them to eliminate branches that are not-taken 1/<this option> times or less.'
-H93BBEDA4C81E: '僅嘗試注入迴圈不變條件，並對其進行unswitch以消除未被採取次數小於或等於1/<此選項>次的分支。'
+H93BBEDA4C81E: '僅嘗試注入迴圈不變條件，並對其進行unswitch以消除未被採取次數小於或等於 1/<此選項>次的分支。'
 # 'Only use DAG-combiner alias analysis in this function'
 H9A1CF1A6CF3A: '僅在此函數中使用DAG-combiner別名分析'
 # 'Only use warnings from specified component'
@@ -11703,13 +11703,13 @@ H6461D2D7A8F6: "OpenMP 目標無效: '%0'"
 # 'Optimise without changing ABI'
 H19D2D13E9ED7: '在不改變ABI的情況下進行優化'
 # 'Optimization level 0. Similar to clang -O0. Same as -passes="default<O0>"'
-H809F6417B5CD: '優化級別0。與clang -O0類似。與-passes="default<O0>"相同'
+H809F6417B5CD: '優化級別 0。與clang -O0類似。與-passes="default<O0>"相同'
 # 'Optimization level 1. Similar to clang -O1. Same as -passes="default<O1>"'
-H563E0780E60E: '優化級別1。與clang -O1類似。與-passes="default<O1>"相同'
+H563E0780E60E: '優化級別 1。與clang -O1類似。與-passes="default<O1>"相同'
 # 'Optimization level 2. Similar to clang -O2. Same as -passes="default<O2>"'
-H71099B09BC66: '優化級別2。與clang -O2類似。與-passes="default<O2>"相同'
+H71099B09BC66: '優化級別 2。與clang -O2類似。與-passes="default<O2>"相同'
 # 'Optimization level 3. Similar to clang -O3. Same as -passes="default<O3>"'
-H73EA61C4E41D: '優化級別3。與clang -O3類似。與-passes="default<O3>"相同'
+H73EA61C4E41D: '優化級別 3。與clang -O3類似。與-passes="default<O3>"相同'
 # 'Optimization level for NVVM compilation'
 HA23F3D2204EA: 'NVVM編譯的優化級別'
 # "Optimization level. [-O0, -O1, -O2, or -O3] (default = '-O2')"
@@ -11731,7 +11731,7 @@ HD2F645235970: '優化位址模式'
 # 'Optimize callbacks'
 H4FA5D57DC24A: '優化回呼函數'
 # 'Optimize calls with "returned" attributes for WebAssembly'
-H77D4D84768F4: '為WebAssembly優化帶有"returned"屬性的呼叫'
+H77D4D84768F4: '為WebAssembly優化帶有 "returned" 屬性的呼叫'
 # 'Optimize for code generation'
 HB09B7FAA4243: '優化程式碼生成'
 # 'Optimize for size'
@@ -12011,7 +12011,7 @@ HBDB4D3B42575: '使用剖面資訊分割資料區段。'
 # 'Partition functions into N groups and select only functions in group i to be instrumented using -fprofile-selected-function-group'
 H245EBE517AA5: '將函數分為N個群組，並僅選擇第i群組的函數進行插樿，使用-fprofile-selected-function-group選項'
 # 'Partition functions into N groups using -fprofile-function-groups and select only functions in group i to be instrumented. The valid range is 0 to N-1 inclusive'
-HE1BA0DFA9946: '使用-fprofile-function-groups將函數分為N個群組，並僅選擇第i群組的函數進行插樿。有效範圍為0到N-1（包含端點）'
+HE1BA0DFA9946: '使用-fprofile-function-groups將函數分為N個群組，並僅選擇第i群組的函數進行插樿。有效範圍為 0 到N-1（包含端點）'
 # 'Pascal string is too long'
 HDF5B602956C9: 'Pascal字串過長'
 # 'Pass -b <arg> to the linker on AIX'
@@ -12055,17 +12055,17 @@ H8F2A17B54334: '傳遞一個工作負載定義。此為包含 JSON 字典的檔�
 # 'Pass all reduction arguments by reference'
 H1F6E6E7DA880: '以引用方式傳遞所有約束參數'
 # 'Pass the comma separated arguments in <arg> to the assembler'
-H0BB4ECAE0BD9: '<arg>中以逗號分隔的參數傳遞給組譯器'
+H0BB4ECAE0BD9: '<arg> 中以逗號分隔的參數傳遞給組譯器'
 # 'Pass the comma separated arguments in <arg> to the linker'
-H01CAEC128AC9: '<arg>中以逗號分隔的參數傳遞給連結器'
+H01CAEC128AC9: '<arg> 中以逗號分隔的參數傳遞給連結器'
 # 'Pass the comma separated arguments in <arg> to the preprocessor'
-H596C87A5B391: '<arg>中以逗號分隔的參數傳遞給預編譯器'
+H596C87A5B391: '<arg> 中以逗號分隔的參數傳遞給預編譯器'
 # 'Passes available:'
 H13989372E812: '可用的Passes：'
 # 'Path and name to DWP file.'
 H6E3C7CBCF218: 'DWP文件的路徑和名稱。'
 # 'Path of .dwp file. When not specified, it will be <binary>.dwp in the same directory as the main binary.'
-H743B0B321E91: '包含.dwp文件的路徑。若未指定，將在主二進位檔的同一目錄下使用<binary>.dwp。'
+H743B0B321E91: '包含.dwp文件的路徑。若未指定，將在主二進位檔的同一目錄下使用 <binary>.dwp。'
 # 'Path of debug info binary, llvm-profgen will load the DWARF info from it instead of the executable binary.'
 H7CB4490678CE: '除錯資訊二進位檔的路徑。llvm-profgen將從此處載入DWARF資訊，而非可執行檔。'
 # 'Path of perf-script trace created by Linux perf tool with `script` command(the raw perf.data should be profiled with -b)'
@@ -12081,7 +12081,7 @@ H946923D050AC: '使用`--skip-symbolization`參數生成的未符號化分析檔
 # 'Path to CSV file containing lines of function names and attributes to add to them in the form of `f1,attr1` or `f2,attr2=str`.'
 HAA93B63D725F: '包含以逗號分隔的函數名稱和屬性清單的CSV文件路徑，格式為`f1,attr1`或`f2,attr2=str`。'
 # 'Path to SavedModel from the previous training iteration.\nThe directory is also expected to contain a JSON specification of the \noutputs expected to be logged, where the first entry must be the \ninlining decision. The file containing the specification should be \ncalled output_spec.json. The expected JSON value is an array of \ndictionaries. Each dictionary should have 2 keys: \n\n- "tensor_spec, followed by the TensorSpec description of the\noutput; and \n- "logging_name", a string indicating the name to use when\nlogging the output values. \n\nExample:\n[\n  {\n    "logging_name" : "some_name", \n    "tensor_spec" : { \n      "name" : "model_name", \n      "port" : 0,\n      "shape" : [2, 3],\n      "type" : "float"\n      }\n  }\n]\n\nThe first value must always correspond to the decision.'
-H9AB7FF7DDB14: '前一次訓練迭代的SavedModel路徑。\n目錄中應包含JSON格式的輸出規格說明文件，第一項必須是內聯決策。規格說明文件應命名為output_spec.json，其JSON結構為字典陣列，每個字典需包含2個鍵：\n\n- "tensor_spec"，後接輸出的TensorSpec描述；\n- "logging_name"，用於記錄輸出值的字符串名稱。\n\n範例：\n[\n  {\n    "logging_name" : "some_name", \n    "tensor_spec" : { \n      "name" : "model_name", \n      "port" : 0,\n      "shape" : [2, 3],\n      "type" : "float"\n      }\n  }\n]\n\n第一個值必須始終對應決策結果。'
+H9AB7FF7DDB14: '前一次訓練迭代的SavedModel路徑。\n目錄中應包含JSON格式的輸出規格說明文件，第一項必須是內聯決策。規格說明文件應命名為output_spec.json，其JSON結構為字典陣列，每個字典需包含 2 個鍵：\n\n- "tensor_spec"，後接輸出的TensorSpec描述；\n- "logging_name"，用於記錄輸出值的字符串名稱。\n\n範例：\n[\n  {\n    "logging_name" : "some_name", \n    "tensor_spec" : { \n      "name" : "model_name", \n      "port" : 0,\n      "shape" : [2, 3],\n      "type" : "float"\n      }\n  }\n]\n\n第一個值必須始終對應決策結果。'
 # 'Path to a directory containing a .clang-format file\ndescribing a formatting style to use for formatting\ncode when -style=file.\n'
 H1C68FD05289D: '包含.clang-format格式設定檔的目錄路徑\n當使用-style=file格式時，用於代碼格式化的樣式描述文件。\n'
 # 'Path to a system assembler, picked up on AIX only'
@@ -12089,7 +12089,7 @@ HD76EB0189931: '僅在AIX系統上使用的系統組譯器路徑'
 # 'Path to binary from which the profile was collected.'
 HDF7F0FA583A9: '分析資料來源二進位檔的路徑。'
 # 'Path to file containing newline-separated [<weight>,]<filename> entries'
-H39AF8CCE2C18: '包含以新行分隔的[<權重>,]<filename>條目的文件路徑'
+H39AF8CCE2C18: '包含以新行分隔的[<權重>,]<filename> 條目的文件路徑'
 # 'Path to file containing the list of function symbols used to populate profile symbol list'
 H85546B6474C7: '用於建立分析符號清單的函數符號列表文件路徑'
 # 'Path to ignorelist file for sanitizers'
@@ -12149,7 +12149,7 @@ HF8B0216049CB: '內聯需要更改PSTATE.SM函數的處罰值'
 # 'Percentage of prologue execution count to use as threshold when evaluating whether a block is cold enough to be profitable to move eligible spills there'
 HB814EF09C393: '使用函數prologue的執行計數百分比作為閾值，用以評估是否將符合條件的溢出移動到冷區塊是否值得'
 # 'Percentage threshold for splitting single-instruction critical edge. If the branch threshold is higher than this threshold, we allow speculative execution of up to 1 instruction to avoid branching to splitted critical edge'
-HF3E418A57D78: '分支閾值高於此閾值時，允許預測執行最多1條指令以避免分支到分割的關鍵邊'
+HF3E418A57D78: '分支閾值高於此閾值時，允許預測執行最多 1 條指令以避免分支到分割的關鍵邊'
 # 'Percentage threshold of matched basic blocks at which stale profile inference is executed.'
 H38AE58F6A0A2: '當匹配的基本區塊百分比閾值達到時執行過時剖面推斷。'
 # 'Percentile of profile quality distributions over hottest functions to report.'
@@ -12447,7 +12447,7 @@ H1C11371CF193: '儲存庫的行代碼前綴。'
 # "Prefix to use for outputs (default: 'bugpoint')"
 H51241093AFDE: "輸出使用的前綴（預設：'bugpoint'）"
 # "Prefix to use from check file (defaults to 'CHECK')"
-HC4A6D5922731: "從檢查檔中使用的前綴（預設為'CHECK'）"
+HC4A6D5922731: "從檢查檔中使用的前綴（預設為 'CHECK'）"
 # "Prefixes for aliases that don't need to be renamed, separated by a comma"
 H93C76DC96906: '不需要重新命名的別名前綴，以逗號分隔。'
 # "Prefixes for functions that don't need to be renamed, separated by a comma"
@@ -12731,17 +12731,17 @@ H333E30843F56: '顯示pass名稱及其序號'
 # 'Print performance metrics and statistics'
 HE4EAA5755D11: '顯示效能指標與統計數據'
 # "Print postdominance tree of function to 'dot' file"
-HB29C66E944CC: "將函數的後支配樹輸出至'dot'檔案"
+HB29C66E944CC: "將函數的後支配樹輸出至 'dot' 檔案"
 # "Print postdominance tree of function to 'dot' file (with no function bodies)"
-HD6176265DDFA: "將函數的後支配樹（不含函數主體）輸出至'dot'檔案"
+HD6176265DDFA: "將函數的後支配樹（不含函數主體）輸出至 'dot' 檔案"
 # 'Print pretty debug info in MLIR output'
 H1D9ED83CA568: '在MLIR輸出中顯示格式化的除錯資訊'
 # 'Print pseudo probe section and disassembled info.'
 H32640273947C: '顯示虛擬探針區段與反組譯資訊。'
 # "Print regions of function to 'dot' file"
-HA2F7AC936E9B: "將函數的區塊結構輸出至'dot'檔案"
+HA2F7AC936E9B: "將函數的區塊結構輸出至 'dot' 檔案"
 # "Print regions of function to 'dot' file (with no function bodies)"
-HB4D8B8B65FF0: "將函數的區塊結構（不含函數主體）輸出至'dot'檔案"
+HB4D8B8B65FF0: "將函數的區塊結構（不含函數主體）輸出至 'dot' 檔案"
 # 'Print register file statistics'
 HD3E0FCA5570D: '顯示記憶體寄存器統計數據'
 # 'Print registered symbol, section, got and stub addresses'
@@ -12989,9 +12989,9 @@ HF00163550893: '修剪無關Phi節點間的依賴關係'
 # 'Prune loop carried order dependences.'
 H49F00DC5D681: '修剪迴圈攜帶的順序依賴關係'
 # 'Put MODULE files in <dir>'
-HEED5CC89CC67: '將MODULE檔放入<dir>'
+HEED5CC89CC67: '將MODULE檔放入 <dir>'
 # 'Put crash-report files in <dir>'
-H837FCDFF092D: '將當機報告檔放入<dir>'
+H837FCDFF092D: '將當機報告檔放入 <dir>'
 # 'Put each data item in its own section'
 HF905C168CBCB: '將每個資料項目置於獨立區段'
 # 'Put each function in its own section'
@@ -12999,7 +12999,7 @@ H169F18C51BFF: '將每個函數置於獨立區段'
 # 'Put global and static data smaller than the limit into a special section'
 H7B737FFA3469: '將小於限制值的全域和靜態資料放入特殊區段'
 # 'Put objects of at most <size> bytes into small data section (MIPS / Hexagon)'
-HB5EE66FF14A5: '將最多<size>個位元組的物件放入小型資料區段（MIPS/Hexagon）'
+HB5EE66FF14A5: '將最多 <size> 個位元組的物件放入小型資料區段（MIPS/Hexagon）'
 # 'Putting Jump Table in function section'
 H0F2B2856EA39: '將跳轉表置於函數區段中'
 # 'Qualified name of the symbol being queried.'
@@ -13079,7 +13079,7 @@ H7D576AB43EFF: 'RISC-V寄存器分配後假指令展開pass'
 # 'RISC-V pseudo instruction expansion pass'
 H0A43861EEE99: 'RISC-V虛指令展開Pass'
 # "RISC-V type %0 requires the '%1' extension"
-HD2DE400562E4: "RISC-V類型%0需要'%1'擴展"
+HD2DE400562E4: "RISC-V類型 %0 需要'%1'擴展"
 # 'ROCm device library path. Alternative to rocm-path.'
 H671F96D79AC7: 'ROCm裝置庫路徑。rocm-path的替代選項。'
 # 'ROCm installation path, used for finding and automatically linking required bitcode libraries.'
@@ -13229,7 +13229,7 @@ H34FEDDEF1D08: '遠端執行客戶端（rsh/ssh）'
 # 'Remote execution client (rsh/ssh)'
 H9FB0D35F3462: '移除.symtab區段'
 # 'Remove .symtab section'
-HDFF82FC1A75B: "從要編譯的裝置列表中移除CUDA/HIP卸載裝置架構（例如sm_35、gfx906）。'all'會將列表重置為預設值。"
+HDFF82FC1A75B: "從要編譯的裝置列表中移除CUDA/HIP卸載裝置架構（例如sm_35、gfx906）。'all' 會將列表重置為預設值。"
 # "Remove CUDA/HIP offloading device architecture (e.g. sm_35, gfx906) from the list of devices to compile for. 'all' resets the list to its default value."
 HC1BC07C832AB: '移除載入至偽用法'
 # 'Remove Loads Into Fake Uses'
@@ -13295,7 +13295,7 @@ H4BF82E4A463A: '將內建函數替換為向量函式庫的呼叫'
 # 'Replace narrow shifts with wider shifts.'
 HF4525F5A5F2E: '將窄位移運算替換為更寬的位移運算'
 # 'Replace occurrences of __nvvm_reflect() calls with 0/1'
-H9A0C0F0562E0: '將__nvvm_reflect()呼叫的所有出現位置替換為0/1'
+H9A0C0F0562E0: '將__nvvm_reflect()呼叫的所有出現位置替換為 0/1'
 # 'Replace physical registers with virtual registers'
 H2480E837105C: '將實體寄存器替換為虛擬寄存器'
 # 'Replace pointer out arguments with struct returns for non-private address space'
@@ -13307,7 +13307,7 @@ H722DD7E4F6B2: '用於重新命名的字串替換'
 # 'Replace target triples in input files with this triple'
 H1FCD419A56EC: '將輸入檔中的目標三元組替換为此三元組'
 # 'Replace the contents of the <from> file with the contents of the <to> file'
-H96ECB37ACA86: '將<from>檔案的內容替換為<to>檔案的內容'
+H96ECB37ACA86: '將 <from> 檔案的內容替換為 <to> 檔案的內容'
 # 'Replace unspecified target triples in input files with this triple'
 H1555B263A14F: '將輸入檔中未指定的目標三元組替換为此三元組'
 # 'Replacement Options'
@@ -13953,13 +13953,13 @@ H687BF304766B: '從通用指令中選擇目標指令'
 # 'Select the HWAddressSanitizer ABI to target (interceptor or platform, default interceptor). This option is currently unused.'
 H2E53C4CE5E14: '選擇目標HWAddressSanitizer的ABI（中繼器或平台，預設為中繼器）。此選項目前未使用。'
 # "Select the SIMD extension(s) to be enabled in LoongArch either 'none', 'lsx', 'lasx'."
-H58773894FD9F: "選擇要在LoongArch中啟用的SIMD擴展，選項為'none'、'lsx'、'lasx'。"
+H58773894FD9F: "選擇要在LoongArch中啟用的SIMD擴展，選項為 'none'、'lsx'、'lasx'。"
 # 'Select the asm variant (integer) to use for output (3: unspecified)'
 H269BE00B3354: '選擇輸出使用的整數型asm變體（3：未指定）'
 # 'Select the assembly style for input'
 HC379BD26B358: '選擇輸入的組裝語言格式'
 # "Select the container format for clang modules and PCH. Supported options are 'raw' and 'obj'."
-H35A81EACF6D7: "選擇clang模組和預編譯標頭（PCH）的容器格式。支援選項為'raw'和'obj'。"
+H35A81EACF6D7: "選擇clang模組和預編譯標頭（PCH）的容器格式。支援選項為 'raw' 和 'obj'。"
 # 'Select the frame chain model used to emit frame records (Arm only).'
 H6E15DFB39F91: '選擇用於發射frame記錄的frame chain模型（僅Arm）。'
 # 'Select the kind of output desired'
@@ -13975,7 +13975,7 @@ HA1F9E472551C: '選擇教程版本'
 # 'Select underlying type for wchar_t'
 H871CFB3D3DBF: '設定wchar_t的底層類型'
 # "Select which XRay instrumentation points to emit. Options: all, none, function-entry, function-exit, function, custom. Default is 'all'.  'function' includes both 'function-entry' and 'function-exit'."
-HF1CF9325D610: "選擇要發射的XRay插樁點類型。選項：all、none、function-entry、function-exit、function、custom。預設為'all'。 'function' 包含 'function-entry'和'function-exit'。"
+HF1CF9325D610: "選擇要發射的XRay插樁點類型。選項：all、none、function-entry、function-exit、function、custom。預設為 'all'。 'function' 包含 'function-entry'和'function-exit'。"
 # 'Select which denormal numbers the code is permitted to require'
 H2AC882EF26F4: '設定程式允許要求的非規格化數值類型'
 # 'Select which denormal numbers the code is permitted to require for float'
@@ -14007,9 +14007,9 @@ HC407FF843F6C: '設定LTO模式'
 # 'Set LTO mode for offload compilation'
 HAFC85CCA6F44: '設定用於卸載編譯的LTO模式'
 # 'Set OpenMP version (e.g. 45 for OpenMP 4.5, 51 for OpenMP 5.1). Default value is 11 for Flang'
-HB4B241AD39C3: '設定OpenMP版本（例如45對應OpenMP 4.5，51對應OpenMP 5.1）。預設值為Flang的11'
+HB4B241AD39C3: '設定OpenMP版本（例如 45 對應OpenMP 4.5，51對應OpenMP 5.1）。預設值為Flang的 11'
 # 'Set OpenMP version (e.g. 45 for OpenMP 4.5, 51 for OpenMP 5.1). Default value is 51 for Clang'
-H81EB65FB7662: '設定OpenMP版本（例如45對應OpenMP 4.5，51對應OpenMP 5.1）。預設值為Clang的51'
+H81EB65FB7662: '設定OpenMP版本（例如 45 對應OpenMP 4.5，51對應OpenMP 5.1）。預設值為Clang的 51'
 # 'Set ThinLTO cache entry expiration time.'
 HAC92585FAE36: '設定ThinLTO快取條目過期時間。'
 # 'Set ThinLTO cache pruning directory maximum number of files.'
@@ -14025,7 +14025,7 @@ H407DDA0187F9: '設定__fastcall為預設調用約定'
 # 'Set __regcall as a default calling convention'
 HBA376537ABE7: '設定__regcall為預設調用約定'
 # 'Set __regcall4 as a default calling convention to respect __regcall ABI v.4'
-H58F2490637FE: '設定__regcall4為預設調用約定以符合__regcall ABI版本4'
+H58F2490637FE: '設定__regcall4為預設調用約定以符合__regcall ABI版本 4'
 # 'Set __stdcall as a default calling convention'
 HE1D6B80E6229: '設定__stdcall為預設調用約定'
 # 'Set __vectorcall as a default calling convention'
@@ -14155,7 +14155,7 @@ HD5A0F69F41ED: '設定預設最通用的表示方式為單一繼承'
 # 'Set the default most-general representation to virtual inheritance'
 H106974060665: '設定預設最通用的表示方式為虛基類繼承'
 # 'Set the default real kind to an 8 byte wide type'
-H7B0DABF8B0EB: '設定預設實數類型為8字節寬的類型'
+H7B0DABF8B0EB: '設定預設實數類型為 8 字節寬的類型'
 # 'Set the default structure layout to be compatible with the Microsoft compiler standard'
 H10F147D00248: '設定結構布局與Microsoft編譯器標準相容'
 # 'Set the default symbol visibility for all global definitions'
@@ -14165,7 +14165,7 @@ H814D918A5F74: '設定部署目標為指定的作業系統及其版本'
 # 'Set the device id.'
 H4C967743D4CC: '設定裝置ID。'
 # "Set the driver mode to either 'gcc', 'g++', 'cpp', 'cl' or 'flang'"
-HD0838A0BABB3: "設定驅動程式模式為'gcc'、'g++'、'cpp'、'cl'或'flang'"
+HD0838A0BABB3: "設定驅動程式模式為 'gcc'、'g++'、'cpp'、'cl' 或 'flang'"
 # 'Set the kind of module destructors emitted by AddressSanitizer instrumentation. These destructors are emitted to unregister instrumented global variables when code is unloaded (e.g. via `dlclose()`).'
 H83083E1D2A16: '設定AddressSanitizer插樁所發出的模組析構函式的類型。這些析構函式用於在代碼被卸載時（例如透過`dlclose()`）取消註冊被插樁的全域變數。'
 # 'Set the loop counter bitwidth'
@@ -14217,17 +14217,17 @@ H6EBBEB07E8B0: '設定執行緒數量'
 # 'Set the out-of-process executor'
 HAF02B074B342: '設定外部處理執行器'
 # 'Set the output <file> for debug infos'
-HA5E541919277: '設定調適資訊的輸出<file>'
+HA5E541919277: '設定調適資訊的輸出 <file>'
 # 'Set the p2align operands for WebAssembly loads and stores'
 H7736F9C56939: '設定WebAssembly載入和儲存的p2align操作數'
 # 'Set the parallelization strategy'
 HF0A794612D46: '設定並行化策略'
 # "Set the profile instrumentation burst duration, which can range from 1 to the value of 'sampled-instr-period' (0 is invalid). This number of samples will be recorded for each 'sampled-instr-period' count update. Setting to 1 enables simple sampling, in which case it is recommended to set 'sampled-instr-period' to a prime number."
-H5CA10C80C24A: "設定配置文件插樁的突发持續時間，其範圍從1到'sampled-instr-period'的值（0無效）。每個'sampled-instr-period'計數更新將記錄此數量的樣本。設置為1可啟用簡易採樣，此時建議將'sampled-instr-period'設置為質數。"
+H5CA10C80C24A: "設定配置文件插樁的突发持續時間，其範圍從 1 到'sampled-instr-period'的值（0無效）。每個'sampled-instr-period'計數更新將記錄此數量的樣本。設置為 1 可啟用簡易採樣，此時建議將'sampled-instr-period'設置為質數。"
 # "Set the profile instrumentation sample period. A sample period of 0 is invalid. For each sample period, a fixed number of consecutive samples will be recorded. The number is controlled by 'sampled-instr-burst-duration' flag. The default sample period of 65536 is optimized for generating efficient code that leverages unsigned short integer wrapping in overflow, but this is disabled under simple sampling (burst duration = 1)."
-HC029DE20A3E1: "設定配置文件插樸的採樣週期。0的採樣週期無效。每個採樣週期將記錄固定數量的連續樣本。此數量由'sampled-instr-burst-duration'旗標控制。預設的65536採樣週期經過最佳化，可生成有效使用無符號短整數溢位的程式碼，但在簡易採樣（burst duration=1）時此功能被禁用。"
+HC029DE20A3E1: "設定配置文件插樸的採樣週期。0的採樣週期無效。每個採樣週期將記錄固定數量的連續樣本。此數量由'sampled-instr-burst-duration'旗標控制。預設的 65536 採樣週期經過最佳化，可生成有效使用無符號短整數溢位的程式碼，但在簡易採樣（burst duration=1）時此功能被禁用。"
 # "Set the rsp quoting to either 'posix', or 'windows'"
-HFF7A11383873: "設定rsp引號格式為'posix'或'windows'"
+HFF7A11383873: "設定rsp引號格式為 'posix' 或 'windows'"
 # 'Set the stack alignment'
 HAAE3F7EC9ADE: '設定堆疊對齊方式'
 # 'Set the stack probe size'
@@ -14583,7 +14583,7 @@ HF556E14613B2: '要省略的來源前綴'
 # "Source-level compatibility for Altivec vectors (for PowerPC targets). This includes results of vector comparison (scalar for 'xl', vector for 'gcc') as well as behavior when initializing with a scalar (splatting for 'xl', element zero only for 'gcc'). For 'mixed', the compatibility is as 'gcc' for 'vector bool/vector pixel' and as 'xl' for other types. Current default is 'mixed'."
 HCF923B012626: '源代碼層級的Altivec向量兼容性（針對PowerPC目標）。這包括向量比較的結果（xl為標量、gcc為向量）以及用純量初始化時的行為（xl進行展開、gcc僅保留第一個元素）。設定mixed時，vector bool/vector pixel類型採用gcc兼容性，而其他類型則使用xl。目前預設為mixed。'
 # 'SourceLocation in file %0 at offset %1 is invalid'
-H2A6519004798: '文件%0中偏移量%1的來源位置無效'
+H2A6519004798: '文件 %0 中偏移量 %1 的來源位置無效'
 # 'Spawn a separate process for each cc1'
 H4079AEA987DF: '為每個cc1啟動獨立的處理程序'
 # 'Spawns a subprocess for each snippet execution, allows for the use of memory annotations'
@@ -14597,7 +14597,7 @@ HAF01AE884575: '指定一組不受TOC資料轉換影響的變數。'
 # 'Specifies a list of variables to which the TOC data transformation will be applied.'
 H33958769FAEF: '指定一組要應用TOC資料轉換的變數。'
 # "Specifies preferred vector width for auto-vectorization. Defaults to 'none' which allows target specific decisions."
-H30D4DB622AB0: "指定自動向量化時的偏好向量寬度。預設值為'none'，允許目標平台自行決定。"
+H30D4DB622AB0: "指定自動向量化時的偏好向量寬度。預設值為 'none'，允許目標平台自行決定。"
 # 'Specifies that the sample profile is accurate'
 H3A3F53CE7955: '指定剖面樣本是準確的'
 # 'Specifies the JITDylib to be used for any subsequent -extra-module arguments.'
@@ -14615,11 +14615,11 @@ H7C74E7BEFD7B: '指定 ::operator new(size_t) 所保證的最大對齊值'
 # 'Specifies the name we should consider the input file'
 H048BF6366B06: '指定我們應視為輸入檔名稱的名稱'
 # 'Specifies the size of batches for processing CUs. Higher number has better performance, but more memory usage. Default value is 1.'
-HE1BE8B43F7F0: '指定處理CU時的批次大小。數值越大，效能越好，但記憶體使用量越高。預設值為1。'
+HE1BE8B43F7F0: '指定處理CU時的批次大小。數值越大，效能越好，但記憶體使用量越高。預設值為 1。'
 # 'Specify "safe" i.e. known-good backend:'
 H8A9DA72ACD37: '指定「安全」（即已知良好）的後端：'
 # 'Specify <function, basic block1[;basic block2...]> pairs to extract.\nEach pair will create a function.\nIf multiple basic blocks are specified in one pair,\nthe first block in the sequence should dominate the rest.\neg:\n  --bb=f:bb1;bb2 will extract one function with both bb1 and bb2;\n  --bb=f:bb1 --bb=f:bb2 will extract two functions, one with bb1, one with bb2.'
-H849E2CD57584: '指定要提取的 <函式, 基本區塊1[;基本區塊2...]> 結對。\n每對會建立一個函式。\n若一對中指定多個基本區塊，\n該序列中的第一個區塊應支配其餘區塊。\n例如：\n  --bb=f:bb1;bb2 將提取一個包含bb1和bb2的函式；\n  --bb=f:bb1 --bb=f:bb2 將提取兩個函式，一個有bb1，另一個有bb2。'
+H849E2CD57584: '指定要提取的 <函式, 基本區塊 1[;基本區塊 2...]> 結對。\n每對會建立一個函式。\n若一對中指定多個基本區塊，\n該序列中的第一個區塊應支配其餘區塊。\n例如：\n  --bb=f:bb1;bb2 將提取一個包含bb1和bb2的函式；\n  --bb=f:bb1 --bb=f:bb2 將提取兩個函式，一個有bb1，另一個有bb2。'
 # 'Specify <script> as linker script'
 HE790F52CC3F0: '指定 <腳本> 為連結腳本'
 # 'Specify CU wavefront execution mode (AMDGPU only)'
@@ -14655,9 +14655,9 @@ H03D163E89A58: '指定CUDA、HIP或OpenMP的卸載裝置架構（如sm_35）。�
 # 'Specify an output filename for an HTML report. This describes both recommendations and reasons for changes.'
 H8B1F64A00015: '指定HTML報告的輸出檔名。此報告將描述變更建議及原因'
 # 'Specify bit size of immediate TLS offsets (AArch64 ELF only): 12 (for 4KB) | 24 (for 16MB, default) | 32 (for 4GB) | 48 (for 256TB, needs -mcmodel=large)'
-H26411589DDDC: '指定即時TLS偏移量位元大小（僅AArch64 ELF）：12（4KB） | 24（預設16MB） | 32（4GB） | 48（256TB，需配合-mcmodel=large）'
+H26411589DDDC: '指定即時TLS偏移量位元大小（僅AArch64 ELF）：12（4KB） | 24（預設 16MB） | 32（4GB） | 48（256TB，需配合-mcmodel=large）'
 # 'Specify code object ABI version. Defaults to 6. (AMDGPU only)'
-HA8698B7A4F07: '指定程式碼物件ABI版本。預設值為6（僅AMDGPU）'
+HA8698B7A4F07: '指定程式碼物件ABI版本。預設值為 6（僅AMDGPU）'
 # 'Specify comma-separated list of offloading target triples (CUDA and HIP only)'
 H4646687E209A: '以逗號分隔的卸載目標三元組清單（僅CUDA和HIP）'
 # 'Specify comma-separated list of triples OpenMP offloading targets to be supported'
@@ -14667,7 +14667,7 @@ H1E332E02D801: '指定要執行的命令'
 # 'Specify configuration file'
 HF189739D324B: '指定配置檔'
 # "Specify default stream. The default value is 'legacy'. (CUDA/HIP only)"
-H9CAF3E629210: "指定預設流。預設值為'legacy'。 (CUDA/HIP 限定)"
+H9CAF3E629210: "指定預設流。預設值為 'legacy'。 (CUDA/HIP 限定)"
 # 'Specify file to retrieve coverage information from'
 HF677E8D618FB: '指定用於取得覆蓋資訊的檔案'
 # 'Specify file to retrieve the list of functions to apply CHR to'
@@ -14795,7 +14795,7 @@ HD696058226F4: '指定「安全」後端程式的路徑'
 # 'Specify the prebuilt module path'
 H3FAB39F2C50D: '指定預建模組路徑'
 # 'Specify the printf lowering scheme (AMDGPU only), allowed values are "hostcall"(printing happens during kernel execution, this scheme relies on hostcalls which require system to support pcie atomics) and "buffered"(printing happens after all kernel threads exit, this uses a printf buffer and does not rely on pcie atomic support)'
-H36B6C5D95ECD: '指定printf降低方案（僅AMDGPU），允許的值為"hostcall"（列印在kernel執行期間進行，此方案依賴hostcall，需要系統支援pcie atomics）和"buffered"（列印在所有kernel執行緒結束後進行，此使用printf緩衝區且不依賴pcie原子支援）'
+H36B6C5D95ECD: '指定printf降低方案（僅AMDGPU），允許的值為 "hostcall"（列印在kernel執行期間進行，此方案依賴hostcall，需要系統支援pcie atomics）和 "buffered"（列印在所有kernel執行緒結束後進行，此使用printf緩衝區且不依賴pcie原子支援）'
 # 'Specify the profile path in PGO use compilation'
 H383968EDB0F3: '在PGO使用編譯時指定剖析路徑'
 # 'Specify the property to collect remarks by.'
@@ -15165,7 +15165,7 @@ H065EFBB6A92E: '用於getRegisterBitWidth查詢的LMUL。會影響自動向量�
 # 'The OOO window for processor resources during scheduling.'
 H7F8CE8011253: '排程期間處理器資源的非順序視窗大小（Out-of-Order window）。'
 # 'The alignment to use when accessing the buffers\nDefault is unaligned\nUse 0 to disable address randomization'
-H9D92202DC06A: '存取緩衝區時使用的對齊方式\n預設為未對齊\n使用0來停用位址隨機化'
+H9D92202DC06A: '存取緩衝區時使用的對齊方式\n預設為未對齊\n使用 0 來停用位址隨機化'
 # 'The amount of branches that we are willing to explore withthe exact algorithm before giving up.'
 H46BDE8E006FD: '願意用精確演算法探索的分支數量，超過後會放棄。'
 # 'The associativity of the first cache level.'
@@ -15181,7 +15181,7 @@ HA507EEDE87C4: '計劃要發射的語法（dialect）中ops的基底類別（bas
 # 'The bonus weight of users of allocas within loop when sorting profitable allocas'
 HBDF3A84E4987: '排序有利可圖的allocas時，循環內allocas使用者的加權值（bonus weight）'
 # 'The clause simdlen must fit the %0-bit lanes in the architectural constraints for SVE (min is 128-bit, max is 2048-bit, by steps of 128-bit)'
-H637FD9B0F74C: '在SVE架構約束下，simdlen子句必須符合%0位lane長度（最小128位元，最大2048位元，以128位元為步進）'
+H637FD9B0F74C: '在SVE架構約束下，simdlen子句必須符合 %0 位lane長度（最小 128 位元，最大 2048 位元，以 128 位元為步進）'
 # 'The clause simdlen(1) has no effect when targeting aarch64.'
 H28E8D9873AFA: '在指定aarch64目標時，指定simdlen(1)不會有作用。'
 # 'The code working set size is considered huge if the number of blocks required to reach the -profile-summary-cutoff-hot percentile exceeds this count.'
@@ -15341,7 +15341,7 @@ H810D09DBDCF0: '建立RTC時，記憶體存取中允許的分離條件最大數�
 # 'The maximal number of parameters allowed in RTCs.'
 HD93322BFBD09: '在RTC中允許的最大參數數量。'
 # "The maximum 'boost' (represented as a percentage >= 100) applied to the threshold when aggressively unrolling a loop due to the dynamic cost savings. If completely unrolling a loop will reduce the total runtime from X to Y, we boost the loop unroll threshold to DefaultThreshold*std::min(MaxPercentThresholdBoost, X/Y). This limit avoids excessive code bloat."
-H02A5B75E496D: '當積極展開迴圈因動態成本節省而提高閾值時，所應用的最大「增幅」（以大於等於100的百分比表示）。若完全展開迴圈將使總執行時間從X縮減至Y，則會將展開閾值調整為DefaultThreshold*std::min(MaxPercentThresholdBoost, X/Y)。此限制可避免代碼膨脹過度。'
+H02A5B75E496D: '當積極展開迴圈因動態成本節省而提高閾值時，所應用的最大「增幅」（以大於等於 100 的百分比表示）。若完全展開迴圈將使總執行時間從X縮減至Y，則會將展開閾值調整為DefaultThreshold*std::min(MaxPercentThresholdBoost, X/Y)。此限制可避免代碼膨脹過度。'
 # 'The maximum LMUL value to use for fixed length vectors. Fractional LMUL values are not supported.'
 H8B177E0FA80A: '固定長度向量所使用的最大LMUL值。不支援分數LMUL值。'
 # 'The maximum allowed number of runtime memory checks'
@@ -15357,7 +15357,7 @@ H7CD48ED835E9: 'ExtTSP值的向後跳轉最大距離（以位元組為單位）'
 # 'The maximum interleave count to use when interleaving a scalar reduction in a nested loop.'
 H672121274D43: '在巢狀迴圈中交錯標量約簡時使用的最大交錯次數。'
 # 'The maximum length of a constant string for a builtin string cmp call eligible for inlining. The default value is 3.'
-H6551F5EAB050: '符合內嵌條件的內建字串cmp呼叫所使用的常數字串最大長度。預設值為3。'
+H6551F5EAB050: '符合內嵌條件的內建字串cmp呼叫所使用的常數字串最大長度。預設值為 3。'
 # 'The maximum length of a constant string to inline a memchr call.'
 HAAA048CEEC02: '內嵌memchr呼叫時可內嵌的常數字串最大長度。'
 # 'The maximum length of a single temporal profile trace (default: 10000)'
@@ -15391,7 +15391,7 @@ H9DEE4E0B8275: '單一函數專業化允許的最大複本數量'
 # 'The maximum number of functions to track per lattice value'
 HCD37A486700C: '每個格值可追蹤的函數最大數量'
 # 'The maximum number of heap allocations to consider in one function before skipping (to save compilation time). Set to 0 for no limit.'
-H9E920C5F07AD: '在函數中要考慮的堆分配次數上限（超過後將跳過，以節省編譯時間）。設為0表示無限。'
+H9E920C5F07AD: '在函數中要考慮的堆分配次數上限（超過後將跳過，以節省編譯時間）。設為 0 表示無限。'
 # 'The maximum number of incoming values a PHI node can have to be considered during the specialization bonus estimation'
 H03E2B05D3E4E: '在專業化獎勵估計期間，PHI節點可考慮的最大傳入值數量'
 # 'The maximum number of instructions considered for cycle sinking.'
@@ -15463,7 +15463,7 @@ HDCE9324580BB: '片段中應包含的最小指令數'
 # 'The minimum number of instructions that should be included in the snippet'
 HD8B3E130AB22: '片段中應包含的最小指令數量'
 # 'The minimum number of loads, which should be considered strided, if the stride is > 1 or is runtime value'
-HA691E257E6C6: '如果步長大於1或為執行階段值，則需視為具有步長載入的最小載入數量'
+HA691E257E6C6: '如果步長大於 1 或為執行階段值，則需視為具有步長載入的最小載入數量'
 # 'The minimum size in bytes before an outlining candidate is accepted'
 H382DFDE541E3: '在接納函數外提候選前的最小尺寸（以位元組為單位）'
 # 'The minimum size in bytes of each global that should considered in merging.'
@@ -15487,7 +15487,7 @@ HF09A01C5BE8E: '要使用的版本名稱'
 # 'The name of the executor to use.'
 H9A67A8D34CB5: '要使用的執行器名稱'
 # "The name of the predefined style used as a\nfallback in case clang-format is invoked with\n-style=file, but can not find the .clang-format\nfile to use. Defaults to 'LLVM'.\nUse -fallback-style=none to skip formatting."
-H605E77115F2D: "當以-style=file參數呼叫clang-format但找不到要使用的.clang-format檔案時，用作備用的預定義格式樣式名稱。預設為'LLVM'。\n使用-fallback-style=none可跳過格式化。"
+H605E77115F2D: "當以-style=file參數呼叫clang-format但找不到要使用的.clang-format檔案時，用作備用的預定義格式樣式名稱。預設為 'LLVM'。\n使用-fallback-style=none可跳過格式化。"
 # 'The name of the struct/class.'
 HA728CE8CB2EB: '結構/類別的名稱。'
 # 'The name of this group of passes'
@@ -15517,7 +15517,7 @@ H1DDD94D0908A: '在窗口算法中每個循環的搜尋次數。0表示不限制
 # 'The number of shards into which the op classes will be divided'
 H2AD8480DFFBC: '將操作類別分割的分片數量'
 # 'The number of threads used to process all files in parallel. Set to 0 for hardware concurrency. This flag only applies to all-TUs.'
-H14270C0E6B74: '用以並行處理所有檔案的執行緒數量。設為0以使用硬件並發。此選項僅適用於所有翻譯單位。'
+H14270C0E6B74: '用以並行處理所有檔案的執行緒數量。設為 0 以使用硬件並發。此選項僅適用於所有翻譯單位。'
 # 'The number of times to repeat measurements on the benchmark k before aggregating the results'
 HEB3E720640C3: '在聚合結果前，對基准k進行測試時的重複次數'
 # 'The option is used to turn on/off warnings about hash mismatch for comdat or weak functions.'
@@ -15649,7 +15649,7 @@ H4AEDA738C805: '基於優先級的樣本剖面載入器內嵌的大小增長上�
 # 'The upper limit of II in the window algorithm.'
 H6259F5DF8819: '在窗口演算法中的II上限制。'
 # 'The value specified in simdlen must be a power of 2 when targeting Advanced SIMD.'
-HAAC03787F717: '在針對Advanced SIMD目標時，simdlen指定的值必須是2的冪次。'
+HAAC03787F717: '在針對Advanced SIMD目標時，simdlen指定的值必須是 2 的冪次。'
 # 'The vectorization factor for byte-compare patterns.'
 H892AED0C291C: '位元組比較模式的向量化係數。'
 # 'The vectorization style for loop idiom transform.'
@@ -15697,7 +15697,7 @@ H47E80A7E5CE7: '這些控制要列印的元素。'
 # 'These control which elements are selected.'
 H093D8C9A169D: '這些控制要選取的元素。'
 # 'These control which sections are dumped. Where applicable these parameters take an optional =<offset> argument to dump only the entry at the specified offset.'
-H4A05AC913F89: '這些控制要轉儲的區段。在適用的情況下，這些參數可選用= <offset>參數以僅轉儲指定偏移量處的條目。'
+H4A05AC913F89: '這些控制要轉儲的區段。在適用的情況下，這些參數可選用= <offset> 參數以僅轉儲指定偏移量處的條目。'
 # 'ThinLink: produces the index by linking only the summaries.'
 H0F627A52D002: 'ThinLink：僅連結摘要以產生索引。'
 # "This appends the content hash to the globally outlined function name. It's beneficial for enhancing the precision of the stable hash and for ordering the outlined functions."
@@ -15715,7 +15715,7 @@ HEF7B686F6202: '此為預設。TOC資料轉換不會套用至任何變數。只�
 # 'This option is for testing purposes only. It forces BOLT to convert low_pc/high_pc to ranges always.'
 H46D236F6D0BE: '此選項僅用於測試。它會強制BOLT始終將low_pc/high_pc轉換為區間。'
 # "Thread pointer access method. For AArch32: 'soft' uses a function call, or 'tpidrurw', 'tpidruro' or 'tpidrprw' use the three CP15 registers. 'cp15' is an alias for 'tpidruro'. For AArch64: 'tpidr_el0', 'tpidr_el1', 'tpidr_el2', 'tpidr_el3' or 'tpidrro_el0' use the five system registers. 'elN' is an alias for 'tpidr_elN'."
-H7A1A2BC28705: "線程指標存取方式。對於AArch32：'soft'使用函式呼叫，而'tpidrurw'、'tpidruro'或'tpidrprw'使用三個CP15寄存器。'cp15'是'tpidruro'的別名。對於AArch64：'tpidr_el0'、'tpidr_el1'、'tpidr_el2'、'tpidr_el3'或'tpidrro_el0'使用五個系統寄存器。'elN'是'tpidr_elN'的別名。"
+H7A1A2BC28705: "線程指標存取方式。對於AArch32：'soft' 使用函式呼叫，而 'tpidrurw'、'tpidruro' 或 'tpidrprw' 使用三個CP15寄存器。'cp15' 是 'tpidruro' 的別名。對於AArch64：'tpidr_el0'、'tpidr_el1'、'tpidr_el2'、'tpidr_el3' 或 'tpidrro_el0' 使用五個系統寄存器。'elN' 是 'tpidr_elN' 的別名。"
 # 'Threshold (in bytes) for the runtime check guarding the memmove.'
 HD35FCD3FC79E: '運行階段檢查用以保護memmove的閾值（以位元組為單位）。'
 # 'Threshold (in bytes) to perform the transformation, if the runtime loop count (mem transfer size) is known at compile-time.'
@@ -15835,15 +15835,15 @@ H912BF1C6F685: '當整數溢出時觸發陷阱'
 # 'Trap when incorrect'
 H9EC2646A38E0: '當錯誤時觸發陷阱'
 # 'Treat <file> as C source file'
-H5AAFC1A35AEE: '將<file>視為C源文件'
+H5AAFC1A35AEE: '將 <file> 視為C源文件'
 # 'Treat <file> as C++ source file'
-H467B7FCAE3B7: '將<file>視為C++源文件'
+H467B7FCAE3B7: '將 <file> 視為C++源文件'
 # 'Treat INCLUDE lines like #include directives in -E mode'
 H8BB5A80B42A6: '在-E模式下將INCLUDE行視為#include指令'
 # 'Treat all #include paths starting with <prefix> as including a system header.'
-H4CD79E350724: '將所有以<prefix>開頭的#include路徑視為包含系統標頭。'
+H4CD79E350724: '將所有以 <prefix> 開頭的#include路徑視為包含系統標頭。'
 # 'Treat all #include paths starting with <prefix> as not including a system header.'
-H7FC347478B10: '將所有以<prefix>開頭的#include路徑視為不包含系統標頭。'
+H7FC347478B10: '將所有以 <prefix> 開頭的#include路徑視為不包含系統標頭。'
 # 'Treat all parameters to functions that are pointers as dereferencible. This is useful for invariant load hoisting, since we can generate less runtime checks. This is only valid if all pointers to functions are always initialized, so that Polly can choose to hoist their loads. '
 H01E314D59C27: '將所有函數的指標參數視為可解引用的。這對不變負載提升很有用，因為可以減少執行階段檢查。此選項僅在所有函數指標始終已初始化的情況下有效，這樣Polly可以選擇提升這些載入。'
 # 'Treat all source files as C'
@@ -15851,15 +15851,15 @@ H55FA85BDA2A5: '將所有源文件視為C'
 # 'Treat all source files as C++'
 H7EEC5BB50052: '將所有源文件視為C++'
 # 'Treat any <pattern> strings as regular expressions when selecting instead of just as an exact string match.'
-HB8CFB19C5C18: '選擇時將任何<pattern>字串視為正則表達式，而非精確字串匹配'
+HB8CFB19C5C18: '選擇時將任何 <pattern> 字串視為正則表達式，而非精確字串匹配'
 # 'Treat each comma separated argument in <arg> as a documentation comment block command'
-HCB49DF1FFB5A: '將<arg>中的每個逗號分隔參數視為文檔註釋區塊命令'
+HCB49DF1FFB5A: '將 <arg> 中的每個逗號分隔參數視為文檔註釋區塊命令'
 # 'Treat editor placeholders as valid source code'
 H5F226C718000: '將編輯器佔位符視為有效源代碼'
 # "Treat fixed form lines with 'd' or 'D' in the first column as blank."
-HADC0D4FE88CA: "將固定格式中第一列為'd'或'D'的行視為空白行。"
+HADC0D4FE88CA: "將固定格式中第一列為 'd' 或 'D' 的行視為空白行。"
 # "Treat fixed form lines with 'd' or 'D' in the first column as comments."
-H3F2B7A8C2293: "將第一個字符為'd'或'D'的固定格式行視為註解。"
+H3F2B7A8C2293: "將第一個字符為 'd' 或 'D' 的固定格式行視為註解。"
 # 'Treat hip and hipv4 offload kinds as compatible with openmp kind, and vice versa.\n'
 HC9954ACD9B9E: '將hip和hipv4卸載類型視為與openmp類型兼容，反之亦然。\n'
 # 'Treat input as a PDB file (default)'
@@ -15887,7 +15887,7 @@ H1D5DFE08E7A8: '將堆疊生命周期的起始點視為首次使用時，而非S
 # 'Treat string literals as const'
 H79E1F4486D77: '將字串字面量視為const'
 # 'Treat subsequent input files as having type <language>'
-HC2DB15026570: '將後續輸入文件視為具有<language>類型'
+HC2DB15026570: '將後續輸入文件視為具有 <language> 類型'
 # 'Treat usage of null pointers as undefined behavior (default)'
 HEF76E5F5F913: '將空指標的使用視為未定義行為（預設）'
 # 'Treat warnings as errors'
@@ -15919,7 +15919,7 @@ H020E4D562B19: '嘗試將呼叫點的 nonnull 參數屬性傳播到呼叫函數'
 # 'Try to simplify all loads.'
 HBDC33CA86746: '嘗試簡化所有 loads'
 # 'Try to vectorize with non-power-of-2 number of elements.'
-H0125A5F09D1C: '嘗試以非2的冪次數元素進行向量化'
+H0125A5F09D1C: '嘗試以非 2 的冪次數元素進行向量化'
 # 'Try wider VFs if they enable the use of vector variants'
 H26EA4E292B56: '如果更寬的 VFs 可以使用向量變體，則嘗試使用'
 # 'Tune debug info for a particular debugger'
@@ -16061,23 +16061,23 @@ H89195E513795: '使用.ctors/.dtors代替.init_array/.fini_array'
 # 'Use .file directives with an explicit directory'
 H9DEC86EE53C8: '使用帶有明確目錄的.file指令'
 # 'Use 16-bit hardware multiplier'
-HE39242B4C409: '使用16位元硬體乘法器'
+HE39242B4C409: '使用 16 位元硬體乘法器'
 # 'Use 32-bit floating point registers (MIPS only)'
-HE9E46E3267C7: '使用32位元浮點寄存器（僅MIPS）'
+HE9E46E3267C7: '使用 32 位元浮點寄存器（僅MIPS）'
 # 'Use 32-bit hardware multiplier'
-H48A0735D6EC9: '使用32位元硬體乘法器'
+H48A0735D6EC9: '使用 32 位元硬體乘法器'
 # 'Use 32-bit pointers for accessing const/local/shared address spaces'
-HEBB1FFB0999C: '使用32位元指標存取const/local/shared地址空間'
+HEBB1FFB0999C: '使用 32 位元指標存取const/local/shared地址空間'
 # 'Use 32-bit pointers for accessing const/local/shared address spaces.'
-H1C423A27FAD4: '使用32位元指標存取const/local/shared地址空間。'
+H1C423A27FAD4: '使用 32 位元指標存取const/local/shared地址空間。'
 # 'Use 64-bit floating point registers (MIPS only)'
-H4492AB59FFA0: '使用64位元浮點寄存器（僅MIPS）'
+H4492AB59FFA0: '使用 64 位元浮點寄存器（僅MIPS）'
 # 'Use <dumpfpx> as a prefix to form auxiliary and dump file names'
-H3DFDBA26A67C: '使用<dumpfpx>作為前綴來形成輔助和dump文件名稱'
+H3DFDBA26A67C: '使用 <dumpfpx> 作為前綴來形成輔助和dump文件名稱'
 # 'Use <suffix> as the suffix for module files (the default value is `.mod`)'
-H0754CF14DB5E: '使用<suffix>作為模組文件的後綴（預設值為`.mod`）'
+H0754CF14DB5E: '使用 <suffix> 作為模組文件的後綴（預設值為`.mod`）'
 # 'Use <value> as character line width in fixed mode'
-HAF90606EAD0C: '在固定模式下使用<value>作為字符行寬'
+HAF90606EAD0C: '在固定模式下使用 <value> 作為字符行寬'
 # 'Use ANSI escape codes for diagnostics'
 HF4E88E8746F8: '使用ANSI轉義碼進行診斷'
 # "Use Apple's kernel extensions ABI"
@@ -16193,7 +16193,7 @@ HA312842C43C5: '使用完整的猜測屏障來強化呼叫和返回邊，而非�
 # 'Use a full speculation fence to harden both call and ret edges rather than a lighter weight mitigation.'
 H600ECC7683CF: '使用最通用的成員指標表示法'
 # 'Use a most-general representation for member pointers'
-H0E7635ED3666: '使用可重新生成的偽指令進行2指令常數材質化'
+H0E7635ED3666: '使用可重新生成的偽指令進行 2 指令常數材質化'
 # 'Use a rematerializable pseudoinstruction for 2 instruction constant materialization'
 H3A40020AE1F7: '對wchar_t使用有符號類型'
 # 'Use a signed type for wchar_t'
@@ -16247,7 +16247,7 @@ HCBB3CB058AC9: '使用大小寫不敏感的匹配'
 # 'Use codegen data read from default.cgdata to optimize the binary'
 HEFC973859186: '使用從預設的cgdata讀取的程式碼生成資料來優化二進位'
 # 'Use codegen data read from the specified <path>.'
-HA873FDC06A7F: '使用從指定的<path>讀取的程式碼生成資料。'
+HA873FDC06A7F: '使用從指定的 <path> 讀取的程式碼生成資料。'
 # 'Use colors in detailed AST output. If not set, colors\nwill be used if the terminal connected to\nstandard output supports colors.'
 H3428909B1528: '在詳細AST輸出中使用顏色。若未設定，則若標準輸出連接的終端機支援顏色，將使用顏色。'
 # 'Use colors in output (default=autodetect)'
@@ -16343,7 +16343,7 @@ H2DC2FFE65115: '使用基於instruction-ref的LiveDebugValues以及標準DBG_VAL
 # 'Use instrumentation data for profile-guided optimization'
 H9DC257CB2810: '使用插樁資料進行配置文件引導型優化'
 # 'Use instrumentation data for profile-guided optimization. If pathname is a directory, it reads from <pathname>/default.profdata. Otherwise, it reads from file <pathname>.'
-HDBC8B9085819: '使用插樁資料進行配置文件引導型優化。如果路徑名為目錄，則讀取<pathname>/default.profdata。否則，從檔案<pathname>讀取。'
+HDBC8B9085819: '使用插樁資料進行配置文件引導型優化。如果路徑名為目錄，則讀取 <pathname>/default.profdata。否則，從檔案 <pathname> 讀取。'
 # 'Use instrumented (context sensitive) profile to guide PGO.'
 HF618D20FE941: '使用插樁（具上下文感知）的剖面來引導PGO。'
 # 'Use instrumented profile to guide PGO.'
@@ -16483,7 +16483,7 @@ H7751642AFC12: '使用basic-block-sections剖析來決定熱函數的text區段�
 # 'Use the current working directory as the base directory of compiled module files.'
 HC4A3722E1C1D: '將目前工作目錄用作已編譯模組檔的基底目錄。'
 # 'Use the current working directory as the home directory of module maps specified by -fmodule-map-file=<FILE>'
-H8AE9B0359BD7: '將目前工作目錄用作由-fmodule-map-file=<FILE>指定的模組地圖的主目錄。'
+H8AE9B0359BD7: '將目前工作目錄用作由-fmodule-map-file=<FILE> 指定的模組地圖的主目錄。'
 # 'Use the dependence analysis interface'
 HDF3A2E881A47: '使用依賴性分析介面'
 # 'Use the experimental C++ class ABI for classes with virtual tables'
@@ -16515,7 +16515,7 @@ H19B5E5B63186: '在展開__FILE__宏時，使用主機平台特定的路徑分�
 # 'Use the implementation defaults'
 H46CDBE8DC11A: '使用實作預設值'
 # 'Use the last modification time of <file> as the build session timestamp'
-HC4A79FF67275: '使用<file>的最後修改時間作為建置階段的時間戳'
+HC4A79FF67275: '使用 <file> 的最後修改時間作為建置階段的時間戳'
 # 'Use the llvm.experimental.noalias.scope.decl intrinsic during inlining.'
 H9063D587CE9C: '在內聯期間使用llvm.experimental.noalias.scope.decl內建函數。'
 # 'Use the named plugin action in addition to the default action'
@@ -16541,7 +16541,7 @@ H2E61A14D081C: '使用舊的（錯誤的）指令延遲計算方式'
 # 'Use the preinliner decisions stored in profile context.'
 HD0A0D412FA60: '使用在剖面上下文中儲存的預內聯決策。'
 # 'Use the remappings described in <file> to match the profile data against names in the program'
-HD47D317FB40F: '使用<file>中描述的重映射規則，將剖面資料與程式中的名稱對應'
+HD47D317FB40F: '使用 <file> 中描述的重映射規則，將剖面資料與程式中的名稱對應'
 # 'Use the scalar evolution interface'
 HD228C1FFC83E: '使用標量演進介面'
 # 'Use the specified contextual profile file'
@@ -16677,7 +16677,7 @@ H357D460E1502: '每次轉換後驗證'
 # 'Verify device memory post execution against the original output.'
 HE16F0A0EAC54: '與原始輸出對比驗證設備記憶體執行後的結果。'
 # 'Verify diagnostic output using comment directives that start with prefixes in the comma-separated sequence <prefixes>'
-HC54A2E24270E: '使用以逗號分隔序列<prefixes>中指定的前綴開頭的註釋指令來驗證診斷輸出。'
+HC54A2E24270E: '使用以逗號分隔序列 <prefixes> 中指定的前綴開頭的註釋指令來驗證診斷輸出。'
 # 'Verify dominator info (time consuming)'
 H7265FCA24E7A: '驗證支配信息（耗時）'
 # 'Verify domtree after unrolling'
@@ -16927,7 +16927,7 @@ HE96BEC53314D: '與filetype=obj搭配使用時，產生可與增量連結器搭�
 # 'When used with filetype=obj, relax all fixups in the emitted object file'
 H167CB844A0DE: '與filetype=obj搭配使用時，鬆弛優化所產生物件檔中的所有修補'
 # 'When using -fxray-function-groups, select which group of functions to instrument. Valid range is 0 to fxray-function-groups - 1'
-H763EF25FAB59: '使用-fxray-function-groups時，選擇要插樿的函數群組。有效範圍為0到fxray-function-groups-1'
+H763EF25FAB59: '使用-fxray-function-groups時，選擇要插樿的函數群組。有效範圍為 0 到fxray-function-groups-1'
 # 'When using a PCH, skip tokens until after a #pragma hdrstop.'
 H0A2ABCA96B55: '使用 PCH 時，跳過語彙直到 #pragma hdrstop 之後。'
 # 'Where to run polly in the pass pipeline'
@@ -17009,13 +17009,13 @@ HA68492B41822: '與 PGO 一起，在優化備註中包含剖面計數'
 # 'Work around Cortex-A57 Erratum 1742098 (ARM only)'
 H2CF5C8E79954: '針對 Cortex-A57 異常 1742098 進行工作週旋（僅限 ARM）'
 # 'Work around Cortex-A72 Erratum 1655431 (ARM only)'
-HB9954D8E1844: '回避Cortex-A72錯誤1655431（僅ARM）'
+HB9954D8E1844: '回避Cortex-A72錯誤 1655431（僅ARM）'
 # 'Work around VLLDM erratum CVE-2021-35465 (ARM only)'
 H6484FD8B0341: '回避VLLDM錯誤CVE-2021-35465（僅ARM）'
 # 'Work with `--skip-symbolization` or `--unsymbolized-profile` to write/read the offset instead of virtual address.'
 H1CA65028F454: '與`--skip-symbolization`或`--unsymbolized-profile`一起使用，以寫入/讀取偏移量而非虛擬地址。'
 # 'Workaround Cortex-A53 erratum 835769 (AArch64 only)'
-H479486F0F64D: '回避Cortex-A53錯誤835769（僅AArch64）'
+H479486F0F64D: '回避Cortex-A53錯誤 835769（僅AArch64）'
 # "Wouldn't use segmented stack"
 HF45022A557BC: '不會使用分段堆疊'
 # 'Write Bitcode'
@@ -17033,7 +17033,7 @@ HF98DECE931FC: '將當前時間寫入COFF輸出（預設）'
 # 'Write debug info in the new non-intrinsic format. Has no effect if --preserve-input-debuginfo-format=true.'
 H438D54E25242: '以新的非本徵格式寫入除錯資訊。若指定了--preserve-input-debuginfo-format=true則無效。'
 # 'Write depfile output from -MMD, -MD, -MM, or -M to <file>'
-H7F1DEF2B183F: '將-MD、-MMD、-MM或-M的依賴文件輸出寫入<file>'
+H7F1DEF2B183F: '將-MD、-MMD、-MM或-M的依賴文件輸出寫入 <file>'
 # 'Write extracted files to a static archive'
 H167164B5BAE5: '將提取的文件寫入靜態庫'
 # 'Write lazy-function executions to a CSV file as (JITDylib, function) pairs'
@@ -17043,7 +17043,7 @@ HCE5CCE000DB8: '在優化前將連結的LTO模組寫入檔案'
 # 'Write merged LTO module to file before CodeGen'
 HD65008F3EA67: '在程式碼生成前將合併的LTO模組寫入檔案'
 # 'Write minimized bitcode to <file> for the ThinLTO thin link only'
-H675031C72335: '將精簡後的位碼寫入<file>供ThinLTO精簡連結使用'
+H675031C72335: '將精簡後的位碼寫入 <file> 供ThinLTO精簡連結使用'
 # 'Write out individual imports files via InProcessThinLTO. Has no effect unless specified with -thinlto-emit-indexes or -thinlto-distributed-indexes'
 H19E7DA782B06: '透過InProcessThinLTO輸出個別的導入文件。除非與-thinlto-emit-indexes或-thinlto-distributed-indexes一起指定，否則無效。'
 # 'Write out individual index and import files for the distributed backend case'
@@ -17055,9 +17055,9 @@ HC401168D9C72: '以LLVM組裝語言輸出'
 # 'Write output as ThinLTO-ready bitcode'
 H81BE69D83D3F: '輸出為ThinLTO準備好的位元碼'
 # 'Write output to <file>'
-HCABB93CE5040: '將輸出寫入<file>'
+HCABB93CE5040: '將輸出寫入 <file>'
 # 'Write output to <file>.'
-HA5CAFFC7A76E: '將輸出寫入<file>。'
+HA5CAFFC7A76E: '將輸出寫入 <file>。'
 # 'Write relative block frequency to function summary '
 H61EDFA1BBE67: '將相對區塊頻率寫入函數摘要 '
 # 'Write summary to given YAML file after running pass'
@@ -17265,25 +17265,25 @@ H65FE428CB516: 'lambda參數不能遮蔽明確捕獲的實體'
 # 'a lambda with an explicit object parameter cannot be mutable'
 HF1252DDC6E4B: '具有顯式物件參數的lambda不能為可變'
 # 'a lastprivate variable with incomplete type %0'
-H8324467E21DA: '具有不完整類型%0的lastprivate變數'
+H8324467E21DA: '具有不完整類型 %0 的lastprivate變數'
 # 'a linear variable with incomplete type %0'
-HE61951ED0B99: '具有不完整類型%0的linear變數'
+HE61951ED0B99: '具有不完整類型 %0 的linear變數'
 # 'a module can only be re-exported as another top-level module'
 H272C723A8726: '只能將模組重新導出為另一個頂層模組'
 # 'a non-type template parameter cannot have type %0'
-H4D4081CB8796: '非類型模板參數不能具有類型%0'
+H4D4081CB8796: '非類型模板參數不能具有類型 %0'
 # 'a non-type template parameter cannot have type %0 before C++20'
-HEEE0AA3066FD: '在C++20之前非類型模板參數不能具有類型%0'
+HEEE0AA3066FD: '在C++20之前非類型模板參數不能具有類型 %0'
 # 'a parameter list without types is only allowed in a function definition'
 H52BB0DED62AC: '只有函數定義允許省略參數類型清單'
 # 'a parameter pack may not be accessed at an out of bounds index'
 H3E85B76262B3: '不能在超出邊界的索引位置存取參數包'
 # 'a private variable with incomplete type %0'
-H0A7C86E8874A: '具有不完整類型%0的私有變數'
+H0A7C86E8874A: '具有不完整類型 %0 的私有變數'
 # 'a randomized struct can only be initialized with a designated initializer'
 H4615845B3A9F: '隨機化結構必須使用指定初始化式進行初始化'
 # 'a reduction list item with incomplete type %0'
-H06AA7BC953CB: '具有不完整類型%0的reduction清單項目'
+H06AA7BC953CB: '具有不完整類型 %0 的reduction清單項目'
 # 'a requires expression cannot have an explicit object parameter'
 H86B74E3E67C6: 'requires表達式不能具有顯式物件參數'
 # 'a requires expression must contain at least one requirement'
@@ -17299,19 +17299,19 @@ HA1124669302F: 'static_assert宣告不能是模板'
 # 'a template argument list is expected after a name prefixed by the template keyword'
 HF4A21ADFAB4E: '以 template 關鍵字為前綴的名稱後面需要跟模板參數列表'
 # 'a type named %0 is hidden by a declaration in a different namespace'
-H26CC1C864C4C: '名為%0的類型被另一個命名空間中的宣告所隱藏'
+H26CC1C864C4C: '名為 %0 的類型被另一個命名空間中的宣告所隱藏'
 # 'a type specifier is required for all declarations'
 HA2239D7DA67E: '所有宣告都需要類型說明符'
 # 'a typedef cannot be a template'
 H878607247E5C: 'typedef不能是模板'
 # 'absolute value function %0 given an argument of type %1 but has parameter of type %2 which may cause truncation of value'
-H2B4AC1EEC989: '絕對值函數%0被傳遞了一個類型為%1的參數，但其參數類型為%2，這可能會導致值被截斷'
+H2B4AC1EEC989: '絕對值函數 %0 被傳遞了一個類型為 %1 的參數，但其參數類型為 %2，這可能會導致值被截斷'
 # "abstract class is marked '%select{final|sealed}0'"
 H9546D737D23E: '抽象類被標記為"%select{final|sealed}0"'
 # 'access declarations are deprecated; use using declarations instead'
 H3431BA5113E5: '訪問宣告已被棄用；請改用using宣告'
 # 'access qualifier %0 cannot be used for %1 %select{|prior to OpenCL C version 2.0 or in version 3.0 and without __opencl_c_read_write_images feature}2'
-HC43552CB1BAC: '訪問限定符%0不能用於%1 %select{|在OpenCL C版本2.0之前或在版本3.0且沒有__opencl_c_read_write_images功能時}2'
+HC43552CB1BAC: '訪問限定符 %0 不能用於 %1 %select{|在OpenCL C版本 2.0之前或在版本 3.0且沒有__opencl_c_read_write_images功能時}2'
 # 'access qualifier can only be used for pipe and image type'
 HCF9598AD42BA: '訪問限定符只能用於pipe和image類型'
 # 'access specifier can only have annotation attributes'
@@ -17321,11 +17321,11 @@ H23D01BBD184F: '訪問說明符是clang HLSL擴充功能'
 # 'accessing a member of an atomic structure or union is undefined behavior'
 H1C0790EC0EC6: '訪問原子結構或共用體的成員是未定義行為'
 # 'accessing inaccessible direct base %0 of %1 is a Microsoft extension'
-H76AFA5796E64: '訪問%1的不可訪問直接基類%0是Microsoft擴充功能'
+H76AFA5796E64: '訪問 %1 的不可訪問直接基類 %0 是Microsoft擴充功能'
 # "acquiring %0 '%1' requires negative capability '%2'"
-HC095E2CF1B84: '獲取%0 "%1" 需要否定能力 "%2"'
+HC095E2CF1B84: '獲取 %0 "%1" 需要否定能力 "%2"'
 # "acquiring %0 '%1' that is already held"
-H4DA573668147: '獲取已經持有的%0 "%1"'
+H4DA573668147: '獲取已經持有的 %0 "%1"'
 # 'action %0 not compiled in'
 HA82E8BAC3ED2: '未編譯進動作 %0'
 # "active '%0' clause defined here"
@@ -17389,7 +17389,7 @@ H05DD72B70C0D: '原子內建函數的地址參數不能是const限定 (%0 錯誤
 # 'address argument to atomic builtin must be a pointer %select{|to a non-zero-sized object }1(%0 invalid)'
 H25FC8322E786: '原子內建函數的地址參數必須是%select{|指向非零大小物件的 }1指標 (%0 錯誤)'
 # 'address argument to atomic builtin must be a pointer to 1,2,4,8 or 16 byte type (%0 invalid)'
-H8F0926664FBC: '原子內建函數的地址參數必須是指向1、2、4、8或16位元組型別的指標 (%0 錯誤)'
+H8F0926664FBC: '原子內建函數的地址參數必須是指向 1、2、4、8或 16 位元組型別的指標 (%0 錯誤)'
 # 'address argument to atomic builtin must be a pointer to integer or pointer (%0 invalid)'
 H05518FC9E223: '原子內建函數的地址參數必須是指向整數或指標型別的指標 (%0 錯誤)'
 # 'address argument to atomic builtin must be a pointer to integer, floating-point or pointer (%0 invalid)'
@@ -17407,7 +17407,7 @@ HED971913A5AB: '原子運算的地址參數必須是指向 _Atomic 類型的指�
 # 'address argument to atomic operation must be a pointer to a trivially-copyable type (%0 invalid)'
 H0F2B276FBFF5: '原子運算的地址參數必須是指向可簡單複製（trivially-copyable）類型的指標（%0 適用）'
 # 'address argument to atomic operation must be a pointer to non-%select{const|constant}0 _Atomic type (%1 invalid)'
-H77D9C30AD097: '原子運算的地址參數必須是指向非%select{const|constant}0 _Atomic 類型的指標（%1 適用）'
+H77D9C30AD097: '原子運算的地址參數必須是指向非 %select{const|constant}0 _Atomic 類型的指標（%1 適用）'
 # 'address argument to atomic operation must be a pointer to non-const type (%0 invalid)'
 HA961ACF648B8: '原子運算的地址參數必須是指向非const類型的指標（%0 適用）'
 # 'address argument to load or store exclusive builtin must be a pointer to 1,2,4 or 8 byte type (%0 invalid)'
@@ -17417,7 +17417,7 @@ H15C0E2A98779: '非暫存內建函數的地址參數必須是指向指標（%0 �
 # 'address argument to nontemporal builtin must be a pointer to integer, float, pointer, or a vector of such types (%0 invalid)'
 H411242986562: '非暫存內建函數的地址參數必須是指向整數、浮點數、指標或這些類型的向量的指標（%0 適用）'
 # "address of %select{'%1'|function '%1'|array '%1'|lambda function pointer conversion operator}0 will always evaluate to 'true'"
-H17F3EBE2635E: "「%select{地址為%1|函數「%1」的地址|陣列「%1」的地址|lambda函數指標轉換運算子}0」的地址將始終評估為'true'"
+H17F3EBE2635E: "「%select{地址為 %1|函數「%1」的地址|陣列「%1」的地址|lambda函數指標轉換運算子}0」的地址將始終評估為 'true'"
 # 'address of %select{bit-field|vector element|property expression|register variable|matrix element}0 requested'
 HD8B1334D046A: '請求%select{位域|向量元素|屬性運算式|登錄變數|矩陣元素}0 的地址'
 # "address of non-static constexpr variable %0 may differ on each invocation of the enclosing function; add 'static' to give it a constant address"
@@ -17451,9 +17451,9 @@ H01FFB29D96B3: '修改系統標頭後，請刪除位於「%0」的模組快取'
 # 'aggregate basic samples (without LBR info)'
 H9B9419C851BC: '聚合基本樣本（無LBR資訊）'
 # 'aggregate initialization of type %0 from a parenthesized list of values is a C++20 extension'
-H6B5CF381E65A: '從值的括號列表初始化類型%0的聚合結構是C++20擴展'
+H6B5CF381E65A: '從值的括號列表初始化類型 %0 的聚合結構是C++20擴展'
 # 'aggregate initialization of type %0 with user-declared constructors is incompatible with C++20'
-HC24621DDDD5F: '具有用戶宣告建構函數的類型%0的聚合初始化與C++20不相容'
+HC24621DDDD5F: '具有用戶宣告建構函數的類型 %0 的聚合初始化與C++20不相容'
 # 'aggressive strategy'
 H5CB7E66C0F79: '激進策略'
 # 'aggressively inline everything'
@@ -17473,7 +17473,7 @@ HE9649A76CF28: '別名宣告是C++11擴展'
 # 'alias declarations are incompatible with C++98'
 H47305448BB21: '別名宣告與C++98不相容'
 # 'alias definition of %0 after tentative definition'
-HBC2E292F4F78: '%0的別名定義在暫時性宣告之後'
+HBC2E292F4F78: '%0 的別名定義在暫時性宣告之後'
 # 'alias for --icp-jump-tables-targets'
 H3295D8EF4BCC: '--icp-jump-tables-targets的別名'
 # 'alias for --indirect-call-promotion-calls-topn'
@@ -17525,29 +17525,29 @@ H40E0BDFB048F: '此函數的所有路徑都會調用自身'
 # "allocate directive specifies %select{default|'%1'}0 allocator while previously used %select{default|'%3'}2"
 HC639234B285B: "allocate指令指定%select{預設|'%1'}0配置器，而之前使用的是%select{預設|'%3'}2"
 # 'allocated size %0 is not a multiple of size %1 of element type %2'
-H279696362CDE: '分配的大小%0不是元素類型%2大小%1的倍數'
+H279696362CDE: '分配的大小 %0 不是元素類型 %2 大小 %1 的倍數'
 # "allocated with 'new%select{[]|}0' here"
 H1AA44259E5AA: "在此處使用'new%select{[]|}0'分配"
 # 'allocating an object of abstract class type %0'
-H07CDBA71F9A5: '分配抽象類別類型%0的物件'
+H07CDBA71F9A5: '分配抽象類別類型 %0 的物件'
 # 'allocation of %select{incomplete|sizeless}0 type %1'
-HD40A80B2E772: '分配%select{不完整|無大小}0類型%1'
+HD40A80B2E772: '分配%select{不完整|無大小}0類型 %1'
 # 'allocation performed here was not deallocated%plural{0:|: (along with %0 other memory leak%s0)}0'
-H04A2F923450C: '此處的分配未被釋放%plural{0:|:（連同%0其他記憶體泄漏%s0）}0'
+H04A2F923450C: '此處的分配未被釋放%plural{0:|:（連同 %0 其他記憶體泄漏%s0）}0'
 # "allocator must be specified in the 'uses_allocators' clause"
-H6A6EDC2E2834: "'uses_allocators'子句必須指定配置器"
+H6A6EDC2E2834: "'uses_allocators' 子句必須指定配置器"
 # "allocator with the 'thread' trait access has unspecified behavior on '%0' directive"
-HDC686C65C1AA: "具有'thread'特性的配置器在'%0'指令上的存取行為未定義"
+HDC686C65C1AA: "具有 'thread' 特性的配置器在'%0'指令上的存取行為未定義"
 # "allocators used in 'uses_allocators' clause cannot appear in other data-sharing or data-mapping attribute clauses"
-H3D9F65EE1204: "'uses_allocators'子句中的配置器不得出現在其他資料共享或資料映射屬性子句中"
+H3D9F65EE1204: "'uses_allocators' 子句中的配置器不得出現在其他資料共享或資料映射屬性子句中"
 # 'allow processing of stripped binaries'
 H7C4A1D362E89: '允許處理已剥离的二進位檔'
 # 'allow to snippet generator to generate at most that many configs'
 H8A45202314E0: '允許片段產生器產生最多該數量的配置'
 # "allowable client missing from %0: '%1'"
-H1792F22F4481: '%0缺少允許的客戶端："%1"'
+H1792F22F4481: '%0 缺少允許的客戶端："%1"'
 # "allowable clients do not match: '%0' (provided) vs '%1' (found)"
-H73C7C1046F8D: '允許的客戶端不匹配："提供的%0" vs "找到的%1"'
+H73C7C1046F8D: '允許的客戶端不匹配："提供的 %0" vs "找到的 %1"'
 # "already inside '#pragma clang arc_cf_code_audited'"
 H490BE327E34C: "已經在'#pragma clang arc_cf_code_audited'範圍內"
 # "already inside '#pragma clang assume_nonnull'"
@@ -17611,7 +17611,7 @@ HBD26597B24D2: '對佔位符 "_" 的參考存在歧義，因為它被多次定�
 # 'ambiguous use of internal linkage declaration %0 defined in multiple modules'
 HE31133550012: '內部連結宣告 %0 在多個模組中被定義，導致使用時產生歧義'
 # 'ambiguous vftable component for %0 introduced via covariant thunks; this is an inherent limitation of the ABI'
-HB0361B37BEF3: '通過協變Thunk引入的%0的vftable組件存在歧義；這是ABI的固有局限性'
+HB0361B37BEF3: '通過協變Thunk引入的 %0 的vftable組件存在歧義；這是ABI的固有局限性'
 # 'amdgpu-arch options'
 HA34A9F0AE01E: 'amdgpu-arch 選項'
 # 'an array type is not allowed here'
@@ -17631,7 +17631,7 @@ H75A07B3C23F5: '顯式物件參數不能出現在%select{構造函數|析構函�
 # 'an explicit object parameter cannot appear in a %select{static|virtual|non-member}0 %select{function|lambda}1'
 HF679F4DDA00F: '顯式物件參數不能出現在%select{靜態|虛函數|非成員}0 %select{函數|lambda}1中'
 # "an explicitly-defaulted %select{copy|move}0 assignment operator may not have 'const'%select{, 'constexpr'|}1 or 'volatile' qualifiers"
-HC61798127DDC: "明確預設的%select{複製|移動}0指定運算子不可具有'const'%select{, 'constexpr'|}1或'volatile'限定符"
+HC61798127DDC: "明確預設的%select{複製|移動}0指定運算子不可具有 'const'%select{, 'constexpr'|}1或 'volatile' 限定符"
 # 'an explicitly-defaulted %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}0 cannot be variadic'
 HE8693CE23671: '明確預設的%select{預設構造函數|複製構造函數|移動構造函數|複製指定運算子|移動指定運算子|析構函數}0不能是可變參'
 # 'an explicitly-defaulted %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}0 cannot have default arguments'
@@ -17663,7 +17663,7 @@ H4CC614D1531D: '在此處註解無限迴圈'
 # 'annotation-type remark to collect count for'
 HF59035A1D641: '用於收集計數的註解類型註解'
 # 'anonymous %select{structs|structs and classes}0 must be %select{struct or union|class}0 members'
-HFBD532892EC0: '匿名%select{結構|結構與類別}0 必須為%select{struct或union|class}0 成員'
+HFBD532892EC0: '匿名%select{結構|結構與類別}0 必須為 %select{struct或union|class}0 成員'
 # 'anonymous %select{structs|unions}0 are a Microsoft extension'
 HFF401250AB40: '匿名%select{結構|共用體}0 是Microsoft擴充功能'
 # 'anonymous %select{struct|union}0 can only contain non-static data members'
@@ -17671,7 +17671,7 @@ H31B46249C247: '匿名%select{結構|共用體}0 只能包含非靜態資料成�
 # "anonymous %select{struct|union}0 cannot be '%1'"
 HF58A2EC09112: '匿名%select{結構|共用體}0 不能是「%1」'
 # 'anonymous %select{struct|union}0 cannot contain a %select{private|protected}1 data member'
-HA1E08BDB3E65: '匿名%select{結構|共用體}0 不能包含%select{private|protected}1 資料成員'
+HA1E08BDB3E65: '匿名%select{結構|共用體}0 不能包含 %select{private|protected}1 資料成員'
 # 'anonymous bit-field cannot have a default member initializer'
 H71090C776F50: '匿名位段不能有預設成員初始值設定式'
 # 'anonymous bit-field cannot have qualifiers'
@@ -17695,23 +17695,23 @@ H1E3F733CCCB4: '匿名結構是C11的擴充功能'
 # 'anonymous structs are a GNU extension'
 H006E53420443: '匿名結構是GNU的擴充功能'
 # 'anonymous types declared in an anonymous %select{struct|union}0 are an extension'
-H3F386C85263B: '在匿名%select{struct|union}0中宣告的匿名類型是擴充功能'
+H3F386C85263B: '在匿名 %select{struct|union}0 中宣告的匿名類型是擴充功能'
 # 'anonymous union at class scope must not have a storage specifier'
 H7518631D05B0: '類別作用域中的匿名共用體不得具有儲存說明符'
 # 'anonymous unions are a C11 extension'
 HDFE9E6E6FE09: '匿名共用體是C11的擴充功能'
 # "anonymous unions at namespace or global scope must be declared 'static'"
-H3FE1C37A16FD: "命名空間或全域作用域中的匿名共用體必須宣告為'static'"
+H3FE1C37A16FD: "命名空間或全域作用域中的匿名共用體必須宣告為 'static'"
 # 'append PID to saved profile file name (default: false)'
 HFDE8729E14B7: '將PID附加到儲存的剖析檔檔名（預設：false）'
 # "application of '%select{alignof|sizeof}1' to interface %0 is not supported on this architecture and platform"
-H7F7758BA5771: "對介面%0應用'%select{alignof|sizeof}1'在此架構和平台上不受支援"
+H7F7758BA5771: "對介面 %0 應用'%select{alignof|sizeof}1'在此架構和平台上不受支援"
 # 'apply additional analysis to remove stores (experimental)'
 H0FDD6748AD67: '套用額外分析以移除存儲（實驗性）'
 # 'apply unchecked-ld-st when the target is definitely within range'
 H75826487B47E: '當目標絕對在範圍內時套用未檢查的ld-st'
 # 'applying attribute %0 to a declaration is deprecated; apply it to the type instead'
-H1F568760A093: '將屬性%0套用到宣告是已棄用的；請改為套用到類型'
+H1F568760A093: '將屬性 %0 套用到宣告是已棄用的；請改為套用到類型'
 # "architecture '%0' does not support '%1' execution mode"
 H341F2DD78603: "架構'%0'不支援'%1'執行模式"
 # "architectures do not match: '%0' (provided) vs '%1' (found)"
@@ -17719,7 +17719,7 @@ H1E0CF63FB0D6: "架構不符：'%0'（提供的）與'%1'（找到的）"
 # 'architectures of the coverage mapping binaries'
 HC4DF8B556ACB: '涵蓋映射二進位檔的架構'
 # 'argument %0 is not an unqualified class type'
-H5DB23C0A38DF: '引數%0不是未限定的類別類型'
+H5DB23C0A38DF: '引數 %0 不是未限定的類別類型'
 # 'argument %0 must be constant integer 1 or -1'
 H4812A4DC04E0: '參數 %0 必須是常數整數 1 或 -1'
 # 'argument %0 of type %1 with mismatched bound'
@@ -17791,7 +17791,7 @@ H970EFD35B5B1: "對 'gang' 子句維度的參數必須為 %select{常數運算�
 # "argument to 'operator<=>' %select{cannot be narrowed from type %1 to %2|evaluates to %1, which cannot be narrowed to type %2}0"
 HAE154D16E74A: "對 'operator<=>' 的參數 %select{無法從類型 %1 縮窄至 %2|評估為 %1，無法縮窄至類型 %2}0"
 # "argument to 'sizeof' in %0 call is the same pointer type %1 as the %select{destination|source}2; expected %3 or an explicit length"
-H35BB4F2B1E83: "在%0調用中的'sizeof'參數與%select{目標|來源}2的指標類型%1相同；期望%3或明確的長度"
+H35BB4F2B1E83: "在 %0 調用中的 'sizeof' 參數與%select{目標|來源}2的指標類型 %1 相同；期望 %3 或明確的長度"
 # 'argument to __builtin_longjmp must be a constant 1'
 HE5F0C7B028D7: '__builtin_longjmp 的參數必須為常數 1'
 # 'argument to __builtin_verbose_trap must %select{be a pointer to a constant string|not contain $}0'
@@ -17835,27 +17835,27 @@ H81F0120B9A69: '對 %select{不完整型別|無大小型別}0 %1 的指標進行
 # 'arithmetic on addresses of potentially overlapping literals has unspecified value'
 H84236342B8A2: '對可能重疊字面值的位址進行算術運算的結果未定'
 # 'arithmetic on pointer to interface %0, which is not a constant size for this architecture and platform'
-H9C9B045DAD4E: '在無法為此架構和平台提供固定大小的介面%0的指標進行算術運算'
+H9C9B045DAD4E: '在無法為此架構和平台提供固定大小的介面 %0 的指標進行算術運算'
 # 'arithmetic on%select{ a|}0 pointer%select{|s}0 to void'
 H58D09A5B5E7F: '在%select{ a|}0指標%select{|s}0到void類型進行算術運算'
 # 'arithmetic on%select{ a|}0 pointer%select{|s}0 to void is a GNU extension'
 HB4BACD25A732: '在%select{ a|}0指標%select{|s}0到void類型進行算術運算是GNU擴展'
 # 'arithmetic on%select{ a|}0 pointer%select{|s}0 to%select{ the|}2 function type%select{|s}2 %1%select{| and %3}2'
-H1FD9A476B84E: '在%select{ a|}0指標%select{|s}0到%select{ the|}2函數類型%select{|s}2 %1%select{|和%3}2進行算術運算'
+H1FD9A476B84E: '在%select{ a|}0指標%select{|s}0到%select{ the|}2函數類型%select{|s}2 %1%select{|和 %3}2進行算術運算'
 # 'arithmetic on%select{ a|}0 pointer%select{|s}0 to%select{ the|}2 function type%select{|s}2 %1%select{| and %3}2 is a GNU extension'
-H94DE585BA344: '在%select{ a|}0指標%select{|s}0到%select{ the|}2函數類型%select{|s}2 %1%select{|和%3}2進行算術運算是GNU擴展'
+H94DE585BA344: '在%select{ a|}0指標%select{|s}0到%select{ the|}2函數類型%select{|s}2 %1%select{|和 %3}2進行算術運算是GNU擴展'
 # 'array %0 declared here'
-HD94D934376D0: '在此處宣告的陣列%0'
+HD94D934376D0: '在此處宣告的陣列 %0'
 # "array 'new' cannot have initialization arguments"
-H5708CAC5AB7B: "'new'陣列不能有初始化參數"
+H5708CAC5AB7B: "'new' 陣列不能有初始化參數"
 # 'array argument is too small; %select{contains %0 elements|is of size %0}2, callee requires at least %1'
-H8A66ED6F9EE3: '陣列參數過小；%select{包含%0個元素|大小為%0}2，被調用方至少需要%1'
+H8A66ED6F9EE3: '陣列參數過小；%select{包含 %0 個元素|大小為 %0}2，被調用方至少需要 %1'
 # 'array backing %select{initializer list subobject of the allocated object|the allocated initializer list}0 will be destroyed at the end of the full-expression'
 H7FC8ADC3508D: '分配物件%select{初始化清單子物件|的初始化清單}0的陣列支撐結構將在完整表達式結束時被銷毀'
 # 'array bound cannot be deduced from a default member initializer'
 H6E170EF5C23C: '無法從預設成員初始化式推導陣列邊界'
 # 'array designator cannot initialize non-array type %0'
-H0BB48B48E929: '陣列指定項不能初始化非陣列類型%0'
+H0BB48B48E929: '陣列指定項不能初始化非陣列類型 %0'
 # 'array designator index (%0) exceeds array bounds (%1)'
 HF8952A3F237D: '陣列指定項索引(%0)超出陣列邊界(%1)'
 # 'array designator range [%0, %1] is empty'
@@ -17865,11 +17865,11 @@ H02A61A71BE5A: "陣列指定項值'%0'為負數"
 # 'array designators are a C99 extension'
 H09604E6E8FF6: '陣列指定項是C99擴展'
 # 'array has %select{incomplete|sizeless}0 element type %1'
-H513D9739D1E9: '陣列元素類型%1%select{不完整|無大小}0'
+H513D9739D1E9: '陣列元素類型 %1%select{不完整|無大小}0'
 # 'array index %0 is before the beginning of the array'
-HE66AD6A3EEDD: '陣列索引%0位於陣列起始位置之前'
+HE66AD6A3EEDD: '陣列索引 %0 位於陣列起始位置之前'
 # 'array index %0 is past the end of the array (that has type %1%select{|, cast to %3}2)'
-HB32CD52AC2F7: '陣列索引%0超出陣列末端（該陣列類型為%1%select{|轉型為%3}2）'
+HB32CD52AC2F7: '陣列索引 %0 超出陣列末端（該陣列類型為 %1%select{|轉型為 %3}2）'
 # 'array index %0 refers past the last possible element for an array in %1-bit address space containing %2-bit (%3-byte) elements (max possible %4 element%s5)'
 H8C89DC3E13D9: '陣列索引 %0 指向超過 %1-bit 位址空間中包含 %2-bit (%3-byte) 元素 (最大可能 %4 元素%s5) 的陣列末尾元素'
 # 'array initializer must be an initializer list%select{| or string literal| or wide string literal}0'
@@ -17877,11 +17877,11 @@ H4C9486DBC430: '陣列初始值設定必須是初始化列表%select{|或字串�
 # 'array is too large (%0 elements)'
 H898DDC47DE13: '陣列過大 (%0 個元素)'
 # 'array of %0 type is invalid in OpenCL'
-H394630398D52: 'OpenCL 中不支援%0類型的陣列'
+H394630398D52: 'OpenCL 中不支援 %0 類型的陣列'
 # 'array of abstract class type %0'
 HD205577BDFE7: '%0 抽象類別型態的陣列無效'
 # 'array of interface %0 is invalid (probably should be an array of pointers)'
-H26CB6BC11BB2: '介面%0的陣列無效（可能應使用指標的陣列）'
+H26CB6BC11BB2: '介面 %0 的陣列無效（可能應使用指標的陣列）'
 # 'array parameter is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified)'
 HF62708756DE6: '陣列參數缺少空值型別指定項（_Nonnull、_Nullable 或 _Null_unspecified）'
 # 'array section %select{lower bound|length}0 is not an integer'
@@ -17895,15 +17895,15 @@ HDEBFF7152057: '最外層維度的陣列區段未指定長度'
 # 'array section must be a subset of the original array'
 H9DAB88506A15: '陣列區段必須是原始陣列的子集'
 # 'array shaping dimension is evaluated to a non-positive value %0'
-H6C186AF92991: '陣列形狀維度計算為非正數值%0'
+H6C186AF92991: '陣列形狀維度計算為非正數值 %0'
 # 'array shaping operation dimension is not an integer'
 H521C171EF9F9: '陣列形狀運算的維度非整數'
 # 'array size expression has incomplete class type %0'
-H48253C816CFD: '陣列大小運算式具有不完整類別類型%0'
+H48253C816CFD: '陣列大小運算式具有不完整類別類型 %0'
 # 'array size expression must have integral or %select{|unscoped }0enumeration type, not %1'
-H46181D36F61E: '陣列大小運算式必須為整數或%select{|未指定作用域 }0枚舉型別，而非%1'
+H46181D36F61E: '陣列大小運算式必須為整數或%select{|未指定作用域 }0枚舉型別，而非 %1'
 # 'array size expression of type %0 requires explicit conversion to type %1'
-H08A74EE986A3: '陣列大小運算式型別%0 需明確轉換為%1型別'
+H08A74EE986A3: '陣列大小運算式型別 %0 需明確轉換為 %1 型別'
 # 'array size is negative'
 H2357C6CBC81F: '陣列大小為負數'
 # 'array size must be specified in new expression with no initializer'
@@ -17911,9 +17911,9 @@ HC377DBA39626: '在沒有初始值的new運算式中必須指定陣列大小'
 # 'array subscript is not an integer'
 HCA57C5D6E89C: '陣列下標不是整數'
 # "array subscript is of type 'char'"
-HF94CCD2B1ECE: "陣列下標為類型'char'"
+HF94CCD2B1ECE: "陣列下標為類型 'char'"
 # 'array type %0 is not assignable'
-H89C95FEC605F: '陣列類型%0 不可指派'
+H89C95FEC605F: '陣列類型 %0 不可指派'
 # 'array types cannot be value-initialized'
 HA2673E710254: '陣列類型無法進行值初始化'
 # 'array-to-pointer decay of array member without known bound is not supported'
@@ -17925,7 +17925,7 @@ HF393CC9965C7: '遞增'
 # 'asm constraint has an unexpected number of alternatives: %0 vs %1'
 HF38699D505AA: 'asm 限制項的替代數量意外：%0 vs %1'
 # 'asm operand has incomplete type %0'
-HAA2952BA222F: '組合語言參數具有不完整類型%0'
+HAA2952BA222F: '組合語言參數具有不完整類型 %0'
 # 'asm operand name "%0" first referenced here'
 H8FB938C946B0: '組合語言標籤「%0」首次在此處引用'
 # 'asm-specifier for input or output variable conflicts with asm clobber list'
@@ -17941,7 +17941,7 @@ H8135CA913359: '將已保留物件賦值給非保留屬性；物件將於指派�
 # "assigning to 'readonly' return result of an Objective-C message not allowed"
 H87457323E0B9: '不允許對Objective-C訊息的「readonly」傳回結果進行指派'
 # 'assigning value of signed enum type %1 to unsigned bit-field %0; negative enumerators of enum %1 will be converted to positive values'
-H03B45829D6A4: '將帶符號列舉類型%1 賦值給無符號位元區段%0；列舉%1 的負值枚舉常數將轉換為正數'
+H03B45829D6A4: '將帶符號列舉類型 %1 賦值給無符號位元區段 %0；列舉 %1 的負值枚舉常數將轉換為正數'
 # 'assignment of a weak-unavailable object to a __weak object'
 H270A68B29DDC: '將弱不可用物件指派給__weak物件'
 # "assignment to Objective-C's isa is deprecated in favor of object_setClass()"
@@ -18083,17 +18083,17 @@ HB0AE642AC2E4: '驗證空指標幾乎肯定會觸發陷阱'
 # 'auto property synthesis is synthesizing property not explicitly synthesized'
 H0B109C7F8F74: '自動屬性合成正在合成未明確宣告的屬性'
 # 'auto property synthesis will not synthesize property %0 because it cannot share an ivar with another synthesized property'
-HB5E0DEB40CE6: '自動屬性合成不會合成屬性%0，因其無法與其他合成屬性共用實例變數'
+HB5E0DEB40CE6: '自動屬性合成不會合成屬性 %0，因其無法與其他合成屬性共用實例變數'
 # "auto property synthesis will not synthesize property %0 because it is 'readwrite' but it will be synthesized 'readonly' via another property"
-H2BD61AD864B9: '自動屬性合成不會合成屬性%0，因其標記為"readwrite"，但將透過另一屬性以"readonly"進行合成'
+H2BD61AD864B9: '自動屬性合成不會合成屬性 %0，因其標記為 "readwrite"，但將透過另一屬性以 "readonly" 進行合成'
 # 'auto property synthesis will not synthesize property %0 declared in protocol %1'
-HA0C341D1A812: '自動屬性合成不會合成在協定%1中宣告的屬性%0'
+HA0C341D1A812: '自動屬性合成不會合成在協定 %1 中宣告的屬性 %0'
 # 'auto property synthesis will not synthesize property %0; it will be implemented by its superclass, use @dynamic to acknowledge intention'
-H0457D53851AF: '自動屬性合成不會合成屬性%0，因其將由超類實作，請使用 @dynamic 以明確表示意圖'
+H0457D53851AF: '自動屬性合成不會合成屬性 %0，因其將由超類實作，請使用 @dynamic 以明確表示意圖'
 # 'automatic variable qualified with an%select{| invalid}0 address space'
 H122ACAE25198: '帶有%select{|無效}0地址空間的自動變數'
 # 'autosynthesized property %0 will use %select{|synthesized}1 instance variable %2, not existing instance variable %3'
-H4495EA68D322: '自動合成的屬性%0將使用%select{|合成的}1實例變數%2，而非現有的實例變數%3'
+H4495EA68D322: '自動合成的屬性 %0 將使用%select{|合成的}1實例變數 %2，而非現有的實例變數 %3'
 # 'availability does not match previous declaration'
 H583F2A1BC062: '可用性宣告與先前宣告不一致'
 # 'available multilibs are:%0'
@@ -18145,7 +18145,7 @@ HD9E44C137738: '因為沒有 %select{<<ERROR>>|建構函數|建構函數|賦值�
 # 'because of ambiguity in conversion %diff{of $ to $|between types}0,1'
 HB064B974A1C3: '因轉換%diff{從 $ 至 $ 的不相容|兩種類型間的不相容}0,1 產生歧義'
 # 'because substituted constraint expression is ill-formed%0'
-H708967A94C80: '因取代後的約束運算式存在語法錯誤%0'
+H708967A94C80: '因取代後的約束運算式存在語法錯誤 %0'
 # 'because the function selected to %select{construct|copy|move|copy|move|destroy}2 %select{base class|field}0 of type %1 is not trivial'
 H1F152D129667: '因%select{建構|複製|移動|複製|移動|銷毀}2 %select{基類|成員}0 類型 %1 的函式非 trivial'
 # 'because type %0 has a member with %select{no|no|__strong|__weak|__autoreleasing}1 ownership'
@@ -18413,7 +18413,7 @@ H2870B0B82BD7: '呼叫類別 %0 的%select{私有|受保護的}1 析構函數'
 # "calling function %0 requires negative capability '%1'"
 HB81388BC5C94: "呼叫函數 %0 需要負向能力 '%1'"
 # "calling function %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
-HF6312AC18647: "呼叫函數%1需要持有%0%select{'%2'|'排他性%2'}3"
+HF6312AC18647: "呼叫函數 %1 需要持有 %0%select{'%2'|'排他性 %2'}3"
 # 'calling function with incomplete return type %0'
 H47066D05EDB3: '呼叫具有不完整返回類型 %0 的函式'
 # 'calls the given entry-point on a new thread (jit-kind=orc-lazy only)'
@@ -18421,13 +18421,13 @@ HD909298BB334: '在新執行緒上呼叫給定的入口點（僅限jit-kind=orc-
 # 'calls to OpenMP runtime API are not allowed within a region that corresponds to a construct with an order clause that specifies concurrent'
 HF0FE255D765C: '在對應於具有指定concurrent子句的構造的區域內，不得呼叫OpenMP運行時API'
 # 'can only access this member on an object of type %0'
-H97DBB9710EB7: '只能在類型%0的物件上存取此成員'
+H97DBB9710EB7: '只能在類型 %0 的物件上存取此成員'
 # 'can only poison identifier tokens'
 HBA757282B22F: '只能毒化識別符號字元'
 # 'can only provide an explicit specialization for a class template, function template, variable template, or a member function, static data member, %select{or member class|member class, or member enumeration}0 of a class template'
 H705307E2F906: '只能為類別範本、函數範本、變數範本，或類別範本的成員函數、靜態資料成員%select{、或成員類別|、成員類別或成員列舉}0提供顯式專案'
 # "can only use 'init_priority' attribute on file-scope definitions of objects of class type"
-H2C248D12A320: "'init_priority'屬性只能用在類別型物件的文件作用域定義上"
+H2C248D12A320: "'init_priority' 屬性只能用在類別型物件的文件作用域定義上"
 # 'candidate %select{constructor|template}0 ignored: inherited constructor cannot be used to %select{copy|move}1 object'
 HA2E8E747932F: '候選%select{建構函數|範本}0被忽略：繼承而來的建構函數無法用於%select{複製|移動}1物件'
 # 'candidate %select{constructor|template}0 ignored: instantiation %select{takes|would take}0 its own class type by value'
@@ -18435,15 +18435,15 @@ H5F81F51806D8: '候選%select{建構函數|範本}0被忽略：實例化%select{
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 has been %select{explicitly made unavailable|explicitly deleted|implicitly deleted}3"
 HDF3920A3A1F2: "候選%select{函數|函數|函數（參數順序反轉）|建構函數|預設建構函數（隱式）|複製建構函數（隱式）|移動建構函數（隱式）|複製指定運算子（隱式）|移動指定運算子（隱式）|為此'operator<=>'隱式產生的'operator=='|繼承而來的建構函數}0%select{|範本| %2}1已被%select{明確標記不可用|明確刪除|隱式刪除}3"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: %ordinal5 argument (%3) would lose %select{const|restrict|const and restrict|volatile|const and volatile|volatile and restrict|const, volatile, and restrict}4 qualifier%select{||s||s|s|s}4"
-H95E4AEB3B23E: "候選%select{函數|函數|函數（參數順序反轉）|建構函數|預設建構函數（隱式）|複製建構函數（隱式）|移動建構函數（隱式）|複製指定運算子（隱式）|移動指定運算子（隱式）|為此'operator<=>'隱式產生的'operator=='|繼承而來的建構函數}0%select{|範本| %2}1不可行：%ordinal5個參數（%3）將失去%select{const|restrict|const和restrict|volatile|const和volatile|volatile和restrict|const、volatile和restrict}4資格%select{||s||s|s|s}4"
+H95E4AEB3B23E: "候選%select{函數|函數|函數（參數順序反轉）|建構函數|預設建構函數（隱式）|複製建構函數（隱式）|移動建構函數（隱式）|複製指定運算子（隱式）|移動指定運算子（隱式）|為此'operator<=>'隱式產生的'operator=='|繼承而來的建構函數}0%select{|範本| %2}1不可行：%ordinal5個參數（%3）將失去 %select{const|restrict|const和restrict|volatile|const和volatile|volatile和restrict|const、volatile和restrict}4 資格%select{||s||s|s|s}4"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: %select{%ordinal7|'this'}6 argument (%3) has %select{no|__unsafe_unretained|__strong|__weak|__autoreleasing}4 ownership, but parameter has %select{no|__unsafe_unretained|__strong|__weak|__autoreleasing}5 ownership"
 H8D414CDC2F4E: "候選%select{函數|函數|函數（參數順序反轉）|建構函數|預設建構函數（隱式）|複製建構函數（隱式）|移動建構函數（隱式）|複製指定運算子（隱式）|移動指定運算子（隱式）|為此'operator<=>'隱式產生的'operator=='|繼承而來的建構函數}0%select{|範本| %2}1不可行：%select{%ordinal7|'this'}6個參數（%3）具有%select{無|__unsafe_unretained|__strong|__weak|__autoreleasing}4所有權，但參數需要%select{無|__unsafe_unretained|__strong|__weak|__autoreleasing}5所有權"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: %select{%ordinal7|'this'}6 argument (%3) has %select{no|__weak|__strong}4 ownership, but parameter has %select{no|__weak|__strong}5 ownership"
 HFD1E148AC849: "候選%select{函數|函數|函數（參數順序反轉）|建構函數|預設建構函數（隱式）|複製建構函數（隱式）|移動建構函數（隱式）|複製指定運算子（隱式）|移動指定運算子（隱式）|為此'operator<=>'隱式產生的'operator=='|繼承而來的建構函數}0%select{|範本| %2}1不可行：%select{%ordinal7|'this'}6個參數（%3）具有%select{無|__weak|__strong}4所有權，但參數需要%select{無|__weak|__strong}5所有權"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: %select{cannot convert initializer list|too few initializers in list|too many initializers in list}7 argument to %4"
-H4C57102C9323: "候選%select{函數|函數|函數（參數順序反轉）|建構函數|預設建構函數（隱式）|複製建構函數（隱式）|移動建構函數（隱式）|複製指定運算子（隱式）|移動指定運算子（隱式）|為此'operator<=>'隱式產生的'operator=='|繼承而來的建構函數}0%select{|範本| %2}1不可行：%select{初始化清單無法轉換|初始化清單項目過少|初始化清單項目過多}7個參數轉換至%4"
+H4C57102C9323: "候選%select{函數|函數|函數（參數順序反轉）|建構函數|預設建構函數（隱式）|複製建構函數（隱式）|移動建構函數（隱式）|複製指定運算子（隱式）|移動指定運算子（隱式）|為此'operator<=>'隱式產生的'operator=='|繼承而來的建構函數}0%select{|範本| %2}1不可行：%select{初始化清單無法轉換|初始化清單項目過少|初始化清單項目過多}7個參數轉換至 %4"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: %select{requires at least|allows at most single|requires single}3 %select{|non-object }6argument %4, but %plural{0:no|:%5}5 arguments were provided"
-H8AD4B8B6097C: "候選%select{函數|函數|函數（參數順序反轉）|建構函數|預設建構函數（隱式）|複製建構函數（隱式）|移動建構函數（隱式）|複製指定運算子（隱式）|移動指定運算子（隱式）|為此'operator<=>'隱式產生的'operator=='|繼承而來的建構函數}0%select{|範本| %2}1不可行：%select{至少需要|最多僅允許單一|需要單一}3 %select{|非物件 }6參數%4，但%plural{0:無|:%5}5個參數被提供"
+H8AD4B8B6097C: "候選%select{函數|函數|函數（參數順序反轉）|建構函數|預設建構函數（隱式）|複製建構函數（隱式）|移動建構函數（隱式）|複製指定運算子（隱式）|移動指定運算子（隱式）|為此'operator<=>'隱式產生的'operator=='|繼承而來的建構函數}0%select{|範本| %2}1不可行：%select{至少需要|最多僅允許單一|需要單一}3 %select{|非物件 }6參數 %4，但%plural{0:無|:%5}5個參數被提供"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: 'this' argument has type %3, but method is not marked %select{const|restrict|const or restrict|volatile|const or volatile|volatile or restrict|const, volatile, or restrict}4"
 HE6BBB39EEE68: "候選%select{函數|函數|參數順序相反的函數|建構函數|預設隱含建構函數|複製隱含建構函數|移動隱含建構函數|複製隱含指定運算子函數|移動隱含指定運算子函數|此 'operator<=>' 的隱含 'operator==' 函數|繼承建構函數}0%select{| 範型| %2}1 不適用：'this' 參數的類型為 %3，但方法未標記 %select{const|restrict|const 或 restrict|volatile|const 或 volatile|volatile 或 restrict|const、volatile 或 restrict}4"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: 'this' object is in %3, but method expects object in %4"
@@ -18469,7 +18469,7 @@ H327F9AFBF1B4: "候選%select{函數|函數|參數順序相反的函數|建構�
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %2}1 not viable: requires%select{ at least| at most|}3 %4 %select{|non-object }6argument%s4, but %5 %plural{1:was|:were}5 provided"
 HE70B20B055FA: "候選%select{函數|函數|參數順序相反的函數|建構函數|預設隱含建構函數|複製隱含建構函數|移動隱含建構函數|複製隱含指定運算子函數|移動隱含指定運算子函數|此 'operator<=>' 的隱含 'operator==' 函數|繼承建構函數}0%select{| 範型| %2}1 不適用：需要%select{至少| 最多|}3 %4 %select{|非物件 }6參數%s4，但 %5 %plural{1:有|:有}5 被提供"
 # "candidate %select{function|function|function (with reversed parameter order)|constructor|constructor (the implicit default constructor)|constructor (the implicit copy constructor)|constructor (the implicit move constructor)|function (the implicit copy assignment operator)|function (the implicit move assignment operator)|function (the implicit 'operator==' for this 'operator<=>)'|inherited constructor}0%select{| template| %3}1%select{| has different class%diff{ (expected $ but has $)|}5,6| has different number of parameters (expected %5 but has %6)| has type mismatch at %ordinal5 parameter%diff{ (expected $ but has $)|}6,7| has different return type%diff{ ($ expected but has $)|}5,6| has different qualifiers (expected %5 but found %6)| has different exception specification}4"
-H8C85DA7348D1: "候選%select{函數|函數|參數順序反轉的函數|建構函數|隱含預設建構函數|隱含複製建構函數|隱含移動建構函數|隱含複製賦值運算子|隱含移動賦值運算子|隱含'operator=='的三向比較運算子)|繼承建構函數}0%select{|函式模板| %3}1%select{| 具有不同的類別%diff{（期望$但具有$）|}5,6| 參數數量不同（期望%5但具有%6）| 第%ordinal5個參數類型不匹配%diff{（期望$但具有$）|}6,7| 回傳類型不同%diff{（期望$但具有$）|}5,6| 具有不同的修飾詞（期望%5但發現%6）| 具有不同的例外規格}4"
+H8C85DA7348D1: "候選%select{函數|函數|參數順序反轉的函數|建構函數|隱含預設建構函數|隱含複製建構函數|隱含移動建構函數|隱含複製賦值運算子|隱含移動賦值運算子|隱含'operator=='的三向比較運算子)|繼承建構函數}0%select{|函式模板| %3}1%select{| 具有不同的類別%diff{（期望$但具有$）|}5,6| 參數數量不同（期望 %5 但具有 %6）| 第%ordinal5個參數類型不匹配%diff{（期望$但具有$）|}6,7| 回傳類型不同%diff{（期望$但具有$）|}5,6| 具有不同的修飾詞（期望 %5 但發現 %6）| 具有不同的例外規格}4"
 # 'candidate address cannot be taken because parameter %0 has pass_object_size attribute'
 H9C284929AC5A: '無法取得候選地址，因為參數 %0 具有 pass_object_size 屬性'
 # 'candidate constructor ignored: cannot be used to construct an object in address space %0'
@@ -18487,7 +18487,7 @@ H46E51FE9BF5C: '候選被忽略：%select{非函數範型|非封裝 %select{類�
 # 'candidate template ignored: cannot deduce a type for %0 that would make %2 equal %1'
 H7E4350C35AB8: '候選範本被忽略：無法推導 %0 的類型使其 %2 等於 %1'
 # 'candidate template ignored: constraints not satisfied%0'
-H6E9C2A6AF9DA: '候選範本被忽略：約束條件未滿足%0'
+H6E9C2A6AF9DA: '候選範本被忽略：約束條件未滿足 %0'
 # 'candidate template ignored: could not match %diff{$ against $|types}0,1'
 HBFC6A5130527: '候選範本被忽略：無法將 %diff{$ 與 $ 匹配|類型}0,1'
 # 'candidate template ignored: could not match %q0 against %q1'
@@ -18511,11 +18511,11 @@ H7C80ECA5E832: '候選範本被忽略：為第 %ordinal0 個範本參數指定�
 # 'candidate template ignored: invalid explicitly-specified argument for template parameter %0'
 HEDC828688F33: '候選範本被忽略：為範本參數 %0 指定的明確參數無效'
 # "candidate template ignored: requirement '%0' was not satisfied%1"
-HB155E3417C9D: "候選範本被忽略：需求 '%0' 未滿足%1"
+HB155E3417C9D: "候選範本被忽略：需求 '%0' 未滿足 %1"
 # 'candidate template ignored: substitution exceeded maximum template instantiation depth'
 H6065ACD0EE36: '候選模板被忽略：替代超過最大模板實體化深度'
 # 'candidate template ignored: substitution failure%0%1'
-HF32FE861D856: '候選模板被忽略：替代失敗%0%1'
+HF32FE861D856: '候選模板被忽略：替代失敗 %0%1'
 # 'candidate template ignored: target attributes do not match'
 H8F2E4648A7AB: '候選模板被忽略：目標屬性不符合'
 # "cannot %select{#include files|import headers}0 inside '#pragma clang arc_cf_code_audited'"
@@ -18757,7 +18757,7 @@ H50812469123A: '無法為 %0 定義隱含的複製賦值運算子，因為非靜
 # 'cannot delete expression of type %0'
 H8F9B57A837EE: '無法刪除類型 %0 的運算式'
 # "cannot delete expression with pointer-to-'void' type %0"
-HCCFA093E9DE2: "無法刪除指標至'void'類型的運算式 %0"
+HCCFA093E9DE2: "無法刪除指標至 'void' 類型的運算式 %0"
 # 'cannot delete pointer to incomplete type %0'
 H7E32F7F5C2AD: '無法刪除指向不完整類型 %0 的指標'
 # "cannot determine %0 architecture: %1; consider passing it via '%2'; environment variable CLANG_TOOLCHAIN_PROGRAM_TIMEOUT specifies the tool timeout (integer secs, <=0 is infinite)"
@@ -18903,23 +18903,23 @@ H733C76C89DE9: '形成成員指標時不能對方法名稱使用括號'
 # 'cannot pass %select{expression of type %1|initializer list}0 to variadic %select{function|block|method|constructor}2'
 H25763FEA732A: '無法將 %select{類型 %1 的運算式|初始化清單}0 傳遞至可變參數 %select{函數|區塊|方法|建構函數}2'
 # 'cannot pass %select{expression of type %1|initializer list}0 to variadic %select{function|block|method|constructor}2; expected type from format string was %3'
-H6A81C62CC358: '無法將%select{類型%1的運算式|初始值列表}0 傳遞給多態參數的%select{函數|區塊|方法|建構函數}2；格式字串的期望類型為%3'
+H6A81C62CC358: '無法將%select{類型 %1 的運算式|初始值列表}0 傳遞給多態參數的%select{函數|區塊|方法|建構函數}2；格式字串的期望類型為 %3'
 # 'cannot pass %select{non-POD|non-trivial}0 object of type %1 to variadic %select{function|block|method|constructor}2; expected type from format string was %3'
-HB3C416B2C325: '無法將%select{非POD|非平凡}0 類型%1的物件傳遞給多態參數的%select{函數|區塊|方法|建構函數}2；格式字串的期望類型為%3'
+HB3C416B2C325: '無法將%select{非POD|非平凡}0 類型 %1 的物件傳遞給多態參數的%select{函數|區塊|方法|建構函數}2；格式字串的期望類型為 %3'
 # 'cannot pass a pointer-to-member through register-constrained inline assembly parameter'
 H1A2FFC7DC3D0: '無法透過受寄存器限制的內嵌組合語言參數傳遞成員指標'
 # 'cannot pass bit-field as __auto_type initializer in C'
 HC2EE224C8229: '在 C 語言中無法將位域用作 __auto_type 初始化式'
 # 'cannot pass non-trivial C object of type %0 by value to variadic %select{function|block|method|constructor}1'
-H2C5461696894: '無法將非平凡的C物件%0以值傳遞方式傳遞到可變長%select{函數|區塊|方法|建構函數}1'
+H2C5461696894: '無法將非平凡的C物件 %0 以值傳遞方式傳遞到可變長%select{函數|區塊|方法|建構函數}1'
 # 'cannot pass object of %select{non-POD|non-trivial}0 type %1 through variadic %select{function|block|method|constructor}2; call will abort at runtime'
-H03C685EEC43F: '無法將%select{非POD|非平凡}0類型%1的物件傳遞到可變長%select{函數|區塊|方法|建構函數}2；呼叫將在運行時中斷'
+H03C685EEC43F: '無法將%select{非POD|非平凡}0類型 %1 的物件傳遞到可變長%select{函數|區塊|方法|建構函數}2；呼叫將在運行時中斷'
 # 'cannot pass object with interface type %0 by value through variadic %select{function|block|method|constructor}1'
-HFFB4BE108833: '無法將具有介面類型%0的物件以值傳遞方式傳遞到可變長%select{函數|區塊|方法|建構函數}1'
+HFFB4BE108833: '無法將具有介面類型 %0 的物件以值傳遞方式傳遞到可變長%select{函數|區塊|方法|建構函數}1'
 # 'cannot pass object with interface type %1 by value to variadic %select{function|block|method|constructor}2; expected type from format string was %3'
-HFCF01B48F1C2: '無法以值方式將介面類型%1的物件傳遞給多態參數的%select{函數|區塊|方法|建構函數}2；格式字串的期望類型為%3'
+HFCF01B48F1C2: '無法以值方式將介面類型 %1 的物件傳遞給多態參數的%select{函數|區塊|方法|建構函數}2；格式字串的期望類型為 %3'
 # "cannot pass undiscriminated type %0 to '__builtin_ptrauth_type_discriminator'"
-HCF5D52D0F4BA: "無法將未指定類型%0傳遞到'__builtin_ptrauth_type_discriminator'"
+HCF5D52D0F4BA: "無法將未指定類型 %0 傳遞到 '__builtin_ptrauth_type_discriminator'"
 # 'cannot perform a tail call %select{from|to}0 a %select{constructor|destructor}1'
 H92D6BE5E0D10: '無法對%select{從|到}0%select{建構函數|解構函數}1執行尾調用'
 # 'cannot perform a tail call from this return statement'
@@ -18929,7 +18929,7 @@ H32E425482ACE: '無法對函數%select{| %1}0執行尾調用，因為它使用�
 # 'cannot perform a tail call to function%select{| %1}0 because its signature is incompatible with the calling function'
 HB6791E3481C6: '無法對函數%select{| %1}0執行尾調用，因為其簽章與呼叫函數不相容'
 # 'cannot perform atomic operation on a pointer to type %0: type has non-trivial ownership'
-H33A9E57472E9: '無法對具有非平凡擁有權的%0類型指標執行原子操作'
+H33A9E57472E9: '無法對具有非平凡擁有權的 %0 類型指標執行原子操作'
 # "cannot read configuration file '%0': %1"
 H0AF7279B0969: "無法讀取配置文件'%0'： %1"
 # "cannot read randomize layout seed file '%0'"
@@ -18937,7 +18937,7 @@ H97BBD89360BC: "無法讀取隨機化佈局種子文件'%0'"
 # "cannot rebuild module '%0' as it is already finalized"
 H80C2AA3A79E5: "無法重建已最終化的模組'%0'"
 # 'cannot redeclare builtin function %0'
-HC3E811B65243: '無法重新宣告內建函數%0'
+HC3E811B65243: '無法重新宣告內建函數 %0'
 # 'cannot refer to a block inside block'
 HEC4D55F7E1FA: '無法在區塊內部引用另一個區塊'
 # 'cannot refer to a non-static member from the handler of a %select{constructor|destructor}0 function try block'
@@ -19029,7 +19029,7 @@ H455974313E2A: "無法在同一函數中同時使用%select{C++ 'try'|Objective-
 # 'cannot use %select{dot|arrow}0 operator on a type'
 H546BD63E07E0: '無法對類型使用%select{點|箭號}0運算符'
 # "cannot use %select{unicode|wide}0 string literal in 'asm'"
-HD3FDC775E04A: "無法在'asm'中使用%select{Unicode|寬字符}0字元串字面量"
+HD3FDC775E04A: "無法在 'asm' 中使用%select{Unicode|寬字符}0字元串字面量"
 # "cannot use '%0' in %select{__device__|__global__|__host__|__host__ __device__}1 function"
 H92A38A76E58C: "無法在%select{__device__|__global__|__host__|__host__ __device__}1函數中使用'%0'"
 # "cannot use '%0' output with multiple -arch options"
@@ -19041,13 +19041,13 @@ H633899DC0353: "在停用Objective-C例外時無法使用'%0'"
 # "cannot use '%0' with exceptions disabled"
 H0F6B73A63960: "在停用例外處理時無法使用'%0'"
 # "cannot use '_Complex' with '__vector'"
-HCFEB59CAC054: "'_Complex'無法與'__vector'一起使用"
+HCFEB59CAC054: "'_Complex' 無法與 '__vector' 一起使用"
 # "cannot use 'float' with '__vector'"
-H8772A8A87C32: "'float'無法與'__vector'一起使用"
+H8772A8A87C32: "'float' 無法與 '__vector' 一起使用"
 # "cannot use 'long double' with '__vector'"
-HD41E42BADD92: "'long double'無法與'__vector'一起使用"
+HD41E42BADD92: "'long double'無法與 '__vector' 一起使用"
 # "cannot use 'long' with '__vector'"
-H0DD309217BB4: "'long'無法與'__vector'一起使用"
+H0DD309217BB4: "'long' 無法與 '__vector' 一起使用"
 # "cannot use SEH '__try' in a coroutine when C++ exceptions are enabled"
 H0484D634DF37: "當C++例外啟用時，協程中無法使用SEH '__try'"
 # "cannot use SEH '__try' in blocks, captured regions, or Obj-C method decls"
@@ -19057,31 +19057,31 @@ H70C162E9FD41: '無法將WebAssembly表作為函式參數使用'
 # 'cannot use a WebAssembly table within a branch of a conditional expression'
 H4CC748CB0567: '無法在條件運算式中將WebAssembly表用於分支的其中一個選項'
 # "cannot use a protocol declared 'objc_non_runtime_protocol' in a @protocol expression"
-H22D18CFED6B9: "無法在@protocol表達式中使用宣告為'objc_non_runtime_protocol'的協定"
+H22D18CFED6B9: "無法在@protocol表達式中使用宣告為 'objc_non_runtime_protocol' 的協定"
 # "cannot use an empty string literal in 'asm'"
-H9269C6D18FCF: "無法在'asm'中使用空字串字面量"
+H9269C6D18FCF: "無法在 'asm' 中使用空字串字面量"
 # 'cannot use dynamic_cast to convert from %0 to %1'
-H5749CC5204B8: '無法使用dynamic_cast將%0轉換為%1'
+H5749CC5204B8: '無法使用dynamic_cast將 %0 轉換為 %1'
 # 'cannot use incomplete type %0 as a range'
-H779605C5A805: '無法使用不完整類型%0作為範圍'
+H779605C5A805: '無法使用不完整類型 %0 作為範圍'
 # 'cannot use initializer list at the beginning of a macro argument'
 HFB12BDAF6D6F: '無法在巨集參數開頭處使用初始化清單'
 # 'cannot use type %0 as a range'
-H9F644F56E9E3: '無法將類型%0用作範圍'
+H9F644F56E9E3: '無法將類型 %0 用作範圍'
 # 'cannot use type %0 as an iterator'
-H45599EAAF2D8: '無法將類型%0用作迭代器'
+H45599EAAF2D8: '無法將類型 %0 用作迭代器'
 # "cannot use type '%0' within '#pragma clang fp eval_method'; type is set according to the default eval method for the translation unit"
 HD91CCA267FD1: "無法在'#pragma clang fp eval_method'中使用類型'%0'；該類型根據翻譯單元的預設評估方法設定"
 # 'cannot use variable %1 in collapsed imperfectly-nested loop %select{init|condition|increment}0 statement'
-H40887EDB8E4A: '無法在塌陷的不完全嵌套迴圈%select{初始化|條件|遞增}0語句中使用變數%1'
+H40887EDB8E4A: '無法在塌陷的不完全嵌套迴圈%select{初始化|條件|遞增}0語句中使用變數 %1'
 # 'cannot use variable-length arrays in %select{__device__|__global__|__host__|__host__ __device__}0 functions'
 H33A7639314BD: '無法在%select{__device__|__global__|__host__|__host__ __device__}0函式中使用可變長度陣列'
 # "cannot write file '%0': %1"
 H57D82DC5A945: "無法寫入檔案'%0'： %1"
 # 'cannot yet @encode type %0'
-H5CF1C5265DEE: '無法對此ABI編譯%0'
+H5CF1C5265DEE: '無法對此ABI編譯 %0'
 # 'cannot yet compile %0 in this ABI'
-H7B123038B924: '尚無法@encode類型%0'
+H7B123038B924: '尚無法@encode類型 %0'
 # 'cannot yet mangle %0 expression'
 HA255CBB16444: '目前無法轉換符號名稱為 %0 的運算式'
 # 'cannot yet mangle OpenACC Asterisk Size expression'
@@ -19089,7 +19089,7 @@ H2D31700B7C49: '目前無法轉換符號名稱為 OpenACC Asterisk Size 運算�
 # 'cannot yet mangle expression type %0'
 HF4D45A826D3A: '目前無法轉換符號名稱為類型 %0 的運算式'
 # 'capture %0 by %select{value|reference}1'
-HD0ACA3E1F2BB: '以%select{值|引用}1方式捕獲%0'
+HD0ACA3E1F2BB: '以%select{值|引用}1方式捕獲 %0'
 # 'capture default must be first'
 HBD6F708D5FEC: '捕獲預設必須為第一個'
 # 'capture host side class data member by this pointer in device or host device lambda function may result in invalid memory access if this pointer is not accessible on device side'
@@ -19099,13 +19099,13 @@ H4218AAE93F26: '在裝置或混合裝置lambda運算式中，以引用方式捕�
 # "capture of '*this' by copy is a C++17 extension"
 H9C3948693023: '以值方式捕獲*this 是C++17擴充語法'
 # "capture of variable '%0' as type %1 calls %select{private|protected}3 %select{default |copy |move |*ERROR* |*ERROR* |*ERROR* |}2constructor"
-H6489D0544330: "以類型%1捕獲變數 '%0' 調用%select{私有|受保護}3 %select{預設 |複製 |移動 |*ERROR* |*ERROR* |*ERROR* |}2建構函數"
+H6489D0544330: "以類型 %1 捕獲變數 '%0' 調用%select{私有|受保護}3 %select{預設 |複製 |移動 |*ERROR* |*ERROR* |*ERROR* |}2建構函數"
 # 'captured structured bindings are a C++20 extension'
 HED60DD4C6A62: '捕獲結構化綁定是C++20擴充語法'
 # 'captured structured bindings are incompatible with C++ standards before C++20'
 HA1967A579A6F: '結構化綁定捕獲在C++20之前標準中不相容'
 # 'capturing %0 strongly in this block is likely to lead to a retain cycle'
-H495EA167E92F: '在此區塊中強制捕獲%0 可能導致保留週期'
+H495EA167E92F: '在此區塊中強制捕獲 %0 可能導致保留週期'
 # 'capturing a structured binding is not yet supported in OpenMP'
 H3DD2898A017E: 'OpenMP尚不支援捕獲結構化綁定'
 # 'case ranges are a C2y extension'
@@ -19115,7 +19115,7 @@ H0ADA830DF441: 'case區間是GNU擴充語法'
 # 'case ranges are incompatible with C standards before C2y'
 H94092A9759CB: 'case範圍與C2y標準之前版本不相容'
 # 'case value not in enumerated type %0'
-H4866E4105494: '枚舉類型%0中不存在該case值'
+H4866E4105494: '枚舉類型 %0 中不存在該case值'
 # 'cast %diff{from $ to $ |}0,1converts to incompatible function type'
 HAE54FE7B3C1C: '將%diff{從 $ 轉換為 $ |}0,1轉換為不相容的函數類型'
 # "cast between incompatible calling conventions '%0' and '%1'; calls through this pointer may abort at runtime"
@@ -19127,21 +19127,21 @@ HD37948261117: '函數指標與物件指標轉換與C++98不相容'
 # 'cast expression to void to silence warning'
 H1D7499C23CFE: '將運算式轉換為void以消除警告'
 # 'cast from %0 is not allowed in a constant expression %select{in C++ standards before C++2c|because the pointed object type %2 is not similar to the target type %3}1'
-H542ED6DEC45B: '在C++標準C++2c之前%select{不允許在常量運算式中從%0轉換|因為所指物件類型%2與目標類型%3不相似}1'
+H542ED6DEC45B: '在C++標準C++2c之前%select{不允許在常量運算式中從 %0 轉換|因為所指物件類型 %2 與目標類型 %3 不相似}1'
 # 'cast from %0 to %1 drops %select{const and volatile qualifiers|const qualifier|volatile qualifier}2'
-HA3B03023258D: '從%0轉換為%1會丟失%select{const和volatile修飾符|const修飾符|volatile修飾符}2'
+HA3B03023258D: '從 %0 轉換為 %1 會丟失%select{const和volatile修飾符|const修飾符|volatile修飾符}2'
 # 'cast from %0 to %1 increases required alignment from %2 to %3'
-H4A02BB23383F: '從%0轉換為%1會將必要對齊值從%2提升至%3'
+H4A02BB23383F: '從 %0 轉換為 %1 會將必要對齊值從 %2 提升至 %3'
 # 'cast from %0 to %1 must have all intermediate pointers const qualified to be safe'
-HB7DFA89AF07B: '從%0轉換為%1必須使所有中間指標具有const修飾符才能確保安全'
+HB7DFA89AF07B: '從 %0 轉換為 %1 必須使所有中間指標具有const修飾符才能確保安全'
 # 'cast from function call of type %0 to non-matching type %1'
-H8CE3B0EB72DC: '將類型%0的函數呼叫轉換為不匹配的類型%1'
+H8CE3B0EB72DC: '將類型 %0 的函數呼叫轉換為不匹配的類型 %1'
 # 'cast from pointer to smaller type %2 loses information'
-H60D928000B5D: '將指標轉換為較小的類型%2會導致資料遺失'
+H60D928000B5D: '將指標轉換為較小的類型 %2 會導致資料遺失'
 # 'cast of %select{Objective-C|block|C}0 pointer type %1 to %select{Objective-C|block|C}2 pointer type %3 cannot use %select{__bridge|__bridge_transfer|__bridge_retained}4'
-H2F5F45B60576: '%select{Objective-C|區塊|C}0指標類型%1轉換為%select{Objective-C|區塊|C}2指標類型%3不能使用%select{__bridge|__bridge_transfer|__bridge_retained}4'
+H2F5F45B60576: '%select{Objective-C|區塊|C}0指標類型 %1 轉換為 %select{Objective-C|區塊|C}2 指標類型 %3 不能使用%select{__bridge|__bridge_transfer|__bridge_retained}4'
 # 'cast of type %0 to %1 is deprecated; use sel_getName instead'
-HC7428E5162D0: '將類型%0轉換為%1已被棄用；請改用sel_getName'
+HC7428E5162D0: '將類型 %0 轉換為 %1 已被棄用；請改用sel_getName'
 # 'cast one or both operands to int to silence this warning'
 H49949EF0EEB5: '將一個或兩個運算元轉換為 int 以消除此警告'
 # 'cast to %1 from smaller integer type %0'
@@ -19355,11 +19355,11 @@ H4D3F55AAB37F: "兩個陣列的比較已被棄用；如需比較陣列位址，�
 # "comparison between two arrays is ill-formed in C++26; to compare array addresses, use unary '+' to decay operands to pointers"
 H20B4EE22A6C2: "C++26中兩個陣列的比較不符合語法規範；如需比較陣列位址，請使用一元 '+' 運算子使操作數衰減為指標"
 # "comparison of %select{address of|function|array}0 '%1' %select{not |}2equal to a null pointer is always %select{true|false}2"
-H61B7557646A7: "與空指標的 %select{地址的|函數的|陣列的}0 '%1' %select{不|}2比較始終為%select{true|false}2"
+H61B7557646A7: "與空指標的 %select{地址的|函數的|陣列的}0 '%1' %select{不|}2比較始終為 %select{true|false}2"
 # 'comparison of address of base class subobject %0 of class %1 to field %2 has unspecified value'
 HCEA4BEB9DFF0: '基類子物件 %0（類別 %1）與成員 %2 的地址比較值未指定'
 # 'comparison of address of fields %0 and %2 of %4 with differing access specifiers (%1 vs %3) has unspecified value'
-H30BB5DCF7738: '具有不同存取修飾符（%1 vs %3）的%4的成員%0和%2地址比較結果未指定'
+H30BB5DCF7738: '具有不同存取修飾符（%1 vs %3）的 %4 的成員 %0 和 %2 地址比較結果未指定'
 # 'comparison of addresses of potentially overlapping literals has unspecified value'
 H59EF9C14B9AF: '重疊文字的地址比較結果未指定'
 # 'comparison of addresses of subobjects of different base classes has unspecified value'
@@ -19525,11 +19525,11 @@ H0B91FFD90BE8: '建議使用 vld1q_%0%1() 從記憶體初始化向量，或使�
 # 'const variable cannot be emitted on device side due to dynamic initialization'
 H2D4E40F2FA4A: '因動態初始化，const 變數無法在裝置側發射'
 # 'const-qualified list item cannot be %0'
-HABDF81BBC813: 'const限定的清單項目無法%0'
+HABDF81BBC813: 'const限定的清單項目無法 %0'
 # 'const-qualified variable cannot be %0'
-H02E8DDC8D310: 'const限定的變數無法%0'
+H02E8DDC8D310: 'const限定的變數無法 %0'
 # 'const-qualified variable without mutable fields cannot be %0'
-HF38DA802B6DD: '無可變字段的const限定變數無法%0'
+HF38DA802B6DD: '無可變字段的const限定變數無法 %0'
 # 'constant evaluation of %0 between arrays of types %1 and %2 is not supported; only arrays of narrow character types can be compared'
 H42EAC15FC487: '類型 %1 和 %2 的陣列間 %0 的常數運算式評估不支援；僅支援窄字符類型陣列的比較'
 # 'constant evaluation of %0 on array of type %1 is not supported; only arrays of narrow character types can be searched'
@@ -19575,11 +19575,11 @@ H8C78EE861C25: 'constexpr if 是 C++17 擴展'
 # 'constexpr if is incompatible with C++ standards before C++17'
 H518345725A13: "'constexpr if' 與C++17之前版本標準不相容"
 # 'constexpr initializer evaluates to %0 which is not exactly representable in type %1'
-HFD7668DF8CE8: "'constexpr' 初始化運算式結果為%0，無法精確表示為類型%1"
+HFD7668DF8CE8: "'constexpr' 初始化運算式結果為 %0，無法精確表示為類型 %1"
 # 'constexpr initializer for type %0 is of type %1'
-H57EA50C1B712: "類型%0的'constexpr' 初始化運算式具有類型%1"
+H57EA50C1B712: "類型 %0 的 'constexpr' 初始化運算式具有類型 %1"
 # 'constexpr on lambda expressions is incompatible with C++ standards before C++17'
-H2F64715F9E19: "lambda運算式的'constexpr' 與C++17之前版本標準不相容"
+H2F64715F9E19: "lambda運算式的 'constexpr' 與C++17之前版本標準不相容"
 # 'constexpr pointer initializer is not null'
 HA90F435C9DCD: "'constexpr' 指標初始化式不是null"
 # 'constexpr union constructor that does not initialize any member is a C++20 extension'
@@ -19587,19 +19587,19 @@ HDA9656DF3125: "C++20擴充功能：未初始化任何成員的'union constexpr�
 # 'constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20'
 H42AB5A6736FE: "未初始化任何成員的'union constexpr建構函數' 與C++20之前版本標準不相容"
 # 'constexpr variable %0 must be initialized by a constant expression'
-H22D6867A6C46: "'constexpr' 變數%0必須以常數運算式初始化"
+H22D6867A6C46: "'constexpr' 變數 %0 必須以常數運算式初始化"
 # 'constexpr variable %0 must have constant destruction'
-H0CB1A9F457E9: "'constexpr' 變數%0必須具有常數銷毀性"
+H0CB1A9F457E9: "'constexpr' 變數 %0 必須具有常數銷毀性"
 # 'constexpr variable cannot have non-literal type %0'
-H8CA68B10BD1E: "具非文字類型%0的'constexpr' 變數無效"
+H8CA68B10BD1E: "具非文字類型 %0 的 'constexpr' 變數無效"
 # 'constexpr variable cannot have type %0'
-H9CBE3FDAF244: "具類型%0的'constexpr' 變數無效"
+H9CBE3FDAF244: "具類型 %0 的 'constexpr' 變數無效"
 # 'constexpr variable declaration must be a definition'
 H28D5C206A058: "'constexpr' 變數宣告必須為定義"
 # 'constrained by %select{|implicitly }1%select{private|protected}0 inheritance here'
 HA215ECA901D4: '因%select{|隱式 }1%select{私有|受保護}0繼承在此處受限制'
 # "constrained placeholder types other than simple 'auto' on non-type template parameters not supported yet"
-HA5CE432D2BF4: "非類型範型參數上除簡單'auto'以外的佔位符類型尚未支援"
+HA5CE432D2BF4: "非類型範型參數上除簡單 'auto' 以外的佔位符類型尚未支援"
 # "constraint '%0' is already present here"
 HDBC0B5C441D3: "限制條件 '%0' 已在此處存在"
 # 'constraint depends on a previously diagnosed expression'
@@ -19663,21 +19663,21 @@ HDD7803D6F7A1: '轉換 %diff{從 $ 到 $|在類型間}0,1 含糊不清'
 # 'conversion between fixed point and %0 is not yet supported'
 HF68AF1DBEB64: '固定點與 %0 之間的轉換尚未支援'
 # 'conversion between matrix type %0 and incompatible type %1 is not allowed'
-H499A22E2DD8F: '不允許在不相容類型%0與%1的矩陣類型之間轉換'
+H499A22E2DD8F: '不允許在不相容類型 %0 與 %1 的矩陣類型之間轉換'
 # 'conversion between matrix types%diff{ $ and $|}0,1 of different size is not allowed'
 H82DF9F4CF265: '不允許不同大小的矩陣類型%diff{ $和$|}0,1之間轉換'
 # 'conversion candidate %0 not viable: constraints not satisfied'
-H1A87D3FA633E: '轉換候選%0不可行：約束條件不符合'
+H1A87D3FA633E: '轉換候選 %0 不可行：約束條件不符合'
 # 'conversion candidate of type %0'
-H1704891C4D79: '轉換為類型%0的轉換函式'
+H1704891C4D79: '轉換為類型 %0 的轉換函式'
 # 'conversion from %0 to %1 in converted constant expression would bind reference to a temporary'
-H22C174FA2D9C: '從%0轉換為%1的轉換常數表達式會將引用綁定到暫時物件'
+H22C174FA2D9C: '從 %0 轉換為 %1 的轉換常數表達式會將引用綁定到暫時物件'
 # 'conversion from %0 to %1 is not allowed in a converted constant expression'
-H64DA1E381CAE: '在轉換常數表達式中從%0轉換為%1不被允許'
+H64DA1E381CAE: '在轉換常數表達式中從 %0 轉換為 %1 不被允許'
 # 'conversion from pointer to member of class %0 to pointer to member of class %1 via virtual base %2 is not allowed'
-HC6DC2FD11DE6: '不允許通過虛基類%2將類%0的成員指標轉換為類%1的成員指標'
+HC6DC2FD11DE6: '不允許通過虛基類 %2 將類 %0 的成員指標轉換為類 %1 的成員指標'
 # 'conversion from string literal to %0 is deprecated'
-H1DEAC81E3C65: '將字串字面量轉換為%0已被棄用'
+H1DEAC81E3C65: '將字串字面量轉換為 %0 已被棄用'
 # 'conversion function %diff{from $ to $|between types}0,1 invokes a deleted function%select{|: %3}2'
 H302A0E48B3BA: '轉換函數%diff{從$到$的轉換|類型之間的轉換}0,1 調用了已刪除的函數%select{|: %3}2'
 # 'conversion function cannot be redeclared'
@@ -19715,7 +19715,7 @@ HFA594BB552D0: '將類型 %0 的delete運算式轉換為類型 %1 時調用了�
 # 'converting the enum constant to a boolean'
 HC26D67935F61: '將列舉常數轉換為布林值'
 # "converting the result of '<<' to a boolean always evaluates to %select{false|true}0"
-H66F90B0804A0: '將「<<」運算結果轉換為布林值始終評估為%select{false|true}0'
+H66F90B0804A0: '將「<<」運算結果轉換為布林值始終評估為 %select{false|true}0'
 # "converting the result of '<<' to a boolean; did you mean '(%0) != 0'?"
 HB5F0E9F35B11: '將「<<」的運算結果轉換為布林值；是否意為「(%0) != 0」？'
 # "converting the result of '?:' with integer constants to a boolean always evaluates to 'true'"
@@ -19751,13 +19751,13 @@ HB17669DA1C41: '無法將 %diff{ $ 匹配 $ |類型}1,0 進行對應'
 # "could not open '%0' for embedding"
 HF452E067B4E2: "無法開啟 '%0' 進行嵌入"
 # "could not read %0 input list '%1': %2"
-H67879BBD7E88: "無法讀取%0輸入清單 '%1'：%2"
+H67879BBD7E88: "無法讀取 %0 輸入清單 '%1'：%2"
 # "could not read directory '%0': %1"
 HBA8BA2C7E279: "無法讀取目錄 '%0'：%1"
 # "could not remap file '%0' to the contents of file '%1'"
 H154079BD4163: "無法將檔案 '%0' 重新映射為檔案 '%1' 的內容"
 # 'covariant thunk required by %0'
-H96E8ACBA5464: '%0所需的協變 thunk'
+H96E8ACBA5464: '%0 所需的協變 thunk'
 # "cpu '%0' does not support rv%select{32|64}1"
 HB22CC79010F2: "CPU '%0' 不支援rv%select{32|64}1"
 # 'create a static PC table'
@@ -19765,7 +19765,7 @@ HA9821FD0C9F2: '建立靜態程序計數器表'
 # "current API version is '%0', but plugin was compiled with version '%1'"
 H399ED19E4A74: "目前API版本為'%0'，但插件編譯時使用版本為'%1'"
 # 'current file is older than dependency %0'
-HCE89B30434E7: '目前檔案比依賴項%0舊'
+HCE89B30434E7: '目前檔案比依賴項 %0 舊'
 # "current handling of vector bool and vector pixel types in this context are deprecated; the default behaviour will soon change to that implied by the '-altivec-compat=xl' option"
 H2144886C992F: "當前向量布林值和向量像素類型在此語境中的處理方式已棄用；預設行為將很快變更為'-altivec-compat=xl'選項所暗示的行為"
 # "current_version does not match: '%0' (provided) vs '%1' (found)"
@@ -19781,13 +19781,13 @@ H3A25FAA1F4B4: "資料參數位置'%0'超過資料參數總數(%1)"
 # 'data layout string to use'
 HBFBB6DFFCFDF: '要使用的資料布局字串'
 # 'data member instantiated with function type %0'
-HE2AF1A6B9D7C: '以函式類型%0實體化的資料成員'
+HE2AF1A6B9D7C: '以函式類型 %0 實體化的資料成員'
 # "data-sharing attribute '%0' in '%1' clause requires OpenMP version %2 or above"
-H12FB4E840EF7: "'%0' 資料共用屬性在'%1'子句中需要OpenMP版本%2或更高版本"
+H12FB4E840EF7: "'%0' 資料共用屬性在'%1'子句中需要OpenMP版本 %2 或更高版本"
 # 'dbx'
 H362301DA6431: 'dbx'
 # "dealloc return type must be correctly specified as 'void' under ARC, instead of %0"
-HF5C8E84C253E: "在ARC下dealloc傳回類型必須正 xác指定為'void'，而非%0"
+HF5C8E84C253E: "在ARC下dealloc傳回類型必須正 xác指定為 'void'，而非 %0"
 # 'debug'
 H32FAAECAC742: 'debug'
 # "debug information option '%0' is not supported for target '%1'"
@@ -20133,15 +20133,15 @@ H40BB23B29C3F: "宏 '%0' 在 AST 檔案 '%3' ('%1') 與命令列 ('%2') 中的�
 # "definition of module '%0' is not available; use -fmodule-file= to specify path to precompiled module interface"
 H1ED33479DE5D: "模組 '%0' 的定義不可用；使用 -fmodule-file= 指定預編譯模組介面的路徑"
 # 'definition of type %0 conflicts with %select{typedef|type alias}1 of the same name'
-H5C3C4CCA94AB: '類型%0的定義與同名的%select{typedef|類型別名}1產生衝突'
+H5C3C4CCA94AB: '類型 %0 的定義與同名的%select{typedef|類型別名}1產生衝突'
 # 'definition of variable with array type needs an explicit size or an initializer'
 H79E09A4784DB: '陣列類型的變數定義需要明確指定大小或提供初始化值'
 # 'definition or redeclaration of %0 cannot name the global scope'
-H3AC58FC9EA5A: '%0的定義或重新宣告不能指定全域作用域'
+H3AC58FC9EA5A: '%0 的定義或重新宣告不能指定全域作用域'
 # 'definition or redeclaration of %0 not allowed inside a block'
-HD4328CF55600: '%0的定義或重新宣告不允許出現在區塊內部'
+HD4328CF55600: '%0 的定義或重新宣告不允許出現在區塊內部'
 # 'definition or redeclaration of %0 not allowed inside a function'
-H26DE3CAC54F0: '%0的定義或重新宣告不允許出現在函數內部'
+H26DE3CAC54F0: '%0 的定義或重新宣告不允許出現在函數內部'
 # "definition with same mangled name '%0' as another definition"
 H9CD626C8B999: "定義與另一個定義具有相同的雜湊名稱 '%0'"
 # 'defsym must be of the form: sym=value: %0'
@@ -20151,7 +20151,7 @@ H57A554A5A2B8: '委派建構函數與 C++98 不相容'
 # 'delegating constructors are permitted only in C++11'
 H859BD39058E0: '僅允許在 C++11 中使用委派建構函數'
 # 'delete of object with dynamic type %1 through pointer to base class type %0 with non-virtual destructor'
-H2817C3914B5E: '通過基類%0的指標刪除動態類型為%1的物件，而基類未宣告虛函數析構函數'
+H2817C3914B5E: '通過基類 %0 的指標刪除動態類型為 %1 的物件，而基類未宣告虛函數析構函數'
 # "delete of pointer '%0' that does not point to a heap-allocated object"
 H8B4F3ED0F000: "刪除未指向堆上物件的指標 '%0'"
 # 'delete of pointer that has already been deleted'
@@ -20161,7 +20161,7 @@ H4DFF941C0746: '刪除%select{指向子物件的 | }1指標 %0%select{ | 其不�
 # 'deleted definition must be first declaration'
 H0F602982588E: '已刪除的函數定義必須為首次宣告'
 # 'deleted function %0 cannot override a non-deleted function'
-H3FCDC44C217B: '已刪除的函數%0無法覆寫未被刪除的函數'
+H3FCDC44C217B: '已刪除的函數 %0 無法覆寫未被刪除的函數'
 # 'deleting incomplete class type %0; no conversions to pointer type'
 H9074591E0AF3: '刪除不完整類型 %0 的指標；無法轉換為指標類型'
 # 'deleting pointer to incomplete type %0 is incompatible with C++2c and may cause undefined behavior'
@@ -20291,7 +20291,7 @@ H034E19BAF4DB: "是否是指 %0 ('%2' U+%1)?"
 # 'did you mean %0?'
 H0AFE75F407BD: '是否意指 %0？'
 # 'did you mean %select{struct|interface|class}0 here?'
-H2F94B54CE3AD: '是否意指在此處使用%select{struct|interface|class}0？'
+H2F94B54CE3AD: '是否意指在此處使用 %select{struct|interface|class}0？'
 # "did you mean '%0'?"
 HC2D29273BC0C: "是否意指 '%0'？"
 # "did you mean 'using namespace'?"
@@ -20299,9 +20299,9 @@ H7384271A4FC4: "是否意指使用 'using namespace'？"
 # "did you mean to %select{dereference the argument to 'sizeof' (and multiply it by the number of elements)|remove the addressof in the argument to 'sizeof' (and multiply it by the number of elements)|provide an explicit length}0?"
 H206E38ACCE90: '是否意圖%select{對sizeof參數取解引用並乘以元素數量|移除sizeof參數的地址運算子並乘以元素數量|明確提供長度}0？'
 # 'did you mean to call the %0 method?'
-H0FF3D4ADDC94: '是否意圖呼叫%0方法？'
+H0FF3D4ADDC94: '是否意圖呼叫 %0 方法？'
 # 'did you mean to compare the result of %0 instead?'
-HA27A0B6056FB: '是否意圖比較%0的結果？'
+HA27A0B6056FB: '是否意圖比較 %0 的結果？'
 # "did you mean to use '%0'?"
 H18F66684E290: "是否意圖使用 '%0'？"
 # "did you mean to use '.' instead?"
@@ -20311,7 +20311,7 @@ H8EB1B38F64B3: "是否意圖使用 '\\u' 轉義序列表示Unicode代碼點？"
 # "did you mean to use 'typename'?"
 HA177681AD789: "是否意圖使用 'typename' 關鍵字？"
 # 'did you mean to use __block %0?'
-H6A59F85FFA80: '是否意圖使用__block修飾符宣告%0？'
+H6A59F85FFA80: '是否意圖使用__block修飾符宣告 %0？'
 # "differing user-defined suffixes ('%0' and '%1') in string literal concatenation"
 HD69068F6D5EE: "字串文字連接時的使用者定義後綴不一致（'%0' 和 '%1'）"
 # 'digit separator cannot appear at %select{start|end}0 of digit sequence'
@@ -20373,7 +20373,7 @@ H90AD861FB58A: '停用將TBAA標籤附加到記憶體存取操作，以覆蓋Fla
 # 'disable attributor runs'
 H6B93977370B5: '停用attributor passes'
 # 'disable automatically generated 32byte paired vector stores'
-H37D64DB7E6AE: '停用自動生成32字節配對向量儲存指令'
+H37D64DB7E6AE: '停用自動生成 32 字節配對向量儲存指令'
 # 'disable constant hoisting on PPC'
 H653549C49999: '停用在PPC架構上的常數提升優化'
 # 'disable debug output'
@@ -20471,11 +20471,11 @@ H06D0BAB57AFF: '不掃描冷函數的外部引用（可能導致二進位執行�
 # 'do not show.'
 H410E3DC30FB6: '不顯示。'
 # 'domain argument %0 does not point to an NSString or CFString constant'
-H04276D1D8088: 'domain引數%0 不指向前NSString或CFString常數'
+H04276D1D8088: 'domain引數 %0 不指向前NSString或CFString常數'
 # 'domain argument %select{|%1 }0does not refer to global constant'
 H427CD3AEDAC3: 'domain引數%select{|%1 }0未引用全域常數'
 # "don't always align innermost loop to 32 bytes on ppc"
-H8446540436C8: '不總是將最內層迴圈對齊至32位元組（在ppc上）'
+H8446540436C8: '不總是將最內層迴圈對齊至 32 位元組（在ppc上）'
 # "don't demangle symbols"
 HFD596F32C278: '不轉換符號名稱'
 # "don't report bad accesses via pointers with this tag"
@@ -20483,15 +20483,15 @@ HC0582E9D5000: '不報告此標籤指標的非法存取'
 # "don't test for failure"
 H2CD70DD9AB50: '不測試失敗'
 # 'double precision constant requires %select{cl_khr_fp64|cl_khr_fp64 and __opencl_c_fp64}0, casting to single precision'
-H4D72ED1FA64B: '雙精度常數需要%select{cl_khr_fp64|cl_khr_fp64和__opencl_c_fp64}0，轉換為單精度'
+H4D72ED1FA64B: '雙精度常數需要 %select{cl_khr_fp64|cl_khr_fp64和__opencl_c_fp64}0，轉換為單精度'
 # 'double-quoted include "%0" cannot be aliased to angle-bracketed include <%1>'
 H136E4A788F48: '雙引號包含路徑"%0"無法轉為尖括號包含路徑<%1>'
 # 'double-quoted include "%0" in framework header, expected angle-bracketed instead'
 H2D4306614026: '框架標頭中使用雙引號包含的 "%0"，應改用尖括號包含'
 # 'due to %0 being dllexported%select{|; try compiling in C++11 mode}1'
-HB6A4EDE022F4: '由於%0 被 dllexport 標記%select{|；嘗試以C++11模式編譯}1'
+HB6A4EDE022F4: '由於 %0 被 dllexport 標記%select{|；嘗試以C++11模式編譯}1'
 # 'due to lvalue conversion of the controlling expression, association of type %0 will never be selected because it is %select{of array type|qualified}1'
-HE4CE0D7DDF88: '由於控制運算式的左值轉換，類型%0 的關聯將永遠不會被選取，因為其%select{是陣列類型|已修飾}1'
+HE4CE0D7DDF88: '由於控制運算式的左值轉換，類型 %0 的關聯將永遠不會被選取，因為其%select{是陣列類型|已修飾}1'
 # 'dump CFG of functions with unknown control flow'
 HDBCCF42DD8E1: '匯出具有未知控制流程函數的CFG'
 # 'dump CodeView symbol record raw bytes'
@@ -20597,7 +20597,7 @@ H02D59206CDC4: '傾印類型雜湊值與索引偏移量'
 # 'dumps the generated benchmark object to disk and prints a message to access it'
 H7BC6D646456E: '將產生的效能測試物件寫入磁碟並印出訊息以存取它'
 # "duplicate %0 clause in an 'external_source_symbol' attribute"
-H3523FE9C404F: "在'external_source_symbol'屬性中重複的%0子句"
+H3523FE9C404F: "在 'external_source_symbol' 屬性中重複的 %0 子句"
 # "duplicate '%0' declaration specifier"
 HD8ED5E5CBF0B: "重複的宣告指定詞'%0'"
 # "duplicate 'virtual' in base specifier"
@@ -20613,33 +20613,33 @@ HCE899F8A3E5C: "重複的case值：'%0'和'%1'都等於'%2'"
 # 'duplicate code segment specifiers'
 HBEFD6978776A: '重複的程式碼段指定項'
 # 'duplicate declaration of method %0'
-HA0EF6CBBD7AC: '方法%0的重複宣告'
+HA0EF6CBBD7AC: '方法 %0 的重複宣告'
 # 'duplicate default generic association'
 H2C51601AE456: '重複的預設泛型關聯'
 # 'duplicate definition of category %1 on interface %0'
-HECFD78DC0BC9: '介面%0上的類別%1的重複定義'
+HECFD78DC0BC9: '介面 %0 上的類別 %1 的重複定義'
 # 'duplicate explicit instantiation of %0'
-HDBC529CD9977: '%0的明確實體化的重複宣告'
+HDBC529CD9977: '%0 的明確實體化的重複宣告'
 # 'duplicate explicit instantiation of %0 ignored as a Microsoft extension'
-HDA2A4AABFB51: '忽略明確實例化%0的重複宣告，因Microsoft擴展規則'
+HDA2A4AABFB51: '忽略明確實例化 %0 的重複宣告，因Microsoft擴展規則'
 # 'duplicate interface definition for class %0'
-H95CB7C0C6F7F: '類%0的介面定義重複'
+H95CB7C0C6F7F: '類 %0 的介面定義重複'
 # 'duplicate key in dictionary literal'
 H048B82F688D2: '字典文字中重複的鍵'
 # 'duplicate macro parameter name %0'
-H066136189F8C: '重複的宏參數名稱%0'
+H066136189F8C: '重複的宏參數名稱 %0'
 # 'duplicate member %0'
-HC0ECCD41D310: '重複的成員%0'
+HC0ECCD41D310: '重複的成員 %0'
 # "duplicate modifier '%0' in '%1' clause"
 HF11C4EF9CA32: "在'%1'子句中重複的修飾符'%0'"
 # "duplicate module file extension block name '%0'"
 HCCAD463A8663: "重複的模組檔案擴展區塊名稱'%0'"
 # 'duplicate nullability specifier %0'
-HBA9CD0A409AC: '重複的nullability指定符%0'
+HBA9CD0A409AC: '重複的nullability指定符 %0'
 # 'duplicate parameter modifier %0'
-H6D49784340BA: '重複的參數修飾符%0'
+H6D49784340BA: '重複的參數修飾符 %0'
 # 'duplicate protocol definition of %0 is ignored'
-HD20F74839349: '忽略%0的重複協定定義'
+HD20F74839349: '忽略 %0 的重複協定定義'
 # 'duplicate unconditional branches that cross a cache line'
 H33FDED0520CF: '跨越快取線的無條件分支重複出現'
 # 'duplicate use of asm operand name "%0"'
@@ -20649,7 +20649,7 @@ H76B78FD8FF48: "重複的命令'%select{\\|@}0%1'"
 # 'during field initialization in %select{this|the implicit default}0 constructor'
 H865BE3842864: '在%select{這個|隱式預設}0建構函式中進行成員變數初始化時'
 # 'during template argument deduction for %select{class|variable}0 template %select{partial specialization |}1%2 %3'
-H7650D46B8E2E: '在%select{類別|變數}0模板%select{部分特化 |}1%2 %3的參數推導期間'
+H7650D46B8E2E: '在%select{類別|變數}0模板%select{部分特化 |}1%2 %3 的參數推導期間'
 # 'dxc compatibility options.'
 H3AF127D95E36: 'Dxc相容選項。'
 # 'dxv not found; resulting DXIL will not be validated or signed for use in release environment'
@@ -20791,9 +20791,9 @@ H0CF57E62B75D: '在AArch64上啟用redzone的使用'
 # 'enable/disable all ARC Optimizations'
 H0DFE6EE5AB14: '啟用/停用所有ARC優化'
 # 'enclose %0 in %select{an @available|a __builtin_available}1 check to silence this warning'
-HC0011ACD5CEF: '將%0包裝在%select{@available的檢查|__builtin_available的檢查}1中以消除此警告'
+HC0011ACD5CEF: '將 %0 包裝在%select{@available的檢查|__builtin_available的檢查}1中以消除此警告'
 # 'encoding of %0 type is incomplete because %1 component has unknown encoding'
-HE63ED9F43B42: '%0類型的編碼不完整，因為%1組成部分具有未知的編碼'
+HE63ED9F43B42: '%0 類型的編碼不完整，因為 %1 組成部分具有未知的編碼'
 # "encoding prefix '%0' on an unevaluated string literal has no effect%select{| and is incompatible with c++2c}1"
 HFB264777D8F6: "在未計算的字串字面值上使用編碼前綴'%0'無效%select{|且與c++2c不相容}1"
 # 'end tag'
@@ -20801,9 +20801,9 @@ HE76165194C35: '結束標籤'
 # "entering module '%0' due to this pragma"
 H00CF7F723C1C: "因這個pragma進入模組'%0'"
 # 'enum %0 was explicitly specialized here'
-H888313DD02EB: '枚舉%0在此處被明確專門化'
+H888313DD02EB: '枚舉 %0 在此處被明確專門化'
 # 'enumeration %0 is incomplete'
-HACD4B99390E7: '枚舉%0不完整'
+HACD4B99390E7: '枚舉 %0 不完整'
 # 'enumeration cannot be a template'
 H0777CF5091AE: '枚舉不能是範本'
 # 'enumeration previously declared as %select{un|}0scoped'
@@ -20907,7 +20907,7 @@ HBB63D54D7089: '覆寫函數的例外說明比基底版本更寬鬆'
 # 'exception specifications are not allowed beyond a single level of indirection'
 HB84B4B7EA104: '例外說明不允許超過單層間接層級'
 # 'exception specifications are not allowed in %select{typedefs|type aliases}0'
-HBAC9EC08A3E9: '%select{typedefs|type aliases}0中不允許例外規格說明'
+HBAC9EC08A3E9: '%select{typedefs|type aliases}0 中不允許例外規格說明'
 # 'exception specifications of %select{return|argument}0 types differ'
 H04931F9B5864: '%select{傳回|引數}0 類型的例外說明不同'
 # 'excess elements in %select{array|vector|scalar|union|struct}0 initializer'
@@ -20921,23 +20921,23 @@ H46192DCC4FC7: '要求過度精確，但目標不支援過度精確，這可能�
 # 'exe called with module IR after each pass that changes it'
 H9DCF33C92D4F: '在每個修改模組的 pass 後，將模組 IR 傳遞給 exe'
 # 'execute only is not supported for the %0 sub-architecture'
-H355C6C44365F: '%0子架構不支援執行僅模式'
+H355C6C44365F: '%0 子架構不支援執行僅模式'
 # 'existing instance variable %1 for __weak property %0 must be __weak'
-HBE1A4247ED95: '__weak屬性%0的現有實例變數%1必須為__weak'
+HBE1A4247ED95: '__weak屬性 %0 的現有實例變數 %1 必須為__weak'
 # 'existing instance variable %1 for property %0 with %select{unsafe_unretained|assign}2 attribute must be __unsafe_unretained'
-H45768C1508E1: '具有%select{unsafe_unretained|assign}2屬性的屬性%0的現有實例變數%1必須為__unsafe_unretained'
+H45768C1508E1: '具有 %select{unsafe_unretained|assign}2 屬性的屬性 %0 的現有實例變數 %1 必須為__unsafe_unretained'
 # 'existing instance variable %1 for strong property %0 may not be %select{|__unsafe_unretained||__weak}2'
-H98A6ABD1A54E: '強屬性%0的現有實例變數%1不可為%select{|__unsafe_unretained||__weak}2'
+H98A6ABD1A54E: '強屬性 %0 的現有實例變數 %1 不可為%select{|__unsafe_unretained||__weak}2'
 # 'existing instance variable %1 for strong property %0 may not be __weak'
-HD554DEC7881B: '強屬性%0的現有實例變數%1不可為__weak'
+HD554DEC7881B: '強屬性 %0 的現有實例變數 %1 不可為__weak'
 # 'exit after writing aggregated data file'
 H8BF29D13B0F2: '寫入聚合資料檔後退出'
 # 'expanding this definition of %0'
-H5BA1B50B21D1: '展開%0的此定義'
+H5BA1B50B21D1: '展開 %0 的此定義'
 # 'expansion of date or time macro is not reproducible'
 H816E771096AD: '日期或時間宏的展開不可重複產生'
 # 'expansion of macro %0 requested here'
-H97F2144252C9: '這裡請求展開宏%0'
+H97F2144252C9: '這裡請求展開宏 %0'
 # "expansion of predefined identifier '%0' to a string literal is a Microsoft extension"
 H89888E84B8EB: "將預定義識別項'%0'展開為字串文字是Microsoft擴充"
 # 'expected "FILENAME" or <FILENAME>'
@@ -21393,7 +21393,7 @@ HC052EF0BAA44: '期望運算式中的值'
 # 'expected variable name as a base of the array %select{subscript|section}0'
 HBE410C345F41: '期望陣列 %select{下標|區段}0 的基底變數名稱'
 # "expected variable name or 'this' in lambda capture list"
-H9A94F049DF94: "在lambda捕獲清單中期望變數名稱或'this'"
+H9A94F049DF94: "在lambda捕獲清單中期望變數名稱或 'this'"
 # 'expected variable name%select{| or data member of current class}0'
 H829F4F463842: '期望變數名稱%select{|或當前類別的資料成員}0'
 # 'expected variable name%select{|, data member of current class}0, array element or array section'
@@ -21401,33 +21401,33 @@ HEAE159C816D1: '期望變數名稱%select{|、當前類別的資料成員}0、�
 # 'expected variable of pointer type'
 H396A94544855: '期望指標型別的變數'
 # "expected variable of the '%0' type%select{|, not %2}1"
-H3293A68C1535: "期望型別為'%0'的變數%select{|，而非%2}1"
+H3293A68C1535: "期望型別為'%0'的變數%select{|，而非 %2}1"
 # "expected variable%select{| or static data member|, static data member, or non-static data member of current class}0 of type '%1'"
 H54FC8A6038F8: "期望型別為'%1'%select{|或靜態資料成員|、靜態資料成員或當前類別的非靜態資料成員}0的變數"
 # 'expected%select{| %1}0 loop iteration variable'
 H9F489F0C181E: '期望%select{| %1}0迴圈迭代變數'
 # "expected%select{| non-const}0 variable of type 'omp_interop_t'"
-H7FA31289BDF2: "期望%select{|非const}0型別為'omp_interop_t'的變數"
+H7FA31289BDF2: "期望%select{|非const}0型別為 'omp_interop_t' 的變數"
 # 'expected%select{| one of}0 %1 directive name modifier%select{|s}0'
-HF9EF92E2746A: '期望%select{|其中一個}0 %1指令名稱修飾詞%select{|s}0'
+HF9EF92E2746A: '期望%select{|其中一個}0 %1 指令名稱修飾詞%select{|s}0'
 # "expecting %0 '%1' to be held at start of each loop"
-HFDC07BD9FDE6: "期望迴圈起始處持有%0 '%1'"
+HFDC07BD9FDE6: "期望迴圈起始處持有 %0 '%1'"
 # "expecting %0 '%1' to be held at the end of function"
-H696ED076811B: "期望函式結尾處持有%0 '%1'"
+H696ED076811B: "期望函式結尾處持有 %0 '%1'"
 # 'explicit %select{constructor|conversion function|deduction guide}0 is not a candidate%select{| (explicit specifier evaluates to true)}1'
 H1B61513FD8B6: '顯式%select{建構函數|轉換函數|推導指引}0 不是候選%select{| (顯式指定符評估為true)}1'
 # 'explicit %select{constructor|deduction guide}0 declared here'
 H110462FEE829: '在此處宣告顯式%select{建構函數|推導指引}0'
 # 'explicit %select{specialization|instantiation}0 of %select{non-|undeclared }3template %1 %2'
-H3111D59957AC: '顯式%select{特化|實例化}0 %select{非宣告|未宣告 }3範本%1 %2'
+H3111D59957AC: '顯式%select{特化|實例化}0 %select{非宣告|未宣告 }3範本 %1 %2'
 # 'explicit call to +initialize results in duplicate call to +initialize'
 H39AD5352EF13: '顯式呼叫+initialize 會導致+initialize 的重複呼叫'
 # 'explicit call to [super initialize] should only be in implementation of +initialize'
 H9E99F53BFF8C: '對[super initialize]的顯式呼叫只能出現在+initialize 實作中'
 # "explicit capture of 'this' with a capture default of '=' is a C++20 extension"
-HAF0F203BEF2F: "使用'='捕獲預設值時顯式捕獲'this'是C++20擴充"
+HAF0F203BEF2F: "使用'='捕獲預設值時顯式捕獲 'this' 是C++20擴充"
 # "explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20"
-H671AAB21DB7A: "使用'='捕獲預設值時顯式捕獲'this'與C++20之前標準不相容"
+H671AAB21DB7A: "使用'='捕獲預設值時顯式捕獲 'this' 與C++20之前標準不相容"
 # 'explicit constructor calls are a Microsoft extension'
 H07E486E825A8: '顯式建構函數呼叫是Microsoft擴充'
 # 'explicit conversion functions are a C++11 extension'
@@ -21439,39 +21439,39 @@ HC278594BF276: '在此處要求顯式資料共用屬性'
 # 'explicit data sharing attribute, data mapping attribute, or is_device_ptr clause requested here'
 H5EF926721360: '在此處要求顯式資料共用屬性、資料映射屬性，或是is_device_ptr子句'
 # 'explicit initialization of field %1 will not be enforced in C++20 and later because %2 has a user-declared constructor, making the type no longer an aggregate'
-HF3AC30340626: 'C++20及之後版本將不再強制執行此欄位%1的顯式初始化，因為%2具有使用者宣告的建構函數，使得類型不再是聚合體'
+HF3AC30340626: 'C++20及之後版本將不再強制執行此欄位 %1 的顯式初始化，因為 %2 具有使用者宣告的建構函數，使得類型不再是聚合體'
 # 'explicit instantiation candidate function %q0 template here %1'
-H23B5BDCD19CC: '顯式實體化候選函數模板%q0在此處定義%1'
+H23B5BDCD19CC: '顯式實體化候選函數模板%q0在此處定義 %1'
 # "explicit instantiation cannot be 'constexpr'"
-H9A1E5AE786E4: "顯式實體化不能是'constexpr'"
+H9A1E5AE786E4: "顯式實體化不能是 'constexpr'"
 # "explicit instantiation cannot be 'inline'"
-HD5DCEA693BA1: "顯式實體化不能是'inline'"
+HD5DCEA693BA1: "顯式實體化不能是 'inline'"
 # 'explicit instantiation cannot have a storage class'
 H2C3AA857F69D: '顯式實體化不能具有儲存類別'
 # "explicit instantiation declaration (with 'extern') follows explicit instantiation definition (without 'extern')"
-HB1AC2FFED2CF: "帶有'extern'的顯式實體化宣告跟隨不帶'extern'的顯式實體化定義"
+HB1AC2FFED2CF: "帶有 'extern' 的顯式實體化宣告跟隨不帶 'extern' 的顯式實體化定義"
 # 'explicit instantiation declaration of %0 with internal linkage'
-HF062EFD01A1B: '顯式實體化宣告%0具有內部連結性'
+HF062EFD01A1B: '顯式實體化宣告 %0 具有內部連結性'
 # 'explicit instantiation declaration requires a name'
 HB6C2B5BBA7F4: '顯式實體化宣告需要名稱'
 # "explicit instantiation declaration should not be 'dllexport'"
-H2015D0FC9EDD: "顯式實體化宣告不应是'dllexport'"
+H2015D0FC9EDD: "顯式實體化宣告不应是 'dllexport'"
 # 'explicit instantiation definition is here'
 H296BCB0F591A: '顯式實體化定義在此處'
 # 'explicit instantiation has dependent template arguments'
 H0CCD42687978: '顯式實體化具有依賴式範型參數'
 # 'explicit instantiation of %0 does not refer to a function template, variable template, member function, member class, or static data member'
-H33CB49EB02C6: '顯式實體化%0未引用函數範型、變數範型、成員函數、成員類別或靜態資料成員'
+H33CB49EB02C6: '顯式實體化 %0 未引用函數範型、變數範型、成員函數、成員類別或靜態資料成員'
 # 'explicit instantiation of %0 in class scope'
-HC730DBDD7AE4: '顯式實體化%0在類別作用域中'
+HC730DBDD7AE4: '顯式實體化 %0 在類別作用域中'
 # 'explicit instantiation of %0 must occur at global scope'
-H0F240F08C055: '顯式實體化%0必須出現在全域作用域'
+H0F240F08C055: '顯式實體化 %0 必須出現在全域作用域'
 # 'explicit instantiation of %0 not in a namespace enclosing %1'
-HE49D377AF72F: '顯式實體化%0未出現在包裝%1的命名空間中'
+HE49D377AF72F: '顯式實體化 %0 未出現在包裝 %1 的命名空間中'
 # 'explicit instantiation of %0 that occurs after an explicit specialization has no effect'
-HB36244473793: '在顯式專門化之後的%0之顯式實體化無效'
+HB36244473793: '在顯式專門化之後的 %0 之顯式實體化無效'
 # 'explicit instantiation of %q0 must occur in namespace %1'
-HB00768729F8E: '%q0的顯式實體化必須發生在命名空間%1中'
+HB00768729F8E: '%q0的顯式實體化必須發生在命名空間 %1 中'
 # 'explicit instantiation of %q0 must specify a template argument list'
 HE88FD9250BA0: '%q0的顯式實體化必須指定模板參數列表'
 # 'explicit instantiation of non-templated type %0'
@@ -21479,9 +21479,9 @@ H31C2727CC2AA: '%0（非模板類型）的顯式實體化'
 # 'explicit instantiation of typedef %0'
 H2C42F0D827C6: '%0（typedef）的顯式實體化'
 # 'explicit instantiation of undefined %select{member class|member function|static data member}0 %1 of class template %2'
-HCF3C5A632D34: '類模板%2的未定義%select{成員類別|成員函數|靜態資料成員}0 %1的顯式實體化'
+HCF3C5A632D34: '類模板 %2 的未定義%select{成員類別|成員函數|靜態資料成員}0 %1 的顯式實體化'
 # 'explicit instantiation of undefined function template %0'
-H5300C0092131: '未定義的函數模板%0的顯式實體化'
+H5300C0092131: '未定義的函數模板 %0 的顯式實體化'
 # 'explicit instantiation of undefined variable template %q0'
 H38D285C06249: '未定義的變數模板%q0的顯式實體化'
 # 'explicit instantiation refers here'
@@ -21491,21 +21491,21 @@ H500C2DC642A9: '顯式實體化指向非實體化的成員函數%q0'
 # 'explicit instantiation refers to static data member %q0 that is not an instantiation'
 H07ED3DC3915D: '顯式實體化指向非實體化的靜態資料成員%q0'
 # "explicit object parameter cannot have 'void' type"
-H5DECA4F1B2FA: "顯式物件參數不能具有'void'類型"
+H5DECA4F1B2FA: "顯式物件參數不能具有 'void' 類型"
 # 'explicit object parameters are incompatible with C++ standards before C++2b'
 H32F147DF3434: '顯式物件參數與C++2b之前的標準不相容'
 # 'explicit ownership qualifier on cast result has no effect'
 H3D013C01B086: '轉型結果的顯式所有權修飾符無效'
 # 'explicit qualification required to use member %0 from dependent base class'
-H469187ADD22A: '使用依賴基類的成員%0時需要顯式修飾'
+H469187ADD22A: '使用依賴基類的成員 %0 時需要顯式修飾'
 # 'explicit specialization cannot have a storage class'
 HADDD65B5ED76: '顯式專門化不能具有儲存類別'
 # 'explicit specialization of %0 after instantiation'
-HDBBF37665EBE: '%0的顯式專門化在實體化之後'
+HDBBF37665EBE: '%0 的顯式專門化在實體化之後'
 # 'explicit specialization of %0 in function scope'
-H4AB8E368275F: '函數作用域中的%0之顯式專門化'
+H4AB8E368275F: '函數作用域中的 %0 之顯式專門化'
 # "explicit template instantiation cannot have a definition; if this definition is meant to be an explicit specialization, add '<>' after the 'template' keyword"
-H88A1F449C08B: "顯式模板實體化不能有定義；如果此定義意圖為顯式專門化，請在'template'關鍵字後添加'<>'"
+H88A1F449C08B: "顯式模板實體化不能有定義；如果此定義意圖為顯式專門化，請在 'template' 關鍵字後添加'<>'"
 # 'explicit template parameter list for lambdas is a C++20 extension'
 HF9AE6F1B9252: 'lambda的顯式模板參數列表是C++20擴充功能'
 # 'explicit template parameter list for lambdas is incompatible with C++ standards before C++20'
@@ -21515,7 +21515,7 @@ H07C70F747BCD: 'explicit(bool) 是C++20擴充功能'
 # 'explicit(bool) is incompatible with C++ standards before C++20'
 H2A0E673F4AE0: 'explicit(bool) 與C++20之前的C++標準不相容'
 # 'explicitly assigning value of variable of type %0 to itself%select{|; did you mean to assign to member %2?}1'
-HB1C6DD04C662: '將類型%0的變數值明確地賦值給自身%select{|; 是否想賦值給成員%2？}1'
+HB1C6DD04C662: '將類型 %0 的變數值明確地賦值給自身%select{|; 是否想賦值給成員 %2？}1'
 # "explicitly capture 'this'"
 HCF140BF35536: "明確捕獲 'this'"
 # 'explicitly cast the argument to size_t to silence this warning'
@@ -21523,7 +21523,7 @@ HBB0D273571B1: '將引數明確轉換為size_t以消除此警告'
 # 'explicitly cast the pointer to silence this warning'
 H8E24FB4D1062: '將指標明確轉換以消除此警告'
 # "explicitly declare getter %objcinstance0 with '%1' to return an 'unowned' object"
-H4E2F7B8127D2: "明確宣告getter %objcinstance0 使用 '%1' 以傳回'unowned'物件"
+H4E2F7B8127D2: "明確宣告getter %objcinstance0 使用 '%1' 以傳回 'unowned' 物件"
 # 'explicitly defaulted %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator is implicitly deleted'
 H811330B8F313: '明確預設的%select{<ERROR>|等同|三路|等同|關係}0比較運算子被隱式刪除'
 # 'explicitly defaulted %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}0 is implicitly deleted'
@@ -21533,11 +21533,11 @@ HF8EF8D3E0A6F: '此明確預設的函數在此處被隱式刪除'
 # 'explicitly defaulting this %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}0 with a type different from the implicit type is incompatible with C++ standards before C++20'
 H5E5EF3FDD4E3: '使用與隱式類型不同的類型明確預設此%select{預設建構子|複製建構子|移動建構子|複製分配運算子|移動分配運算子|析構子}0，與C++20之前的C++標準不相容'
 # 'explicitly moving variable of type %0 to itself%select{|; did you mean to move to member %2?}1'
-H35CC5A2B002D: '明確地將類型%0的變數移動到自身%select{|; 是否想移動到成員%2？}1'
+H35CC5A2B002D: '明確地將類型 %0 的變數移動到自身%select{|; 是否想移動到成員 %2？}1'
 # 'explicitly specialized declaration is here'
 H0E01C428C014: '明確特殊化的宣告在此處'
 # 'explicitly-defaulted %select{copy|move}0 assignment operator must return %1'
-H36FB5B74F68A: '明確預設的%select{複製|移動}0分配運算子必須傳回%1'
+H36FB5B74F68A: '明確預設的%select{複製|移動}0分配運算子必須傳回 %1'
 # 'exponent has no digits'
 H17C521E1F810: '指數無數位'
 # 'export block begins here'
@@ -21761,7 +21761,7 @@ H208E3D0A2BB0: "文件 '%1' 不是有效的預編譯 %select{PCH|module|AST}0 �
 # 'file containing an ordered list of functions to use for function reordering'
 HAA6E189FC7DA: '包含用於函數重新排序的有序函數列表的文件'
 # 'file entered %0 time%s0 using %1B (%human1B) of space%plural{0:|: plus %2B (%human2B) for macro expansions}2'
-H6D5FEB2AA58C: '該文件以 %1B（%human1B）的空間%plural{0:|: 加上 %2B（%human2B）用於宏展開}2 被%0 time%s0存取過'
+H6D5FEB2AA58C: '該文件以 %1B（%human1B）的空間%plural{0:|: 加上 %2B（%human2B）用於宏展開}2 被 %0 time%s0存取過'
 # 'file name for generated dot file'
 H3426DAEC804D: '生成的 DOT 檔案名稱'
 # 'file name where instrumented profile will be saved (default: /tmp/prof.fdata)'
@@ -21845,11 +21845,11 @@ H4A77B1741C96: "浮點ABI '%0' 當前程式庫不支援"
 # 'floating point arithmetic produces %select{an infinity|a NaN}0'
 HE17E4C75C5CF: '浮點運算產生%select{無限大值|NaN}0'
 # 'floating point classification requires argument of floating point type (passed in %0)'
-HD0C7777CBCB2: '浮點分類需要傳遞浮點型別的引數（傳遞的是%0）'
+HD0C7777CBCB2: '浮點分類需要傳遞浮點型別的引數（傳遞的是 %0）'
 # 'floating point literal in preprocessor expression'
 HB66AC9BD4411: '預處理器表達式中出現浮點字面量'
 # 'floating-point comparison is always %select{true|false}0; constant cannot be represented exactly in type %1'
-HCE8BE2CDB468: '浮點運算的結果始終為%select{true|false}0；常數無法在類型%1中精確表示'
+HCE8BE2CDB468: '浮點運算的結果始終為 %select{true|false}0；常數無法在類型 %1 中精確表示'
 # 'fold functions with identical code'
 H57C9420813A5: '合併具有相同程式碼的函數'
 # 'fold jcc+mov into cmov'
@@ -21865,7 +21865,7 @@ HCCF9CE851541: 'for範圍宣告必須宣告變數'
 # 'for training'
 H23FBBEB90B89: '為訓練'
 # 'for type %0'
-HE30274CCC76F: '針對類型%0'
+HE30274CCC76F: '針對類型 %0'
 # 'force openmp unified shared memory mode'
 H98550220A417: '強制啟用OpenMP統一共享記憶體模式'
 # 'force patching of original entry points to ensure execution follows only the new/optimized code.'
@@ -21879,7 +21879,7 @@ H8F7AF4F2F3B0: '沒有對應 force_cuda_host_device begin 的 force_cuda_host_de
 # 'format argument is %select{a value|an indirect field width|an indirect precision|an auxiliary value}0, but it should be %select{a value|an indirect field width|an indirect precision|an auxiliary value}1'
 H26324CE63C64: '格式引數應為%select{一個值|間接欄位寬度|間接精確度|輔助值}1，但實際是%select{一個值|間接欄位寬度|間接精確度|輔助值}0'
 # 'format argument modifies specifier at position %0, but it should modify specifier at position %1'
-HE2EBF92B2A88: '格式引數修改了位置%0的指定符，但應修改位置%1的指定符'
+HE2EBF92B2A88: '格式引數修改了位置 %0 的指定符，但應修改位置 %1 的指定符'
 # 'format argument not a string type'
 H84E99A867F54: '格式引數不是字串類型'
 # 'format attribute cannot specify the implicit this argument as the format string'
@@ -21887,7 +21887,7 @@ H6DFBB5CF7F53: '格式屬性無法將隱含的this引數指定為格式字串'
 # "format specifier '%0' is incompatible with '%1'"
 H4D29848904BC: "格式指定符 '%0' 與 '%1' 不相容"
 # 'format specifies type %0 but the argument has %select{type|underlying type}2 %1'
-H2B1918042742: '格式指定符指定類型%0，但引數具有%select{type|underlying type}2 %1'
+H2B1918042742: '格式指定符指定類型 %0，但引數具有 %select{type|underlying type}2 %1'
 # "format string contains '\\0' within the string body"
 H262604652293: "格式字串在字串本體中包含'\\0'"
 # 'format string is defined here'
@@ -21907,13 +21907,13 @@ H5D46A69914C2: '格式字串不應為寬字串'
 # 'format to dump profile output in aggregation mode, default is fdata'
 H4B4189014528: '以聚合模式輸出剖析資料的格式，預設值為fdata'
 # 'forward declaration of %0'
-H9E3BA9144F24: '%0的前向宣告'
+H9E3BA9144F24: '%0 的前向宣告'
 # 'forward declaration of %0 cannot have a nested name specifier'
-HED9D019594EF: '%0的前向宣告不能具有嵌套名稱限定詞'
+HED9D019594EF: '%0 的前向宣告不能具有嵌套名稱限定詞'
 # 'forward declaration of class here'
 H169D8B5BC4E6: '類別的前向宣告在此處'
 # 'forward declaration of non-parameterized class %0 cannot have type parameters'
-H5EA8F1567F5D: '非參數化類別%0的前向宣告不能具有類型參數'
+H5EA8F1567F5D: '非參數化類別 %0 的前向宣告不能具有類型參數'
 # 'forward declaration of template entity is here'
 H61734FDBAB98: '模板實體的前向宣告在此處'
 # "forward references to 'enum' types are a Microsoft extension"
@@ -21923,7 +21923,7 @@ HFDE68D3C1582: "在%select{模板名稱|addrspace_cast|const_cast|dynamic_cast|r
 # "found near match '%0'"
 HE96C9DD0F351: "找到近似匹配 '%0'"
 # 'fp convert instructions on integers with more than <N> bits are expanded.'
-HBF7A8F526E5F: '對超過<N>位的整數執行浮點轉換指令時會被展開。'
+HBF7A8F526E5F: '對超過 <N> 位的整數執行浮點轉換指令時會被展開。'
 # "friend cannot be declared in an explicit instantiation; if this declaration is meant to be a friend declaration, remove the 'template' keyword"
 H2CA4FF8AC2DD: '無法在顯式實體化中宣告 friend；如果此宣告是 friend 宣告，請移除「template」關鍵字'
 # 'friend declaration cannot be a concept'
@@ -22083,7 +22083,7 @@ H5995CF0D518F: '對內置類型的函數式轉型只能接受一個參數'
 # 'functional-style cast to %0 has incompatible initializer of type %1'
 H0F52DA9B703F: '將 %0 進行函數式轉型時具有不相容的初始值類型 %1'
 # 'functions cannot be declared in an anonymous %select{struct|union}0'
-H50EACF1C1B1C: '不能在匿名%select{struct|union}0中宣告函數'
+H50EACF1C1B1C: '不能在匿名 %select{struct|union}0 中宣告函數'
 # "functions may not be declared with 'cmse_nonsecure_call' attribute"
 H21052FB1BA63: '具有 "cmse_nonsecure_call" 屬性的函數不可宣告'
 # 'functions that differ only in their return type cannot be overloaded'
@@ -22099,7 +22099,7 @@ H0E649CF6B515: '為輸入檔案產生包含模式的C++來源檔'
 # 'generate a list of function sections in a format suitable for inclusion in a linker script'
 H26853D1AF334: '產生適合包含在連結器腳本中的函數區段列表'
 # 'generate code for binaries <128MB on AArch64'
-H5478C82F0746: '在AArch64上產生小於128MB的二進位檔代碼'
+H5478C82F0746: '在AArch64上產生小於 128MB的二進位檔代碼'
 # 'generate loops for copy-in/copy-out of objects with descriptors'
 HEE6A80E60F2B: '產生用描述符複製物件的copy-in/copy-out循環'
 # 'generate new tags with runtime library calls'
@@ -22119,7 +22119,7 @@ H0E2372801126: '泛型lambda與C++11不相容'
 # 'getter name mismatch between property redeclaration (%1) and its original declaration (%0)'
 HCB66D133764C: '屬性重宣告（%1）與其原始宣告（%0）的getter名稱不匹配'
 # 'given <sectname>,<filename>[@<sym>=<offset>,...]  add the content of <filename> to <sectname>'
-HB3C96722F67D: '將<filename>的內容添加到<sectname>部分'
+HB3C96722F67D: '將 <filename> 的內容添加到 <sectname> 部分'
 # "glob '%0' did not match any header file"
 H7F85F549D444: "glob '%0'未匹配任何標頭檔"
 # 'global sampler requires a const or constant address space qualifier'
@@ -22135,11 +22135,11 @@ H0D3E968182E3: 'guarded_by在此處宣告'
 # 'half precision constant requires cl_khr_fp16'
 H4CC0B372F96B: '半精度常數需要cl_khr_fp16'
 # 'hardware TLS register is not supported for the %0 sub-architecture'
-HDE3B68F7C8A6: '硬體TLS寄存器不支援%0子架構'
+HDE3B68F7C8A6: '硬體TLS寄存器不支援 %0 子架構'
 # "header attribute '%0' specified multiple times"
 H7E7CB9EE75BF: "標頭屬性'%0'被多次指定"
 # "header file %0 (aka '%1') cannot be imported because it is not known to be a header unit"
-H0A389CC3DB5F: "無法導入標頭檔%0（即'%1'），因為它未被識別為標頭單元"
+H0A389CC3DB5F: "無法導入標頭檔 %0（即'%1'），因為它未被識別為標頭單元"
 # "header file '%0' input '%1' does not match the type of prior input in api extraction; use '-x %2' to override"
 HCC1F871B655D: "在API提取期間，標頭檔'%0'的輸入'%1'與先前輸入類型不符；使用'-x %2'覆蓋"
 # "header file '%0' input type '%1' does not match type of prior input in module compilation; use '-x %2' to override"
@@ -22173,15 +22173,15 @@ H4C1045D46DF7: 'hugify'
 # 'human-readable YAML format'
 HE74AE57FF6C4: '人類可讀的YAML格式'
 # "identifier %0 after '~' in destructor name does not name a type"
-H83FECEE0EB8D: "'~' 之後的識別碼%0 在析構函數名稱中未指定類型"
+H83FECEE0EB8D: "'~' 之後的識別碼 %0 在析構函數名稱中未指定類型"
 # 'identifier %0 in object destruction expression does not name a type'
-H9BF7AFAC2ABF: '物件銷毀運算式中的識別碼%0 未指定類型'
+H9BF7AFAC2ABF: '物件銷毀運算式中的識別碼 %0 未指定類型'
 # 'identifier %0 in object destruction expression does not name the type %1 of the object being destroyed'
-H3AA5F97C4B64: '物件銷毀運算式中的識別碼%0 未指定正在銷毀物件的類型%1'
+H3AA5F97C4B64: '物件銷毀運算式中的識別碼 %0 未指定正在銷毀物件的類型 %1'
 # "identifier %0 is reserved because %select{<ERROR>|it starts with '_' at global scope|it starts with '_' and has C language linkage|it starts with '__'|it starts with '_' followed by a capital letter|it contains '__'}1"
-HB25A0B12A970: '識別碼%0 被保留因為%select{<ERROR>|它在全域作用域以"_"開頭|它以"_"開頭且具有C語言連結|它包含"__"|它以"_"後接大寫字母開頭|它包含"__"}1'
+HB25A0B12A970: '識別碼 %0 被保留因為%select{<ERROR>|它在全域作用域以 "_" 開頭|它以 "_" 開頭且具有C語言連結|它包含 "__"|它以 "_" 後接大寫字母開頭|它包含 "__"}1'
 # 'identifier %0 preceded by whitespace in a literal operator declaration is deprecated'
-H0DD590ABAF7E: '字元串前有空白的字元串運算子宣告中的%0 已棄用'
+H0DD590ABAF7E: '字元串前有空白的字元串運算子宣告中的 %0 已棄用'
 # 'identifier after literal will be treated as a reserved user-defined literal suffix in C++11'
 HC12CCB91962D: '字元串後的識別碼在C++11中將被視為保留的用戶定義文字後綴'
 # 'identifier after literal will be treated as a user-defined literal suffix in C++11'
@@ -22189,7 +22189,7 @@ HBE6CD4B6A8AE: '字元串後的識別碼在C++11中將被視為用戶定義文�
 # 'identifier contains Unicode character <U+%0> that is invisible in some environments'
 H5D7B884070AB: '識別項包含在部分環境中不可見的Unicode字元<U+%0>'
 # "identifier followed by '<' indicates a class template specialization but %0 %select{does not refer to a template|refers to a function template|<unused>|refers to a variable template|<unused>|<unused>|refers to a concept}1"
-HAF5607DFBCE7: "接續'<'的識別項表示類模板特化，但%0 %select{未引用模板|引用函式模板|<unused>|引用變數模板|<unused>|<unused>|引用概念}1"
+HAF5607DFBCE7: "接續'<'的識別項表示類模板特化，但 %0 %select{未引用模板|引用函式模板|<unused>|引用變數模板|<unused>|<unused>|引用概念}1"
 # "if processing a memory profile, filter out stack or heap accesses that won't be useful for BOLT to reduce profile file size"
 HECF8ECDF0776: '若處理記憶體剖析，過濾對BOLT無用的堆疊或堆存取以減少剖析檔大小'
 # 'if reorder-functions is used, order functions putting hottest last'
@@ -22219,17 +22219,17 @@ H482A47671C74: '匹配函式時忽略lto_priv或const後綴'
 # 'ignore recursive calls when constructing the call graph'
 H79AFD225957D: '建立呼叫圖時忽略遞迴呼叫'
 # "ignored 'inline' attribute on kernel function %0"
-HD7F59CCBC545: "忽略核心函式%0的'inline'屬性"
+HD7F59CCBC545: "忽略核心函式 %0 的 'inline' 屬性"
 # "ignored asm label '%0' on automatic variable"
 H457253219067: "忽略自動變數上的組合語言標籤'%0'"
 # 'ignored trigraph would end block comment'
 HC0EDD32FEF14: '被忽略的三字元會結束區塊註解'
 # 'ignoring %0 attribute because its argument is invalid'
-H5CBA55A0FD5C: '因參數無效而忽略屬性%0'
+H5CBA55A0FD5C: '因參數無效而忽略屬性 %0'
 # 'ignoring %select{return value|temporary}0 of type %2 declared with %1 attribute%select{|: %4}3'
-H18EB408CFE62: '忽略宣告具有%1屬性的類型%2的%select{返回值|臨時物件}0%select{|：%4}3'
+H18EB408CFE62: '忽略宣告具有 %1 屬性的類型 %2 的%select{返回值|臨時物件}0%select{|：%4}3'
 # "ignoring '%0' as it conflicts with that implied by '%1' (%2)"
-HB9837B039EA4: "忽略'%0'，因為它與'%1'所暗示的%2相衝突"
+HB9837B039EA4: "忽略'%0'，因為它與'%1'所暗示的 %2 相衝突"
 # "ignoring '%0' option as it cannot be used with %select{implicit usage of|}1 -mabicalls and the N64 ABI"
 H17CC723C2497: "忽略'%0'選項，因為它無法與%select{默認使用|}1 -mabicalls及N64 ABI一起使用"
 # "ignoring '%0' option as it is not currently supported for processor '%1'"
@@ -22239,7 +22239,7 @@ H4AA39F54EF26: "忽略'%0'選項，因為它目前不支援目標平台'%1'"
 # "ignoring '%0' option for offload arch '%1' as it is not currently supported there. Use it with an offload arch containing '%2' instead"
 H788152E08844: "忽略在卸載架構'%1'中的'%0'選項，因為該處目前不支援。請改用包含'%2'的卸載架構"
 # "ignoring '%select{static|inline}0' keyword on explicit template instantiation"
-H8A80FA7727CA: '忽略在顯式模板實例化上的%select{static|inline}0關鍵字'
+H8A80FA7727CA: '忽略在顯式模板實例化上的 %select{static|inline}0 關鍵字'
 # "ignoring '-f%select{no-|}0raw-string-literals', which is only valid for C and C++ standards before C++11"
 H135D75731B01: "忽略'-f%select{no-|}0raw-string-literals'，因為它僅對C++11之前的C和C++標準有效"
 # "ignoring '-mabs=2008' option because the '%0' architecture does not support it"
@@ -22263,7 +22263,7 @@ HC86237F887FA: '忽略LLVM位元碼中的-fdiscard-value-names'
 # "ignoring -fverify-debuginfo-preserve-export=%0 because -fverify-debuginfo-preserve wasn't enabled"
 H36FCA7FF86DB: '忽略-fverify-debuginfo-preserve-export=%0，因為-fverify-debuginfo-preserve未被啟用'
 # 'ignoring __declspec(allocator) because the function return type %0 is not a pointer or reference type'
-H6AAEF2701683: '忽略__declspec(allocator)，因為該函數返回類型%0不是指標或引用類型'
+H6AAEF2701683: '忽略__declspec(allocator)，因為該函數返回類型 %0 不是指標或引用類型'
 # "ignoring availability attribute %select{on '+load' method|with constructor attribute|with destructor attribute}0"
 H24871179ED63: "忽略在%select{'+load'方法上|具有構造函數屬性|具有析構函數屬性}0的可用性屬性"
 # "ignoring extension '%0' because the '%1' architecture does not support it"
@@ -22271,7 +22271,7 @@ HD131D7C5772F: "忽略擴展 '%0'，因為架構 '%1' 不支援它"
 # "ignoring invalid -ftabstop value '%0', using default value %1"
 H55F6E19B595A: "忽略無效的 -ftabstop 值 '%0'，使用預設值 %1"
 # "ignoring invalid /arch: argument '%0'; for %select{64|32}1-bit expected one of %2"
-HF5AE60D7E4BF: "忽略無效的/arch: 參數'%0'；對%select{64|32}1位期望其中一個%2"
+HF5AE60D7E4BF: "忽略無效的/arch: 參數'%0'；對 %select{64|32}1 位期望其中一個 %2"
 # 'ignoring redefinition of Objective-C qualifier macro'
 HE01ADCD1C19E: '忽略重新定義的 Objective-C 修飾符宏'
 # 'ignoring return value of function declared with %0 attribute'
@@ -22285,7 +22285,7 @@ HF5FC687425B2: "忽略 'branch-protection' 屬性，因為架構 '%0' 不支援�
 # 'illegal OpenMP user-defined mapper identifier'
 H4FE25A4B348F: '非法的 OpenMP 使用者定義映射器識別碼'
 # 'illegal call to %0, expected %1 argument type'
-H4DEE4185FC7F: '對%0的非法呼叫，期望%1參數類型'
+H4DEE4185FC7F: '對 %0 的非法呼叫，期望 %1 參數類型'
 # 'illegal call to enqueue_kernel, incorrect argument types'
 H96AA6DCB3DCC: '對 enqueue_kernel 發生非法呼叫，引數型別錯誤'
 # 'illegal call to enqueue_kernel, parameter needs to be specified as integer type'
@@ -22309,19 +22309,19 @@ H1CDC7C944B48: '對 Objective-C 容器索引存取的非法運算'
 # 'illegal qualifiers on @catch parameter'
 H2C6EDFE337AA: '@catch參數上的非法限定符'
 # "illegal redeclaration of 'readwrite' property in class extension %0 (perhaps you intended this to be a 'readwrite' redeclaration of a 'readonly' public property?)"
-H77F956612F13: "在類別擴展%0中對'readwrite'屬性的非法重新宣告（也許您想將此宣告為'readonly'公開屬性的'readwrite'重新宣告？）"
+H77F956612F13: "在類別擴展 %0 中對 'readwrite' 屬性的非法重新宣告（也許您想將此宣告為 'readonly' 公開屬性的 'readwrite' 重新宣告？）"
 # "illegal redeclaration of property in class extension %0 (attribute must be 'readwrite', while its primary must be 'readonly')"
-HA09E774D29B3: "在類別擴展%0中對屬性的非法重新宣告（屬性必須是'readwrite'，而其主要宣告必須是'readonly'）"
+HA09E774D29B3: "在類別擴展 %0 中對屬性的非法重新宣告（屬性必須是 'readwrite'，而其主要宣告必須是 'readonly'）"
 # 'illegal scalar extension cast on argument %0 to %select{|in}1out paramemter'
-HF91E5CAEA96B: '在參數%0到%select{|in}1out參數上進行非法標量擴展轉換'
+HF91E5CAEA96B: '在參數 %0 到%select{|in}1out參數上進行非法標量擴展轉換'
 # 'illegal storage class on file-scoped variable'
 H601564466459: '文件作用域變數上的非法存儲類別'
 # 'illegal storage class on function'
 H930E494BEBBE: '函數上的非法存儲類別'
 # 'illegal type %0 used in a boxed expression'
-H5782BEFABE5B: '在裝箱運算式中使用非法類型%0'
+H5782BEFABE5B: '在裝箱運算式中使用非法類型 %0'
 # 'illegal vector component name %0'
-H6F3BE393AEDE: '非法的向量元件名稱%0'
+H6F3BE393AEDE: '非法的向量元件名稱 %0'
 # 'illegal visibility specification'
 H39F781806C46: '非法的可見性規範'
 # 'imaginary constants are a C2y extension'
@@ -22333,7 +22333,7 @@ H8F7EDEA31FE9: '虛數常量與C2y之前的C標準不相容'
 # 'imaginary types are not supported'
 H8AEF701858F7: '不支援虛數類型'
 # 'immediate function %0 used before it is defined'
-H1A240E8F6E49: '在定義前使用立即函數%0'
+H1A240E8F6E49: '在定義前使用立即函數 %0'
 # 'implementing deprecated %select{method|class|category}0'
 H9AA979884A67: '實作已棄用的%select{方法|類別|類別別名}0'
 # 'implementing unavailable method'
@@ -22457,13 +22457,13 @@ H25C0CF982742: 'import 必須直接跟隨模組宣告'
 # 'impossible constraint in asm: cannot store value into a register'
 HEC9C616BA3F9: 'asm 中的不可能約束：無法將值存入寄存器'
 # 'in %select{implicit|defaulted}0 %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}1 for %2 first required here'
-H7F88B1ED021A: '在%select{隱式|已預設的}0%select{預設建構函式|複製建構函式|移動建構函式|複製指派運算子|移動指派運算子|析構函式}1的%2中，首次需要在此處'
+H7F88B1ED021A: '在%select{隱式|已預設的}0%select{預設建構函式|複製建構函式|移動建構函式|複製指派運算子|移動指派運算子|析構函式}1的 %2 中，首次需要在此處'
 # "in call to '%0'"
 H5F44B6591F5A: "在調用'%0'時"
 # "in call to printing function with arguments '(%0)' while dumping struct"
 H5B10BE57CF69: "在列印函式調用時，以參數'(%0)'傾印結構"
 # 'in defaulted %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator for %1 first required here'
-H41C2C013E2E2: '在%1的預設%select{<ERROR>|等式|三向|等式|關聯}0比較運算子中，首次需要在此處'
+H41C2C013E2E2: '在 %1 的預設%select{<ERROR>|等式|三向|等式|關聯}0比較運算子中，首次需要在此處'
 # 'in evaluating default argument here'
 HA6EC671D8C49: '在評估此處的預設參數時'
 # 'in evaluation of exception specification for %q0 needed here'
@@ -22471,25 +22471,25 @@ H94CE96486393: '在評估%q0所需的例外規格時'
 # 'in first definition, possible difference is here'
 HAF3474709EF4: '在首次定義中，可能的差異在此處'
 # "in implicit call to 'operator%select{!=|*|++}0' for iterator of type %1"
-HA1274A4A4765: "在%1類型的迭代器隱式調用'operator%select{!=|*|++}0'時"
+HA1274A4A4765: "在 %1 類型的迭代器隱式調用'operator%select{!=|*|++}0'時"
 # 'in implicit initialization for inherited constructor of %0'
-HE4CCA87F39AA: '在%0的繼承建構函式的隱式初始化時'
+HE4CCA87F39AA: '在 %0 的繼承建構函式的隱式初始化時'
 # 'in implicit initialization of %select{array element %1 with omitted initializer|field %1 with omitted initializer|trailing array elements in runtime-sized array new}0'
-HD4BCA75D333B: '在%select{省略初始值設定的陣列元素%1|省略初始值設定的成員%1|執行階段尺寸陣列new的尾隨陣列元素}0的隱式初始化時'
+HD4BCA75D333B: '在%select{省略初始值設定的陣列元素 %1|省略初始值設定的成員 %1|執行階段尺寸陣列new的尾隨陣列元素}0的隱式初始化時'
 # 'in implicit initialization of binding declaration %0'
-H6B3B1A4A0790: '在%0綁定宣告的隱式初始化時'
+H6B3B1A4A0790: '在 %0 綁定宣告的隱式初始化時'
 # 'in initialization of temporary of type %0 created to list-initialize this reference'
-H5C5815C0F326: '在初始化用於列表初始化此引用所建立的%0類型暫存時'
+H5C5815C0F326: '在初始化用於列表初始化此引用所建立的 %0 類型暫存時'
 # "in instantiation of default argument for '%0' required here"
-H920C89F748D0: '在%0的預設參數實體化所需時'
+H920C89F748D0: '在 %0 的預設參數實體化所需時'
 # "in instantiation of default function argument expression for '%0' required here"
-H05CBF7F0C1EE: '在%0的預設函式參數表達式實體化所需時'
+H05CBF7F0C1EE: '在 %0 的預設函式參數表達式實體化所需時'
 # 'in instantiation of default member initializer %q0 requested here'
 HD2F44CDF38B1: '在%q0的預設成員初始值設定實體化請求時'
 # 'in instantiation of enumeration %q0 requested here'
 H6EB646EE227A: '在%q0列舉實體化請求時'
 # 'in instantiation of exception specification for %0 requested here'
-H3C01A542E6EB: '在%0的例外規格實體化請求時'
+H3C01A542E6EB: '在 %0 的例外規格實體化請求時'
 # 'in instantiation of function template specialization %q0 requested here'
 HAEB9C4D2EE7B: '在%q0函式模板實體化請求時'
 # 'in instantiation of member class %q0 requested here'
@@ -22569,7 +22569,7 @@ HFD878F5F2922: '不相容的指標到整數轉換 %select{%diff{將$指派給$|�
 # 'incompatible pointer types %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &|; remove *|; remove &}3'
 HBA7B4F7FCD76: '不相容的指標類型 %select{%diff{將$指派給$|指派給不同類型}1,0|%diff{將$傳遞給類型為$的參數|傳遞給不同類型的參數}0,1|%diff{從返回類型為$的函數返回$|從不同返回類型的函數返回}1,0|%diff{將$轉換為類型$|轉換不同類型}0,1|%diff{用類型$的運算式初始化$|用不同類型的運算式初始化}1,0|%diff{將$傳遞給類型為$的參數|傳遞給不同類型的參數}0,1|%diff{將$轉換為類型$|轉換不同類型}0,1}2%select{|; 使用*解引用|; 取得位址 &|; 移除 *|; 移除 &}3'
 # 'incompatible pointer types passing retainable parameter of type %0to a CF function expecting %1 type'
-H85C3F4475A3D: '不兼容的指標類型：將型別為%0的可保留參數傳遞給期望%1型別的Core Foundation函數'
+H85C3F4475A3D: '不兼容的指標類型：將型別為 %0 的可保留參數傳遞給期望 %1 型別的Core Foundation函數'
 # 'incompatible redeclaration of library function %0'
 H4DCB8A7133E4: '函式庫函數 %0 的重新宣告類型不相容'
 # 'incompatible types casting %0 to %1 with a %select{__bridge|__bridge_transfer|__bridge_retained}2 cast'
@@ -22577,33 +22577,33 @@ HA70D951974C7: '使用 %select{__bridge|__bridge_transfer|__bridge_retained}2 ca
 # 'incompatible vector types %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2'
 H349444057F6C: '%select{%diff{將$指派給$型別 | 指派不同型別}1,0|%diff{將$傳遞給型別為$的參數 | 傳遞給不同型別的參數}0,1|%diff{從結果型別為$的函數返回$ | 從不同返回型別的函數返回}1,0|%diff{將$轉換為$型別 | 轉換不同型別}0,1|%diff{用型別$的運算式初始化$ | 用不同型別的運算式初始化}1,0|%diff{將$傳遞給型別為$的參數 | 傳遞給不同型別的參數}0,1|%diff{將$轉換為$型別 | 轉換不同型別}0,1}2'
 # 'incomplete definition of type %0'
-H74F733EC60E9: '不完整的型別%0定義'
+H74F733EC60E9: '不完整的型別 %0 定義'
 # "incomplete delimited universal character name; treating as '\\' '%0' '{' identifier"
 H45A3D640545C: "不完整的界定通用字符名称；視為'\\' '%0' '{' 标識符"
 # 'incomplete format specifier'
 HC2682570C017: '格式指定項不完整'
 # 'incomplete receiver type %0'
-H6C117CF6E37A: '不完整的接收者型別%0'
+H6C117CF6E37A: '不完整的接收者型別 %0'
 # 'incomplete result type %0 in function definition'
-HA8E1F3068B20: '函數定義中的結果型別%0不完整'
+HA8E1F3068B20: '函數定義中的結果型別 %0 不完整'
 # 'incomplete result type %0 in lambda expression'
-H69E2641DED85: 'lambda運算式中的結果型別%0不完整'
+H69E2641DED85: 'lambda運算式中的結果型別 %0 不完整'
 # "incomplete type %0 in a '_Generic' association is a C2y extension"
-H7D3852AE4A16: "'_Generic'關聯中的不完整型別%0是C2y擴充功能"
+H7D3852AE4A16: "'_Generic' 關聯中的不完整型別 %0 是C2y擴充功能"
 # 'incomplete type %0 is not a literal type'
-H8AFDEC1F2348: '不完整型別%0不是文字型別'
+H8AFDEC1F2348: '不完整型別 %0 不是文字型別'
 # 'incomplete type %0 is not assignable'
-HF862B3215822: '不完整型別%0無法指派'
+HF862B3215822: '不完整型別 %0 無法指派'
 # 'incomplete type %0 named in nested name specifier'
-HCA7665DF5910: '在嵌套名稱指定項中命名的不完整型別%0'
+HCA7665DF5910: '在嵌套名稱指定項中命名的不完整型別 %0'
 # 'incomplete type %0 used in a boxed expression'
-HF426C73BD83F: '在boxed運算式中使用不完整型別%0'
+HF426C73BD83F: '在boxed運算式中使用不完整型別 %0'
 # 'incomplete type %0 used in type trait expression'
-H4539C0CCBFB9: '在型別特性運算式中使用不完整型別%0'
+H4539C0CCBFB9: '在型別特性運算式中使用不完整型別 %0'
 # 'incomplete type %0 where a complete type is required'
-H95C11FF1D056: '在需要完整型別的位置使用不完整型別%0'
+H95C11FF1D056: '在需要完整型別的位置使用不完整型別 %0'
 # 'incomplete type in call to object of type %0'
-HB57B0356D109: '型別%0的物件呼叫中使用不完整型別'
+HB57B0356D109: '型別 %0 的物件呼叫中使用不完整型別'
 # 'incomplete universal character name'
 H0184822E59BB: '不完整的通用字符名稱'
 # "incomplete universal character name; treating as '\\' followed by identifier"
@@ -22619,13 +22619,13 @@ H6BCE6C4F91C6: "不正確的映射類型修飾符，期望其中一個：'always
 # "incorrect map type, expected one of 'to', 'from', 'tofrom', 'alloc', 'release', or 'delete'"
 HFC0556B7E292: "不正確的映射類型，應為 'to', 'from', 'tofrom', 'alloc', 'release' 或 'delete' 其中之一"
 # 'incorrect number of bits in integer (expected %0 bits, have %1)'
-H39F86512F6F1: '整数位数不正确（期望%0位，但有%1位）'
+H39F86512F6F1: '整数位数不正确（期望 %0 位，但有 %1 位）'
 # 'incorrect number of bits in vector operand (expected %select{|a multiple of}0 %1 bits, have %2)'
 HDF4134C84931: '向量操作數的位數不正確（期望 %select{|的倍數}0 %1 位，但有 %2 位）'
 # "incorrect reduction identifier, expected one of '+', '*', '&', '|', '^', '&&', '||', 'min' or 'max' or declare reduction for type %0"
-HD90D2B65D413: "約束標識符不正確，期望其中一個 '+', '-', '*', '&', '|', '^', '&&', '||', 'min' 或 'max'，或為類型%0宣告約束"
+HD90D2B65D413: "約束標識符不正確，期望其中一個 '+', '-', '*', '&', '|', '^', '&&', '||', 'min' 或 'max'，或為類型 %0 宣告約束"
 # "incorrect reduction identifier, expected one of '+', '-', '*', '&', '|', '^', '&&', '||', 'min' or 'max' or declare reduction for type %0"
-HC80B58A26C84: "約束標識符不正確，期望其中一個 '+', '*', '&', '|', '^', '&&', '||', 'min' 或 'max'，或為類型%0宣告約束"
+HC80B58A26C84: "約束標識符不正確，期望其中一個 '+', '*', '&', '|', '^', '&&', '||', 'min' 或 'max'，或為類型 %0 宣告約束"
 # 'incorrect use of #pragma clang force_cuda_host_device begin|end'
 HB4E983FB1A7D: '不正確使用 #pragma clang force_cuda_host_device begin|end'
 # "incorrect use of '#pragma fenv_access (on|off)' - ignored"
@@ -22641,7 +22641,7 @@ H33F55260A9EF: '遞增的枚舉值 %0 超出最大整數型態的表示範圍'
 # 'incrementing expression of type bool is deprecated and incompatible with C++17'
 HB438D9D07956: '使用 bool 型態的增量運算式已棄用，且與 C++17 不兼容'
 # 'increments 8-bit counter for every edge'
-H286B107846BC: '每邊緣遞增8位計數器'
+H286B107846BC: '每邊緣遞增 8 位計數器'
 # "indeterminate value can only initialize an object of type 'unsigned char'%select{, 'char',|}1 or 'std::byte'; %0 is invalid"
 H26C79B7B3090: "不確定值只能初始化 %select{|、'char'、}1 'unsigned char' 或 'std::byte' 類型的物件；%0 無效"
 # 'index %0 must appear exactly once in the permutation clause'
@@ -22651,13 +22651,13 @@ H2AA72873C8D9: '__builtin_shufflevector的索引必須是常數整數'
 # 'index for __builtin_shufflevector must be less than the total number of vector elements'
 HDC5D16284BAC: '__builtin_shufflevector的索引必須小於向量元素的總數'
 # 'index for __builtin_shufflevector not within the bounds of the input vectors; index of -1 found at position %0 is not permitted in a constexpr context'
-H0F3D61BA78F9: '在constexpr上下文中，輸入向量的索引超出範圍；在位置%0發現的-1索引是不允許的'
+H0F3D61BA78F9: '在constexpr上下文中，輸入向量的索引超出範圍；在位置 %0 發現的-1索引是不允許的'
 # 'indexing expression is invalid because subscript type %0 has multiple type conversion functions'
-H28D375C7CDB6: '索引運算式無效，因為下標類型%0具有多個類型轉換函數'
+H28D375C7CDB6: '索引運算式無效，因為下標類型 %0 具有多個類型轉換函數'
 # 'indexing expression is invalid because subscript type %0 is not an Objective-C pointer'
-H76E63693A71C: '索引運算式無效，因為下標類型%0不是 Objective-C 指標'
+H76E63693A71C: '索引運算式無效，因為下標類型 %0 不是 Objective-C 指標'
 # 'indexing expression is invalid because subscript type %0 is not an integral or Objective-C pointer type'
-H5DB003FBDC67: '索引運算式無效，因為下標類型%0不是整數或 Objective-C 指標類型'
+H5DB003FBDC67: '索引運算式無效，因為下標類型 %0 不是整數或 Objective-C 指標類型'
 # 'indexing of array without known bound is not allowed in a constant expression'
 HE2B8FD1CE633: '在已知邊界前對陣列進行索引在常數運算式中是不允許的'
 # 'indirect call promotion'
@@ -22665,11 +22665,11 @@ H63A9B36F7D0A: '間接呼叫提升'
 # 'indirect goto in function with no address-of-label expressions'
 H145FEAAFA432: '在未使用標籤地址的函數中使用間接 goto'
 # 'indirection not permitted on operand of type %0'
-H2DF3DCAF7C13: '類型%0的操作元不允許進行間接存取'
+H2DF3DCAF7C13: '類型 %0 的操作元不允許進行間接存取'
 # 'indirection of non-volatile null pointer will be deleted, not trap'
 H016B5CE240D6: '非揮發性空指標的間接存取將被刪除而非觸發異常'
 # 'indirection requires pointer operand (%0 invalid)'
-H17A67BCCC65A: '間接存取需要指標運算式（%0無效）'
+H17A67BCCC65A: '間接存取需要指標運算式（%0 無效）'
 # 'infer execution count for fall-through blocks'
 H5D8BF838CEAA: '推論跳躍塊的執行次數'
 # "inferred framework modules cannot be 'explicit'"
@@ -22679,31 +22679,31 @@ H3C9148B14284: '推論的子模組不能是框架子模組'
 # 'inferred submodules require a module with an umbrella'
 HB4F6C039EA5A: '帶有umbrella模組的推論子模組才有效'
 # "inferring '_Nonnull' for pointer type within %select{array|reference}0 is deprecated"
-H0BCF4D33599B: "在%select{陣列|參考}0中的指標類型推論'_Nonnull'已棄用"
+H0BCF4D33599B: "在%select{陣列|參考}0中的指標類型推論 '_Nonnull' 已棄用"
 # 'inheritance model does not match %select{definition|previous declaration}0'
 H6F4F77A5056C: '繼承模型與%select{定義|先前宣告}0不符'
 # 'inheritance model ignored on %select{primary template|partial specialization}0'
 H5E5E4985C4D2: '在%select{主要範本|部分特化}0上忽略繼承模型設定'
 # 'inherited from base class %0 here'
-H942CB9135C88: '從基底類別%0繼承至此'
+H942CB9135C88: '從基底類別 %0 繼承至此'
 # 'inherited virtual base class %1 has %select{private|protected}2 destructor'
-HC776172C0FE5: '虛基類別%1的%select{private|protected}2析構函數'
+HC776172C0FE5: '虛基類別 %1 的 %select{private|protected}2 析構函數'
 # 'inheriting constructors are incompatible with C++98'
 H811CC4188AC3: '虛構函數與C++98不相容'
 # 'inherits from superclass %0 here'
-HFC19FC83A6FB: '從超類別%0繼承至此'
+HFC19FC83A6FB: '從超類別 %0 繼承至此'
 # 'init method must return a type related to its receiver type'
 HE0B5DF2EAC96: '初始化方法必須返回與接收器類型相關的類型'
 # 'init methods must return a type related to the receiver type'
 H77EF2E241D1F: '所有初始化方法必須返回與接收器類型相關的類型'
 # 'init methods must return an object pointer type, not %0'
-HA49BF476668F: '初始化方法必須返回物件指標類型，而非%0'
+HA49BF476668F: '初始化方法必須返回物件指標類型，而非 %0'
 # "initialization clause of OpenMP for loop is not in canonical form ('var = init' or 'T var = init')"
 H55BD0EE327C7: 'OpenMP for迴圈的初始化子句必須為標準形式（"var = init"或"T var = init"）'
 # 'initialization is not supported for __shared__ variables'
 H36A01643C5A6: '__shared__變數不支援初始化'
 # 'initialization of %0 may run twice when built into a shared library: it has hidden visibility and external linkage'
-H8FC0CAE3AC23: '初始化%0可能在建置為共享函式庫時執行兩次：其可見性為隱藏但具有外部連結性'
+H8FC0CAE3AC23: '初始化 %0 可能在建置為共享函式庫時執行兩次：其可見性為隱藏但具有外部連結性'
 # "initialization of %select{|signed }0char array with UTF-8 string literal is not permitted by %select{'-fchar8_t'|C++20}1"
 H2A8B3176C3CF: "使用 UTF-8 字符串文字初始化 %select{|有符號 }0char 陣列不被 %select{'-fchar8_t'|C++20}1 所允許"
 # 'initialization of an array %diff{of type $ from a compound literal of type $|from a compound literal}0,1 is a GNU extension'
@@ -22711,7 +22711,7 @@ HA729653B7153: '以複合字面值初始化陣列%diff{類型$的$|從複合字�
 # 'initialization of flexible array member is not allowed'
 H080F42BFBE3B: '無法初始化柔性陣列成員'
 # 'initialization of incomplete type %0'
-H8382A60542C7: '初始化不完整類型%0'
+H8382A60542C7: '初始化不完整類型 %0'
 # 'initialization of initializer_list object is incompatible with C++98'
 HB868A7DFE86A: 'initializer_list 物件的初始化與 C++98 不相容'
 # 'initialization of non-aggregate type %0 with a designated initializer list'
@@ -22749,29 +22749,29 @@ H2820D73AEF2F: '無元素的聚合初始化器需要明確的大括號'
 # 'initializer for functional-style cast to %0 contains multiple expressions'
 H98881129A20C: '對 %0 進行函數式轉型的初始化器包含多個運算式'
 # 'initializer for functional-style cast to %0 is empty'
-H4EA4C8E23F55: '以%0進行函數式類型轉換的初始值設定為空值'
+H4EA4C8E23F55: '以 %0 進行函數式類型轉換的初始值設定為空值'
 # 'initializer for lambda capture %0 contains multiple expressions'
-H66A3A7273E8A: 'lambda傳遞清單%0的初始值設定包含多個運算式'
+H66A3A7273E8A: 'lambda傳遞清單 %0 的初始值設定包含多個運算式'
 # 'initializer for sizeless type %0 cannot be empty'
-H8FFA617F38FD: '無大小型%0的初始值設定不能為空'
+H8FFA617F38FD: '無大小型 %0 的初始值設定不能為空'
 # 'initializer for thread-local variable must be a constant expression'
 HD7C0523C87D0: '執行緒局部變數的初始值設定必須是常數運算式'
 # 'initializer for variable %0 with type %1 contains multiple expressions'
-HA7D83169E121: '型別%1的變數%0初始值設定包含多個運算式'
+HA7D83169E121: '型別 %1 的變數 %0 初始值設定包含多個運算式'
 # 'initializer for variable %0 with type %1 is empty'
-HD6A61B62F49C: '型別%1的變數%0初始值設定為空'
+HD6A61B62F49C: '型別 %1 的變數 %0 初始值設定為空'
 # 'initializer for virtual base class %0 of abstract class %1 will never be used'
-H377D13F4BA4B: '抽象類別%1的虛基類%0的初始值設定器永遠不會被使用'
+H377D13F4BA4B: '抽象類別 %1 的虛基類 %0 的初始值設定器永遠不會被使用'
 # "initializer list cannot be used on the %select{left|right}0 hand side of operator '%1'"
 H08A1BB46A564: "初始化清單無法用於運算子'%1'的%select{左|右}0邊側"
 # 'initializer missing for lambda capture %0'
-H362962332DA4: 'lambda傳遞清單%0缺少初始值設定'
+H362962332DA4: 'lambda傳遞清單 %0 缺少初始值設定'
 # 'initializer of %0 is not a constant expression'
-HF34500BAECA9: '%0的初始值設定並非常數運算式'
+HF34500BAECA9: '%0 的初始值設定並非常數運算式'
 # 'initializer of %0 is unknown'
-H4815D272C20B: '%0的初始值設定未定義'
+H4815D272C20B: '%0 的初始值設定未定義'
 # 'initializer of weak variable %0 is not considered constant because it may be different at runtime'
-HBD6BC73EA44F: '弱變數%0的初始值設定器未被視為常數，因為它在執行階段可能不同'
+HBD6BC73EA44F: '弱變數 %0 的初始值設定器未被視為常數，因為它在執行階段可能不同'
 # 'initializer on function does not look like a pure-specifier'
 H79A85F4AF5C7: '函數的初始值設定器看起來不像是純規格指定'
 # 'initializer order does not match the declaration order'
@@ -22779,29 +22779,29 @@ HBA21FCA776B9: '初始值設定器的順序與宣告的順序不匹配'
 # 'initializer priorities are not supported in HLSL'
 HFAA073E424F4: '初始化器的優先權在HLSL中不被支援'
 # 'initializer would partially override prior initialization of object of type %1 with non-trivial destruction'
-H52C4E394B1C2: '初始值設定器會部分覆寫先前對型別%1物件的初始化（該物件具有非平凡銷毀特性）'
+H52C4E394B1C2: '初始值設定器會部分覆寫先前對型別 %1 物件的初始化（該物件具有非平凡銷毀特性）'
 # 'initializer-string for char array is too long'
 HF948F6263A8D: '字元陣列的初始值字串過長'
 # 'initializer-string for char array is too long, array size is %0 but initializer has size %1 (including the null terminating character)'
-H17CD335B9F9F: '字元陣列的初始值字串過長，陣列大小為%0但初始值設定的大小為%1（包含空終止字元）'
+H17CD335B9F9F: '字元陣列的初始值字串過長，陣列大小為 %0 但初始值設定的大小為 %1（包含空終止字元）'
 # 'initializing %0 from an empty initializer list is incompatible with C++98'
-H822723DC0E42: '從空初始值清單初始化%0與C++98不相容'
+H822723DC0E42: '從空初始值清單初始化 %0 與C++98不相容'
 # "initializing 'char8_t' array with plain string literal"
-H1EA4AB240813: "使用純字面字串初始化'char8_t'陣列"
+H1EA4AB240813: "使用純字面字串初始化 'char8_t' 陣列"
 # "initializing an array from a '%0' predefined identifier is a Microsoft extension"
 H8573434E16CF: "從'%0'預定義識別符初始化陣列是Microsoft擴充"
 # 'initializing char array with wide string literal'
 H698D73717CFB: '使用寬字元字面值初始化char陣列'
 # 'initializing field %0 with default member initializer'
-HC1BC6A14F9CB: '使用成員預設初始化器初始化成員%0'
+HC1BC6A14F9CB: '使用成員預設初始化器初始化成員 %0'
 # 'initializing multiple members of union'
 HC7C97F10525A: '初始化聯盟中的多個成員'
 # 'initializing parameter %0 with default argument'
-H20102CE039A6: '使用預設參數初始化參數%0'
+H20102CE039A6: '使用預設參數初始化參數 %0'
 # 'initializing pointer member %0 to point to a temporary object whose lifetime is shorter than the lifetime of the constructed object'
-H705DCA77F9DC: '將指標成員%0初始化為指向生存期短於所建構物件的臨時物件'
+H705DCA77F9DC: '將指標成員 %0 初始化為指向生存期短於所建構物件的臨時物件'
 # 'initializing pointer member %0 with the stack address of %select{variable|parameter}2 %1'
-HF09BD5727610: '將指標成員%0初始化為%select{變數|參數}2 %1的堆疊位址'
+HF09BD5727610: '將指標成員 %0 初始化為%select{變數|參數}2 %1 的堆疊位址'
 # 'initializing wide char array with incompatible wide string literal'
 HA0905D8F9102: '使用與寬字元陣列不相容的寬字元字面值初始化寬字元陣列'
 # 'initializing wide char array with non-wide string literal'
@@ -22811,11 +22811,11 @@ HF0EA4880CACC: '內联所有檢查'
 # 'inline all functions'
 HEE76F6E2509B: '內联所有函數'
 # 'inline assembly label %0 declared here'
-H1FAD9492270E: '此處宣告內联組件標籤%0'
+H1FAD9492270E: '此處宣告內联組件標籤 %0'
 # 'inline declaration of %0 follows non-inline definition'
-H9E262DCDBF26: '非內联定義後跟隨的%0內联宣告'
+H9E262DCDBF26: '非內联定義後跟隨的 %0 內联宣告'
 # 'inline declaration of %0 not allowed in block scope'
-H0812ED282234: '區塊作用域中不允许%0的內联宣告'
+H0812ED282234: '區塊作用域中不允许 %0 的內联宣告'
 # 'inline function %q0 is not defined'
 HC9FA92373F42: '內联函數%q0未定義'
 # 'inline function not defined%select{| before the private module fragment}0'
@@ -22913,7 +22913,7 @@ H99AB003B5614: '實例變數必須具有固定大小'
 # 'instantiated into assembly here'
 H396FFF689BB5: '在此處轉換為組合語言'
 # 'instantiating fold expression with %0 arguments exceeded expression nesting limit of %1'
-H467EDA4122CE: '使用%0個參數實例化摺疊運算式時超過了%1層的運算式嵌套限制'
+H467EDA4122CE: '使用 %0 個參數實例化摺疊運算式時超過了 %1 層的運算式嵌套限制'
 # 'instantiation of %q0 is different in different modules'
 H7179BAA1427A: '%q0在不同模組中的實例化不同'
 # "instantiation of '%0' not supported yet"
@@ -22949,19 +22949,19 @@ HA31AFF85F744: '插樁寫入指令'
 # 'instrumentation map used to identify function ids. Currently supports elf file instrumentation maps.'
 HABD136211445: '用於識別函數ID的插樁地圖。目前支援ELF檔案插樁地圖。'
 # 'integer constant expression evaluates to value %0 that cannot be represented in a %1-bit %select{signed|unsigned}2 integer type'
-HA689EA8A19CC: '%select{有符號|無符號}2整數類型的%1位中無法表示整數常量運算式求值的值%0'
+HA689EA8A19CC: '%select{有符號|無符號}2整數類型的 %1 位中無法表示整數常量運算式求值的值 %0'
 # 'integer constant not in range of enumerated type %0'
-H38F9A13FA923: '枚舉類型%0的整數常量超出範圍'
+H38F9A13FA923: '枚舉類型 %0 的整數常量超出範圍'
 # 'integer literal is too large to be represented in a signed integer type, interpreting as unsigned'
 H510046C2B2ED: '整數字面量無法用有符號整數類型表示，將解釋為無符號類型'
 # 'integer literal is too large to be represented in any %select{signed |}0integer type'
 H586D057CD6B8: '整數字面量無法在%select{有符號 |}0整數類型中表示'
 # "integer literal is too large to be represented in type 'long' and is subject to undefined behavior under C++98, interpreting as 'unsigned long'; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards"
-H84C22AB83CDC: "此字面量在C++11及之後版本將%select{具有'long long'類型|不符合語法}0。因無法在'long'類型中表示，根據C++98將解釋為'unsigned long'"
+H84C22AB83CDC: "此字面量在C++11及之後版本將%select{具有'long long'類型|不符合語法}0。因無法在 'long' 類型中表示，根據C++98將解釋為'unsigned long'"
 # "integer literal is too large to be represented in type 'long', interpreting as 'unsigned long' per C++98; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards"
-H4C2C8A72E536: "此字面量在C++11及之後版本將%select{具有'long long'類型|不符合語法}0。因無法在'long'類型中表示，根據C89將解釋為'unsigned long'"
+H4C2C8A72E536: "此字面量在C++11及之後版本將%select{具有'long long'類型|不符合語法}0。因無法在 'long' 類型中表示，根據C89將解釋為'unsigned long'"
 # "integer literal is too large to be represented in type 'long', interpreting as 'unsigned long' per C89; this literal will %select{have type 'long long'|be ill-formed}0 in C99 onwards"
-H58DBBF3A9BD1: "此字面量在C99及之後版本將%select{具有'long long'類型|不符合語法}0。因無法在'long'類型中表示，根據C89將解釋為'unsigned long'"
+H58DBBF3A9BD1: "此字面量在C99及之後版本將%select{具有'long long'類型|不符合語法}0。因無法在 'long' 類型中表示，根據C89將解釋為'unsigned long'"
 # 'integer overflow in preprocessor expression'
 H24214C6EA913: '預處理器運算式中發生整數溢位'
 # 'integer sequences must have integral element type'
@@ -22969,13 +22969,13 @@ H16392B2B25B5: '整數序列必須具有整數型別元素'
 # 'integer sequences must have non-negative sequence length'
 HC3DBF19F94A9: '整數序列必須具有非負長度'
 # 'integer value %0 is outside the valid range of values [%1, %2] for the enumeration type %3'
-HB6C02E17F94C: '枚舉類型%3的有效值範圍[%1, %2]外的整數值%0'
+HB6C02E17F94C: '枚舉類型 %3 的有效值範圍[%1, %2]外的整數值 %0'
 # 'integral constant expression has incomplete class type %0'
-H52768B5A0D44: '具有不完整類別類型%0的整數常量運算式'
+H52768B5A0D44: '具有不完整類別類型 %0 的整數常量運算式'
 # 'integral constant expression requires explicit conversion from %0 to %1'
-H482F498F126E: '需要明確轉換%0至%1才能形成整數常量運算式'
+H482F498F126E: '需要明確轉換 %0 至 %1 才能形成整數常量運算式'
 # 'interface type %1 cannot be %select{returned|passed}0 by value; did you forget * in %1?'
-H5F16699831A7: '%select{傳回|傳遞}0介面類型%1時必須使用指標；是否在%1中遺漏了*？'
+H5F16699831A7: '%select{傳回|傳遞}0介面類型 %1 時必須使用指標；是否在 %1 中遺漏了*？'
 # 'interface type cannot be statically allocated'
 HFB7A102C4547: '無法以靜態儲存類別宣告介面類型'
 # 'interface type cannot inherit from %select{struct|non-public interface|class}0 %1'
@@ -22985,7 +22985,7 @@ H5BB34D1AC02B: "介面類型無法指定'%select{私有|受保護}0'存取修飾
 # "interop type '%0' cannot be specified more than once"
 H92EFF909211E: "互通類型'%0'只能指定一次"
 # 'interop variable %0 used in multiple action clauses'
-H6D1E048E9343: '互通變數%0用於多個動作子句中'
+H6D1E048E9343: '互通變數 %0 用於多個動作子句中'
 # "interop variable must be of type 'omp_interop_t'"
 H4EE913CC5003: "interop變數必須為類型 'omp_interop_t'"
 # 'interrupt service routine cannot be called directly'
@@ -23001,13 +23001,13 @@ H9C8DEF0487D6: '內在模組搜尋路徑'
 # 'introduce a module file extension for testing purposes. The argument is parsed as blockname:major:minor:hashed:user info'
 HC4A3048AAD1F: '為測試目的新增模組檔擴充項。參數會被解析為 blockname:major:minor:hashed:user info 的格式'
 # 'introduce a parameter name to make %0 part of the selector'
-HF88F126D64B8: '引介參數名稱以將%0納入選擇器（selector）'
+HF88F126D64B8: '引介參數名稱以將 %0 納入選擇器（selector）'
 # 'invalid #ident directive'
 H33DD8376B05A: '無效的#ident指示項'
 # 'invalid %% escape in inline assembly string'
 HDBE197B56289: '內嵌組裝字串中無效的%%轉義'
 # "invalid %0 at end of declaration; did you mean '='?"
-H6911F0CCF565: '宣告末尾的%0無效；您是否想要使用"="？'
+H6911F0CCF565: '宣告末尾的 %0 無效；您是否想要使用"="？'
 # 'invalid %select{arithmetic between|bitwise operation between|comparison of|conditional expression between|compound assignment of}0 %select{floating-point|enumeration}1 type %2 %plural{2:with|4:from|:and}0 %select{enumeration|floating-point}1 type %3'
 H06A881D8D9FE: '無效的%select{浮點數/列舉型別間的算術運算|浮點數/列舉型別間的位元運算|浮點數/列舉型別的比較|浮點數/列舉型別間的條件運算式|浮點數/列舉型別的複合指派}0 %select{浮點數|列舉}1 類型 %2 %plural{2:與|4:從|:和}0 %select{列舉|浮點數}1 類型 %3'
 # 'invalid %select{arithmetic between|bitwise operation between|comparison of|conditional expression between|compound assignment of}0 different enumeration types%diff{ ($ and $)|}1,2'
@@ -23017,7 +23017,7 @@ H898CA374F6B7: '無效的%select{分支|返回|拋出}0 %select{超出|進入}1 
 # 'invalid %select{constructor|destructor}0 declaration'
 HDEF8993ADCB9: '無效的%select{建構函數|析構函數}0 宣告'
 # "invalid 'this' expression on 'map' clause"
-H008D791665EC: "在'map'子句中的'this'運算式無效"
+H008D791665EC: "在 'map' 子句中的 'this' 運算式無效"
 # "invalid -Xopenmp-target argument: '%0', options requiring arguments are unsupported"
 H705427655A77: "無效的-Xopenmp-target 參數：'%0'，需要參數的選項不受支援"
 # "invalid C++ ABI name '%0'"
@@ -23029,7 +23029,7 @@ HA0C57A49CA76: '無效的Darwin版本號：%0'
 # "invalid OS value '%0' in '%1'"
 H00BD3F016742: "無效的作業系統值'%0'在'%1'中"
 # 'invalid OpenACC clause %0'
-HA3099393E590: '無效的OpenACC子句%0'
+HA3099393E590: '無效的OpenACC子句 %0'
 # "invalid OpenACC directive %select{%1|'%1 %2'}0"
 H74A42ADBF419: "無效的OpenACC指令%select{%1|'%1 %2'}0"
 # 'invalid PCS type'
@@ -23047,11 +23047,11 @@ H7917BEC4B42C: "無效的Xarch參數：'%0'，需要參數的選項未被支援"
 # 'invalid __hlsl_resource_t type attributes'
 H9A97FF7B54BE: '無效的__hlsl_resource_t類型屬性'
 # 'invalid address discrimination mode %0'
-H1D217687F248: '無效的地址區分模式%0'
+H1D217687F248: '無效的地址區分模式 %0'
 # "invalid alignment option in '#pragma %select{align|options align}0' - ignored"
 H410475644E70: "在'#pragma %select{align|options align}0'中發現無效的對齊選項 - 已忽略"
 # "invalid application of '%0' to %select{an incomplete|sizeless}1 type %2"
-H3984632B643A: "對%select{不完整|無尺寸}1類型%2不恰當地應用'%0'"
+H3984632B643A: "對%select{不完整|無尺寸}1類型 %2 不恰當地應用'%0'"
 # "invalid application of '%0' to WebAssembly table"
 HA443432F106F: "對WebAssembly表格不恰當地應用'%0'"
 # "invalid application of '%0' to a function type"
@@ -23071,13 +23071,13 @@ H053EB6DE40C8: "無效的CPU名稱'%0'"
 # "invalid arch name '%0', %1"
 HAF3A77CFBCF8: "無效的CPU名稱'%0'，%1"
 # 'invalid argument %0 to function: %1, expecting a generic pointer argument'
-H45B49DB90594: '函數%0的無效參數類型：%1，期望一個通用指標參數'
+H45B49DB90594: '函數 %0 的無效參數類型：%1，期望一個通用指標參數'
 # "invalid argument '%0' not allowed with '%1'"
 H5F814EC912CC: "與'%1'一起使用時，'%0'參數無效"
 # "invalid argument '%0' only allowed with '%1'"
 HCD365CC8E5D4: "只有與'%1'一起使用時才允許'%0'參數"
 # "invalid argument '%0' to -%1"
-H8405E80D8137: "對-%1使用無效參數'%0'"
+H8405E80D8137: "對-%1 使用無效參數'%0'"
 # "invalid argument '%0' to -malign-branch=; each element must be one of: %1"
 H20657E1CDBBF: "對-malign-branch=使用無效參數'%0'；每個元素必須是以下之一：%1"
 # "invalid argument '%0' to -mfpu=; must be one of: 64, 32, none, 0 (alias for none)"
@@ -23085,35 +23085,35 @@ HF131652C4C29: "對-mfpu=使用無效參數'%0'；必須是以下之一：64、3
 # "invalid argument '%0' to -msimd=; must be one of: none, lsx, lasx"
 H2BA112BC46B6: "對-msimd=使用無效參數'%0'；必須是以下之一：none、lsx、lasx"
 # "invalid argument '%0' to atomic attribute; valid options are: 'remote_memory', 'fine_grained_memory', 'ignore_denormal_mode' (optionally prefixed with 'no_')"
-H438B1A442EF4: "原子屬性無效參數'%0'；有效選項包括：'remote_memory'、'fine_grained_memory'、'ignore_denormal_mode'（可選擇在前面加上'no_'）"
+H438B1A442EF4: "原子屬性無效參數'%0'；有效選項包括：'remote_memory'、'fine_grained_memory'、'ignore_denormal_mode'（可選擇在前面加上 'no_'）"
 # "invalid argument '-mno-amdgpu-ieee' only allowed with relaxed NaN handling"
 H507F0448DDCC: '對-mno-amdgpu-ieee使用無效參數，僅允許在鬆弛NaN處理時使用'
 # "invalid argument in '%0', only integer or 'auto' is supported"
-H40210717B247: "在'%0'中使用無效參數，僅支持整數或'auto'"
+H40210717B247: "在'%0'中使用無效參數，僅支持整數或 'auto'"
 # "invalid argument in '%0', only integers are supported"
 H7CC5EAE0927D: "在'%0'中使用無效參數，僅支持整數"
 # 'invalid argument of type %0; expected an integer type'
-HDC97D348BCF9: '類型%0的無效引數；期望整數類型'
+HDC97D348BCF9: '類型 %0 的無效引數；期望整數類型'
 # 'invalid argument to convert to character'
 H035CE8B39D0F: '無法轉換為字符的無效參數類型'
 # 'invalid argument type %0 to unary expression'
-HB7A2329B026C: '一元表達式無效的參數類型%0'
+HB7A2329B026C: '一元表達式無效的參數類型 %0'
 # 'invalid argument type to function %0 (expecting %1 having %2)'
-H740D8FB32D84: '函數%0的參數類型無效（期望%1具有%2）'
+H740D8FB32D84: '函數 %0 的參數類型無效（期望 %1 具有 %2）'
 # 'invalid argument: symbol must be a device-side function or global variable'
 HB29E0DD1BCB5: '無效的參數；符號必須是裝置端函數或全域變數'
 # "invalid argument; expected 'disable'"
-H14256C1A2363: "無效引數；期望'disable'"
+H14256C1A2363: "無效引數；期望 'disable'"
 # "invalid argument; expected 'enable'%select{|, 'full'}0%select{|, 'assume_safety'}1 or 'disable'"
-H369903756AB7: "無效引數；期望'enable'%select{|, 'full'}0%select{|, 'assume_safety'}1 或'disable'"
+H369903756AB7: "無效引數；期望 'enable'%select{|, 'full'}0%select{|, 'assume_safety'}1 或 'disable'"
 # 'invalid authentication key %0'
-H1380B8ED725A: '無效的驗證金鑰%0'
+H1380B8ED725A: '無效的驗證金鑰 %0'
 # 'invalid block pointer conversion %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2'
 H1E4447440EDF: '無效的區塊指標轉換%select{%diff{將$指派給$|指派給不同類型}1,0|%diff{將$傳遞給類型$的參數|傳遞到不同類型的參數}1,0|%diff{從返回類型為$的函數返回$|從不同返回類型的函數返回}1,0|%diff{將$轉換為類型$|在類型之間轉換}1,0|%diff{用類型$的運算式初始化$|用不同類型的運算式初始化}1,0|%diff{將$傳送到類型$的參數|傳送到不同類型的參數}1,0|%diff{將$轉換為類型$|在類型之間轉換}1,0}2'
 # 'invalid block variable declaration - must be %select{const qualified|initialized}0'
 HF892D907A5A7: '無效的區塊變數宣告 - 必須%select{具const修飾|已初始化}0'
 # "invalid block variable declaration - using 'extern' storage class is disallowed"
-H2029EAB9FA9A: "無效的區塊變數宣告 - 禁止使用'extern'儲存類別"
+H2029EAB9FA9A: "無效的區塊變數宣告 - 禁止使用 'extern' 儲存類別"
 # 'invalid branch into OpenACC Compute/Combined Construct'
 HC49FDF0B5C89: '非法分支到OpenACC Compute/Combined Construct內部'
 # 'invalid branch out of OpenACC Compute/Combined Construct'
@@ -23123,17 +23123,17 @@ H69A222420F22: "在'%1'中無效的分支保護選項'%0'"
 # "invalid character '%0' in raw string delimiter; use PREFIX( )PREFIX to delimit raw string"
 H82170E32D0E4: "原始字串分隔符中的無效字元'%0'；使用PREFIX( )PREFIX來界定原始字串"
 # "invalid comparison flag %0; use 'layout_compatible' or 'must_be_null'"
-H677EA1A68EB0: "無效的比較旗標%0；使用'layout_compatible'或'must_be_null'"
+H677EA1A68EB0: "無效的比較旗標 %0；使用 'layout_compatible' 或 'must_be_null'"
 # "invalid component '%0' used; expected 'x', 'y', 'z', or 'w'"
-H32632D0CDE2F: "使用了無效的元件'%0'；期望的元件為'x'、'y'、'z'或'w'"
+H32632D0CDE2F: "使用了無效的元件'%0'；期望的元件為 'x'、'y'、'z' 或 'w'"
 # 'invalid constructor from class in system header, should not be explicit'
 HEFC602372E3E: '系統標頭中的類別構造器不應為顯式'
 # 'invalid conversion between ext-vector type %0 and %1'
-H4E43BF77A891: '擴展向量類型%0與%1之間的轉換無效'
+H4E43BF77A891: '擴展向量類型 %0 與 %1 之間的轉換無效'
 # 'invalid conversion between vector type %0 and integer type %1 of different size'
-HAD5A2EB8C76E: '與不同大小的整數類型%1之間的向量類型%0轉換無效'
+HAD5A2EB8C76E: '與不同大小的整數類型 %1 之間的向量類型 %0 轉換無效'
 # 'invalid conversion between vector type %0 and scalar type %1'
-H0E21BE8324C1: '與純量類型%1之間的向量類型%0轉換無效'
+H0E21BE8324C1: '與純量類型 %1 之間的向量類型 %0 轉換無效'
 # 'invalid conversion between vector type%diff{ $ and $|}0,1 of different size'
 H62FB40425AFD: '與%diff{ $ 和 $|}1,0不同大小的向量類型轉換無效'
 # "invalid conversion specifier '%0'"
@@ -23187,9 +23187,9 @@ H1627FB393F43: '大小為 %2 的封包 %1 的無效索引 %0'
 # "invalid input constraint '%0' in asm"
 H09D927559067: "組合語言中的無效輸入限制 '%0'"
 # "invalid input for analyzer-config option '%0', that expects %1 value"
-HB14EB9C7A93F: "分析器配置選項'%0'的輸入無效，該選項期望%1值"
+HB14EB9C7A93F: "分析器配置選項'%0'的輸入無效，該選項期望 %1 值"
 # "invalid input for checker option '%0', that expects %1"
-H784B521FDFA9: "檢查器選項'%0'的輸入無效，該選項期望%1"
+H784B521FDFA9: "檢查器選項'%0'的輸入無效，該選項期望 %1"
 # "invalid input size for constraint '%0'"
 H8F6CDB6F0449: "限制 '%0' 的無效輸入大小"
 # "invalid integral value '%1' in '%0'"
@@ -23211,7 +23211,7 @@ H2CA59C9EF59C: "限制 '%0' 的組合語言輸入中的無效左值"
 # 'invalid lvalue in asm output'
 HED6C7D31AA01: '組合語言輸出中的無效左值'
 # 'invalid matrix element type %0'
-H9CDCD6DAE3BE: '無效的矩陣元素類型%0'
+H9CDCD6DAE3BE: '無效的矩陣元素類型 %0'
 # 'invalid newline character in raw string delimiter; use PREFIX( )PREFIX to delimit raw string'
 HF6C358E90110: '原始字串分隔符中包含無效的換行字符；請使用PREFIX( )PREFIX來分隔原始字串'
 # 'invalid number of arguments to function: %0'
@@ -23221,15 +23221,15 @@ H92F337A26551: "無效的卸載架構組合：'%0'和'%1'（針對特定處理�
 # 'invalid operand number in inline asm string'
 H3DCCD1026997: '內聯組合語言字串中的操作數編號無效'
 # 'invalid operand of type %0 where %1 or a vector of such type is required'
-HD52C15C02D70: '類型%0的操作數無效，此處需要%1類型或該類型的向量'
+HD52C15C02D70: '類型 %0 的操作數無效，此處需要 %1 類型或該類型的向量'
 # 'invalid operand of type %0 where floating, complex or a vector of such types is required'
-HC1A341FFC462: '類型%0的操作數無效，此處需要浮點、複數或該類型的向量'
+HC1A341FFC462: '類型 %0 的操作數無效，此處需要浮點、複數或該類型的向量'
 # 'invalid operand of type %0%select{| where a scalar or vector is required}1'
-H848780E5A063: '類型%0的操作數無效%select{|，此處需要純量或向量}1'
+H848780E5A063: '類型 %0 的操作數無效%select{|，此處需要純量或向量}1'
 # 'invalid operands to binary expression (%0 and %1)'
-HC5560B091967: '二元運算式中的操作數無效（%0和%1）'
+HC5560B091967: '二元運算式中的操作數無效（%0 和 %1）'
 # "invalid option '%0' for %select{cpu_specific|cpu_dispatch}1"
-HEFAAB35E81AF: "%select{cpu_specific|cpu_dispatch}1的選項'%0'無效"
+HEFAAB35E81AF: "%select{cpu_specific|cpu_dispatch}1 的選項'%0'無效"
 # "invalid option '%0' not of the form <from-file>;<to-file>"
 HCB5BB85712F1: "選項'%0'無效，非<from-file>;<to-file>格式"
 # 'invalid option combination; LASX depends on LSX'
@@ -23249,11 +23249,11 @@ H1AE0ECD8B562: "與gcc工具一起使用時，輸出類型'%0'無效"
 # "invalid parameter name: '%0' is a keyword"
 HBA4C66D8A8AA: "無效的參數名稱：'%0'是保留字"
 # 'invalid parameter type for defaulted %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator; found %1, expected %2%select{| or %4}3'
-H1333988BA8FC: '預設的%select{<ERROR>|等同性|三向|等同性|關係}0比較運算子的參數類型無效；發現%1，期望%2%select{|或%4}3'
+H1333988BA8FC: '預設的%select{<ERROR>|等同性|三向|等同性|關係}0比較運算子的參數類型無效；發現 %1，期望 %2%select{|或 %4}3'
 # 'invalid parameter type for non-member defaulted %select{<ERROR>|equality|three-way|equality|relational}0 comparison operator; found %1, expected class or reference to a constant class'
-HEB967961C960: '非成員預設的%select{<ERROR>|等同性|三向|等同性|關係}0比較運算子的參數類型無效；發現%1，期望類別或對常量類別的引用'
+HEB967961C960: '非成員預設的%select{<ERROR>|等同性|三向|等同性|關係}0比較運算子的參數類型無效；發現 %1，期望類別或對常量類別的引用'
 # 'invalid pipe access modifier (expecting %0)'
-HA4FFF117B821: '無效的管道存取修飾符（期望%0）'
+HA4FFF117B821: '無效的管道存取修飾符（期望 %0）'
 # 'invalid position specified for %select{field width|field precision}0'
 H5DF564C1B18C: '指定的%select{字段寬度|字段精確度}0位置無效'
 # "invalid preprocessing directive%select{|, did you mean '#%1'?}0"
@@ -23265,19 +23265,19 @@ H3723A726B37F: '非ObjC類型上的協定修飾符無效'
 # 'invalid prototype, variadic arguments are not allowed in OpenCL'
 H5E1888FFA26E: '無效的原型，OpenCL中不允許使用可變參數'
 # "invalid range expression of type %0; did you mean to dereference it with '*'?"
-H1FCBEB4D2213: '類型%0的範圍運算式無效；是否想用"*"解引用它？'
+H1FCBEB4D2213: '類型 %0 的範圍運算式無效；是否想用"*"解引用它？'
 # "invalid range expression of type %0; no viable '%select{begin|end}1' function available"
-H76B630AFA57F: '類型%0的範圍運算式無效；沒有可用的"%select{begin|end}1"函數'
+H76B630AFA57F: '類型 %0 的範圍運算式無效；沒有可用的"%select{begin|end}1"函數'
 # "invalid range following '-' in expected %0"
-H99FD9B7E0352: '在期望的%0後面的範圍無效'
+H99FD9B7E0352: '在期望的 %0 後面的範圍無效'
 # "invalid reduction operator,  expected '+', '*', 'max', 'min', '&', '|', '^', '&&', or '||'"
 H3407BE2F5E5D: '無效的約簡運算子，期望"+", "*", "max", "min", "&", "|", "^", "&&", 或 "||"'
 # 'invalid reference to function %0: constraints not satisfied'
-H9E6FAF3D6010: '對函數%0的引用無效：約束條件未滿足'
+H9E6FAF3D6010: '對函數 %0 的引用無效：約束條件未滿足'
 # 'invalid reinterpretation: sizes of %0 and %1 must match'
-HC6E0606A101D: '無效的重新詮釋：%0和%1的大小必須匹配'
+HC6E0606A101D: '無效的重新詮釋：%0 和 %1 的大小必須匹配'
 # "invalid resource class specifier '%0' for packoffset, expected 'c'"
-H2B96C40BB1F0: "packoffset的無效資源類別指定符'%0'，期望為'c'"
+H2B96C40BB1F0: "packoffset的無效資源類別指定符'%0'，期望為 'c'"
 # 'invalid rounding argument'
 HD77BD554C068: '無效的捨入參數'
 # "invalid runtime library name in argument '%0'"
@@ -23285,7 +23285,7 @@ HCC4F20591ADF: "參數'%0'中的無效執行階段程式庫名稱"
 # 'invalid size value'
 H41C03C7DB477: '無效的大小值'
 # "invalid space specifier '%0' used; expected 'space' followed by an integer, like space1"
-HB8CFB0AAB2CD: "使用了無效的間隔指定符'%0'；期望以'space'後跟整數，例如space1"
+HB8CFB0AAB2CD: "使用了無效的間隔指定符'%0'；期望以 'space' 後跟整數，例如space1"
 # 'invalid special register for builtin'
 H26E533E2D360: '無效的內建特殊寄存器'
 # 'invalid storage class specifier in function declarator'
@@ -23293,15 +23293,15 @@ HF2FD2E42B318: '函數宣告中的無效存儲類別指定符'
 # "invalid string literal, ignoring final '\\'"
 H550F921F116D: "無效的字串文字，忽略最後的 '\\'"
 # "invalid suffix '%0' on %select{integer|floating|fixed-point}1 constant"
-HFE61994BB7A3: "%select{integer|floating|fixed-point}1常數的無效後綴'%0'"
+HFE61994BB7A3: "%select{integer|floating|fixed-point}1 常數的無效後綴'%0'"
 # 'invalid suffix on literal; C++11 requires a space between literal and identifier'
 H3AC3DC712C63: '字面值的無效後綴；C++11要求字面值和識別符之間有空格'
 # "invalid tag %0 on '%1' %select{directive|clause}2"
-HB6EF4B837656: "在'%1'的%select{指令|子句}2上使用無效標籤%0"
+HB6EF4B837656: "在'%1'的%select{指令|子句}2上使用無效標籤 %0"
 # "invalid target ID '%0'; format is a processor name followed by an optional colon-delimited list of features followed by an enable/disable sign (e.g., 'gfx908:sramecc+:xnack-')"
 HF2F065F66FFD: "無效的目標ID '%0'；格式為處理器名稱後跟可選的以冒號分隔的功能清單，再後跟啟用/禁用符號（例如'gfx908:sramecc+:xnack-'）"
 # 'invalid target type %0 for dynamic_cast; target type must be a reference or pointer type to a defined class'
-HFE4D2B7D8E06: 'dynamic_cast的無效目標類型%0；目標類型必須是已定義類別的引用或指標類型'
+HFE4D2B7D8E06: 'dynamic_cast的無效目標類型 %0；目標類型必須是已定義類別的引用或指標類型'
 # "invalid thread model '%0' in '%1' for this target"
 HE75965380195: "此目標在'%1'中的無效執行緒模型'%0'"
 # "invalid thread pointer reading mode '%0'"
@@ -23313,15 +23313,15 @@ HA6A8BDC08D89: '巨集參數列表中的無效記號'
 # 'invalid transaction abort code'
 H75E4D8742736: '無效的交易中斷代碼'
 # 'invalid type %0 as argument of iboutletcollection attribute'
-HE41F37E3851B: '在iboutletcollection屬性的引數中，類型%0無效'
+HE41F37E3851B: '在iboutletcollection屬性的引數中，類型 %0 無效'
 # 'invalid type %0 in asm %select{input|output}1'
-H2A71CC82E6A7: '在asm的%select{輸入|輸出}1中包含無效類型%0'
+H2A71CC82E6A7: '在asm的%select{輸入|輸出}1中包含無效類型 %0'
 # "invalid type %0 in asm input for constraint '%1'"
-H1E6A37C4D619: "在asm輸入中類型%0不符合約束'%1'"
+H1E6A37C4D619: "在asm輸入中類型 %0 不符合約束'%1'"
 # 'invalid type %0 is a %select{member|base}1 of %2'
-HB6D9D0DC110A: '無效的類型%0是%2的%select{成員|基底}1'
+HB6D9D0DC110A: '無效的類型 %0 是 %2 的%select{成員|基底}1'
 # 'invalid type %0 to %1 operator'
-H4C8C1A65C2A4: '無效的類型%0轉換為%1運算子'
+H4C8C1A65C2A4: '無效的類型 %0 轉換為 %1 運算子'
 # 'invalid universal character'
 H73C6676CA247: '無效的通用字元'
 # "invalid unwind library name in argument '%0'"
@@ -23329,7 +23329,7 @@ HD675186A50F6: "在引數'%0'中包含無效的unwind函式庫名稱"
 # "invalid use of '__funcref' keyword outside the WebAssembly triple"
 H5B018C340841: '在非WebAssembly三元組中使用__funcref關鍵字無效'
 # "invalid use of '__super', %0 has no base classes"
-HC8BFC8F3D816: '使用__super無效，%0沒有基類'
+HC8BFC8F3D816: '使用__super無效，%0 沒有基類'
 # "invalid use of '__super', this keyword can only be used inside class or member function scope"
 H02BB07D5882C: '使用__super無效，此關鍵字只能在類別或成員函數作用域內使用'
 # "invalid use of 'this' %select{outside of a non-static member function|in a function with an explicit object parameter}0"
@@ -23339,17 +23339,17 @@ H23BD562DB2DF: '使用PPC MMA類型無效'
 # 'invalid use of a cast in an inline asm context requiring an lvalue'
 H5D073F64410B: '在需要左值的-inline asm上下文中使用轉型無效'
 # 'invalid use of incomplete type %0'
-H7FE8554F5009: '使用不完整類型%0無效'
+H7FE8554F5009: '使用不完整類型 %0 無效'
 # 'invalid use of member %0 in %select{static|explicit object}1 member function'
-H50EBCD910232: '在%select{靜態|顯式物件}1成員函數中使用成員%0無效'
+H50EBCD910232: '在%select{靜態|顯式物件}1成員函數中使用成員 %0 無效'
 # 'invalid use of non-static data member %0'
-H59D616D352F1: '使用非靜態資料成員%0無效'
+H59D616D352F1: '使用非靜態資料成員 %0 無效'
 # 'invalid use of pointer to member type after %select{.*|->*}0'
 H48A2AD1643D5: '在%select{.*|->*}0之後使用成員類型指標無效'
 # 'invalid validator version : %0; format of validator version is "<major>.<minor>" (ex:"1.4")'
 H4B1AA82F67A0: '無效的驗證器版本：%0；驗證器版本格式為"<主要>.<次要>"（例如："1.4"）'
 # 'invalid validator version : %0; if validator major version is 0, minor version must also be 0'
-HD365448B0579: '無效的驗證器版本：%0；如果驗證器的主要版本為0，次要版本也必須為0'
+HD365448B0579: '無效的驗證器版本：%0；如果驗證器的主要版本為 0，次要版本也必須為 0'
 # 'invalid validator version : %0; validator version must be less than or equal to current internal version'
 HED613B352B91: '無效的驗證器版本：%0；驗證器版本必須小於或等於當前內部版本'
 # "invalid value '%1' in '%0'"
@@ -23567,9 +23567,9 @@ H3541695AB458: 'lambda調用運算子不應明確特化或實例化'
 # 'lambda cannot be both mutable and static'
 H057D935E257D: 'lambda無法同時為mutable和static'
 # 'lambda cannot be declared %0'
-H523BA4919111: 'lambda不能被宣告為%0'
+H523BA4919111: 'lambda不能被宣告為 %0'
 # 'lambda capture %0 is not %select{used|required to be captured for this use}1'
-HED12D4324492: 'lambda捕獲%0 %select{未被使用|需要被捕獲才能用於此處}1'
+HED12D4324492: 'lambda捕獲 %0 %select{未被使用|需要被捕獲才能用於此處}1'
 # 'lambda closure types are non-literal types before C++17'
 H3BDD817E383F: 'lambda閉包類型在C++17之前是非文字類型'
 # 'lambda expression begins here'
@@ -23585,25 +23585,25 @@ H33C909CD1D80: '無參數項的lambda是C++23擴展'
 # 'lambda without a parameter clause is a C++23 extension'
 HD70498A5F3EC: 'lambda表達式未指定參數子句是C++23的擴充功能'
 # 'lambdas are a %select{C++11|clang HLSL}0 extension'
-HD58884723190: 'lambda表達式是%select{C++11|clang HLSL}0的擴充功能'
+HD58884723190: 'lambda表達式是 %select{C++11|clang HLSL}0 的擴充功能'
 # "language not recognized: '%0'"
 H102C1DB9CB0E: "未識別的語言：'%0'"
 # 'large atomic operation may incur significant performance penalty; the access size (%0 bytes) exceeds the max lock-free size (%1 bytes)'
-H31655F77BD73: '大原子操作可能導致顯著的效能損失；存取大小（%0字節）超過最大無鎖大小（%1字節）'
+H31655F77BD73: '大原子操作可能導致顯著的效能損失；存取大小（%0 字節）超過最大無鎖大小（%1 字節）'
 # 'layout blocks in reverse order'
 H19EE0FFEC518: '布局區塊按反向順序排列'
 # 'lcov tracefile output'
 HCE669C9CA888: 'lcov 追蹤檔輸出'
 # 'left hand operand of type %0 to compound assignment cannot be truncated when used with right hand operand of type %1'
-H00D9FE7F4F87: '左操作元的類型%0在複合指派時，與右操作元的類型%1混合時不能被截斷'
+H00D9FE7F4F87: '左操作元的類型 %0 在複合指派時，與右操作元的類型 %1 混合時不能被截斷'
 # 'left hand operand to %0 must be a %select{|pointer to }1class compatible with the right hand operand, but is %2'
-HE8A81161D486: '%0的左操作元必須與右操作元兼容的%select{|指標到 }1類別，但實際是%2'
+HE8A81161D486: '%0 的左操作元必須與右操作元兼容的%select{|指標到 }1類別，但實際是 %2'
 # "left hand side of assignment operation('%0') must match one side of the sub-operation on the right hand side('%1' and '%2')"
 HA99FEEFA45D5: "指派運算的左邊（'%0'）必須與右邊的子運算（'%1'和'%2'）其中一邊的類型一致"
 # 'left operand of comma operator has no effect'
 H1D36CC5E4D5A: '逗號運算子的左操作元無效'
 # 'left shift of negative value %0'
-HF788BD55C118: '對負值%0進行左移位操作'
+HF788BD55C118: '對負值 %0 進行左移位操作'
 # "length modifier '%0' results in undefined behavior or no effect with '%1' conversion specifier"
 HDCB24BE7C9E8: "長度修飾符'%0'與'%1'轉換說明符一起使用時會導致未定義行為或無效"
 # 'libclc builtin preparation tool\n'
@@ -23645,7 +23645,7 @@ H1C3AE7A6EC95: '要印出的函數清單'
 # 'list of functions to skip'
 HED4CB34A956C: '要跳過的函數清單'
 # 'list of functions with call sites for which to specialize memcpy() for size 1'
-HD7F5B54EFF49: '要針對大小1進行memcpy()特殊化的呼叫位址所屬函數清單'
+HD7F5B54EFF49: '要針對大小 1 進行memcpy()特殊化的呼叫位址所屬函數清單'
 # "list of sections containing functions used for hugifying hot text. BOLT makes sure these functions are not placed on the same page as the hot text. (default='.stub,.mover')."
 H07A4ADB5443D: '包含用於hugifying熱文本的函數的區段清單。BOLT確保這些函數不會與熱文本放在同一頁面上。（預設值為".stub,.mover"）'
 # 'list of sections to reorder'
@@ -23741,23 +23741,23 @@ H6116FD3EFF04: '在 C++98 中，將本地類型 %0 作為模板參數是不相�
 # "local variable '%0' should not be used in 'declare target' directive;"
 HF2D2B034481C: "在'declare target'指令中不应使用本地變數'%0'；"
 # "local variable cannot be declared 'constinit'"
-HE35DCF249418: "本地變數不能被聲明為'constinit'"
+HE35DCF249418: "本地變數不能被聲明為 'constinit'"
 # "locking '%0' to build module '%1'"
 H36ABFAB03219: "將'%0'鎖定以建立模組'%1'"
 # 'logical expression with vector %select{type %1 and non-vector type %2|types %1 and %2}0 is only supported in C++'
-H1200F428FBB0: '帶有向量%select{類型%1和非向量類型%2|類型%1和%2}0的邏輯運算式僅在C++中受支援'
+H1200F428FBB0: '帶有向量%select{類型 %1 和非向量類型 %2|類型 %1 和 %2}0的邏輯運算式僅在C++中受支援'
 # 'logical not is only applied to the left hand side of this %select{comparison|bitwise operator}0'
 H9E8ECD267F25: '邏輯非僅應用於此%select{比較運算子|位元運算子}0的左邊操作數'
 # 'lookup from the current scope refers here'
 H9AFA3EAEA36F: '從當前作用域的查找指向此處'
 # 'lookup in the object type %0 refers here'
-H3FD57FB46E2B: '在物件類型%0的查找指向此處'
+H3FD57FB46E2B: '在物件類型 %0 的查找指向此處'
 # 'lookup of %0 in member access expression is ambiguous'
-H52F57D0BB44E: '在成員存取運算式中查找%0存在歧義'
+H52F57D0BB44E: '在成員存取運算式中查找 %0 存在歧義'
 # 'lookup of %0 in member access expression is ambiguous; using member of %1'
-H632E112FD2AD: '在成員存取運算式中查找%0存在歧義；使用%1的成員'
+H632E112FD2AD: '在成員存取運算式中查找 %0 存在歧義；使用 %1 的成員'
 # "loop iteration variable in the associated loop of 'omp %1' directive may not be %0, predetermined as %2"
-H777624FA6F75: "與'omp %1'指令相關的循環迭代變數不能是%0，其已被預先確定為%2"
+H777624FA6F75: "與'omp %1'指令相關的循環迭代變數不能是 %0，其已被預先確定為 %2"
 # 'loop step is expected to be %select{negative|positive}0 due to this condition'
 HF9B9B19EF744: '期望因這個條件，迴圈步長為%select{負數|正數}0'
 # 'loop to be fully unrolled must have a constant trip count'
@@ -23765,13 +23765,13 @@ HF58CAD452050: '要完全展開的循環必須具有常數次數'
 # 'loop variable %0 %diff{of type $ binds to a temporary constructed from type $|binds to a temporary constructed from a different type}1,2'
 H8E540E772339: '%0 迴圈變數 %diff{類型為$的變數與從類型$建立的臨時物件綁定|與不同類型的臨時物件綁定}1,2'
 # 'loop variable %0 binds to a temporary value produced by a range of type %1'
-HDD2F7E9780FE: '循環變數%0綁定到由類型%1的範圍產生的臨時值'
+HDD2F7E9780FE: '循環變數 %0 綁定到由類型 %1 的範圍產生的臨時值'
 # 'loop variable %0 creates a copy from type %1'
-H0EB738A6DA64: '循環變數%0從類型%1創建副本'
+H0EB738A6DA64: '循環變數 %0 從類型 %1 創建副本'
 # "loop variable %0 may not be declared %select{'extern'|'static'|'__private_extern__'|'auto'|'register'|'constexpr'|'thread_local'}1"
-HD1C2B82FE9FA: "循環變數%0不能被聲明為%select{'extern'|'static'|'__private_extern__'|'auto'|'register'|'constexpr'|'thread_local'}1"
+HD1C2B82FE9FA: "循環變數 %0 不能被聲明為%select{'extern'|'static'|'__private_extern__'|'auto'|'register'|'constexpr'|'thread_local'}1"
 # "loop variable of loop associated with an OpenACC '%0' construct must be of integer, pointer, or random-access-iterator type (is %1)"
-HDE685F11E1FA: "與OpenACC '%0'結構相關的循環變數必須是整數、指標或隨機存取迭代器類型（目前為%1）"
+HDE685F11E1FA: "與OpenACC '%0'結構相關的循環變數必須是整數、指標或隨機存取迭代器類型（目前為 %1）"
 # 'loop will run at most once (loop increment never executed)'
 H41A7771F3080: '此循環最多執行一次（循環增量從未執行）'
 # "loop with a '%0' clause may not exist in the region of a '%1' clause%select{| on a '%3' construct}2"
@@ -23781,19 +23781,19 @@ H1DC7FFF629C0: '不使用執行階段調用進行轉置'
 # 'mac68k alignment pragma is not supported on this target'
 H13A22B895D9E: '此目標不支援mac68k對齊pragma'
 # 'macro %0 defined here'
-H224BD0DEAAD4: '在此處定義的宏%0'
+H224BD0DEAAD4: '在此處定義的宏 %0'
 # 'macro %0 has been marked as deprecated%select{|: %2}1'
-HB9E9BBB38434: '宏%0 已被標記為已棄用%select{|： %2}1'
+HB9E9BBB38434: '宏 %0 已被標記為已棄用%select{|： %2}1'
 # 'macro %0 has been marked as final and should not be %select{undefined|redefined}1'
-H416ADCAF4BDC: '宏%0 已被標記為最終且不得%select{未定義|重新定義}1'
+H416ADCAF4BDC: '宏 %0 已被標記為最終且不得%select{未定義|重新定義}1'
 # 'macro %0 has been marked as unsafe for use in headers%select{|: %2}1'
-H0BD2BA6647E5: '此宏%0 不應在標頭中使用%select{|： %2}1'
+H0BD2BA6647E5: '此宏 %0 不應在標頭中使用%select{|： %2}1'
 # "macro '%0' contains embedded newline; text after the newline is ignored"
 HCA29C3134207: "宏'%0' 包含嵌入式換行符；換行符後的文本將被忽略"
 # "macro '%0' was %select{defined|undef'd}1 in the AST file '%2' but %select{undef'd|defined}1 on the command line"
 HEF8B87D78B88: "AST 檔案'%2' 中的宏'%0' 被%select{定義|#undef'd}0，但命令列中%select{#undef'd|定義}0"
 # "macro expansion producing 'defined' has undefined behavior"
-H6CE80CBEAD13: "產生'defined'的宏展開具有未定義行為"
+H6CE80CBEAD13: "產生 'defined' 的宏展開具有未定義行為"
 # 'macro is not used'
 HB7A93ECCBE4F: '此宏未被使用'
 # "macro marked '%select{deprecated|restrict_expansion|final}0' here"
@@ -23807,7 +23807,7 @@ HA83E076252EC: '宏名稱必須是識別符'
 # "macro was %select{defined|#undef'd}0 here"
 H90411BE5521B: "此處宏%select{被定義|#undef'd}0"
 # 'magnitude of floating-point constant too large for type %0; maximum is %1'
-HC45BAE211EEF: '%0 類型的浮點常數數值過大；最大值為%1'
+HC45BAE211EEF: '%0 類型的浮點常數數值過大；最大值為 %1'
 # 'magnitude of floating-point constant too small for type %0; minimum is %1'
 H77948F2AADFE: '浮點常數的數值範圍小於類型 %0 的最小值；最小值為 %1'
 # 'main cannot be declared as a variable %select{in the global scope|with C language linkage}0'
@@ -23999,29 +23999,29 @@ H9C1FB20B5554: '方法 %0 用於前置類別宣告'
 # 'method %0 that returns %1 declared here'
 H81FA72B87C9D: '這裡宣告返回 %1 的方法 %0'
 # 'method definition for %0 not found'
-H2A6463515852: '找不到%0的方法定義'
+H2A6463515852: '找不到 %0 的方法定義'
 # 'method for accessing %select{dictionary|array}1 element must have Objective-C object return type instead of %0'
-H2A6E5DD7828B: '存取%select{dictionary|array}1元素的方法必須回傳Objective-C物件類型，而不是%0'
+H2A6E5DD7828B: '存取 %select{dictionary|array}1 元素的方法必須回傳Objective-C物件類型，而不是 %0'
 # "method has no return type specified; defaults to 'id'"
-HD11D99B1C083: "方法未指定回傳類型；預設為'id'"
+HD11D99B1C083: "方法未指定回傳類型；預設為 'id'"
 # 'method implementation does not match its declaration'
 H2D5D386F5AFB: '方法實作與宣告不相符'
 # 'method index parameter type %0 is not integral type'
-H630B60C086B7: '方法索引參數類型%0不是整數型別'
+H630B60C086B7: '方法索引參數類型 %0 不是整數型別'
 # 'method is expected to return an instance of its class type %diff{$, but is declared to return $|, but is declared to return different type}0,1'
 H4EBF90DD6088: '%diff{此方法應返回類型$，但宣告為返回$|，但宣告為返回不同類型}0,1'
 # 'method key parameter type %0 is not object type'
-H93D8788321DF: '方法鍵參數類型%0不是物件類型'
+H93D8788321DF: '方法鍵參數類型 %0 不是物件類型'
 # 'method marked as designated initializer of the class here'
 H6D873EC57BBB: '此方法被標記為類別的指定初始值設定項'
 # "method name referenced in property setter attribute must end with ':'"
 H48FC25BCA089: "屬性設定方法屬性中引用的方法名稱必須以':'結尾"
 # 'method object parameter type %0 is not object type'
-H7C5EC09F4D4E: '方法物件參數類型%0不是物件類型'
+H7C5EC09F4D4E: '方法物件參數類型 %0 不是物件類型'
 # 'method override for the designated initializer of the superclass %objcinstance0 not found'
 H353D09FC8C8A: '未找到超類%objcinstance0指定初始值設定項的方法覆寫'
 # 'method parameter of type %0 with no explicit ownership'
-H012CAADA6E5A: '類型%0的方法參數未明確指定所有權'
+H012CAADA6E5A: '類型 %0 的方法參數未明確指定所有權'
 # 'method parameter type %diff{$ does not match super class method parameter type $|does not match super class method parameter type}0,1'
 H52F29D4B5323: '%diff{方法參數類型$與超類方法參數類型$不相符|與超類方法參數類型不相符}0,1'
 # 'method possibly missing a [super %0] call'
@@ -24039,7 +24039,7 @@ H17AAF1CF7567: "目標CPU '%0'不支援micromips"
 # 'minimal size of the basic block that should be aligned'
 H9310AFA3C7C1: '應對齊的基本區塊的最小大小'
 # 'minimum address considered valid for heatmap (default 0)'
-HB0C898B37318: '熱圖中視為有效的最小地址（預設值為0）'
+HB0C898B37318: '熱圖中視為有效的最小地址（預設值為 0）'
 # 'minimum condition bias (pct) to perform a CMOV conversion, -1 to not account bias'
 HF9B056CCAAE3: '執行CMOV轉換的最小條件偏移率（%），-1表示忽略偏移'
 # 'minimum function durations'
@@ -24051,7 +24051,7 @@ H24AF23851D8A: '分析群集中的最小資料點數（僅限DBSCAN）'
 # 'minimum offset needed between block and successor to allow duplication'
 H75F42A78BFD9: '允許複製前後區塊與後繼區塊所需的最小偏移量'
 # 'minimum vscale must be an unsigned integer greater than 0'
-H97D216C9F9DC: '最小vscale必須是大於0的無符號整數'
+H97D216C9F9DC: '最小vscale必須是大於 0 的無符號整數'
 # 'minus(-) operator for reductions is deprecated; use + or user defined reduction instead'
 HB503599C3686: '約簡運算中使用減法（-）運算子已被棄用；建議改用+或使用者定義的約簡'
 # 'misaligned atomic operation may incur significant performance penalty; the expected alignment (%0 bytes) exceeds the actual alignment (%1 bytes)'
@@ -24063,13 +24063,13 @@ HFB1C45E0F3D8: "目標三元組'%0'中的架構與環境不符；是否應指定
 # 'mismatch in number of block parameters and local size arguments passed'
 H297CC009BE30: '區塊參數數量與傳遞的本地大小引數數量不匹配'
 # 'misplaced %0; expected %0 here'
-H6EEF8ABBCBBD: '此處出現不正確的%0；應在此處使用%0'
+H6EEF8ABBCBBD: '此處出現不正確的 %0；應在此處使用 %0'
 # 'misplaced attributes; expected attributes here'
 H71DF23AD8094: '屬性放置位置錯誤；應在此處指定屬性'
 # 'misprediction threshold for skipping ICP on an indirect call'
 H2799B1202BB8: '跳過間接呼叫ICP的預測錯誤閾值'
 # 'missing %1 after %0'
-H71A0939C10D8: '缺少%0後面的%1'
+H71A0939C10D8: '缺少 %0 後面的 %1'
 # "missing '(' after '#pragma %0' - ignoring"
 H9BCF4D2D832C: "在 '#pragma %0' 後缺少 '(' - 忽略"
 # "missing '(' following __VA_OPT__"
@@ -24409,7 +24409,7 @@ H69290D9B2469: '命名空間別名不能是內聯的'
 # 'namespace alias must be a single identifier'
 HA11E2A62D886: '命名空間別名必須是單一識別符'
 # "namespace can only apply to 'push' or 'pop' directives"
-H6F30E709453F: "命名空間只能套用在'push'或'pop'指令上"
+H6F30E709453F: "命名空間只能套用在 'push' 或 'pop' 指令上"
 # 'namespaces can only be defined in global or namespace scope'
 HDB4E6C24AE7F: '命名空間只能在全域或命名空間範疇中定義'
 # "negated attribute subject matcher sub-rule '%0' contradicts sub-rule '%1'"
@@ -24425,15 +24425,15 @@ H326DE285E8C5: '宣告的巢狀命名空間指定項 %0 不指向類別、類別
 # 'nested name specifier for a declaration cannot depend on a template parameter'
 H87A0C3C18BC3: '宣告的巢狀命名空間指定項不能依賴範型參數'
 # "nested namespace definition cannot be 'inline'"
-HB262A63F161A: "巢狀命名空間定義不能標示為'inline'"
+HB262A63F161A: "巢狀命名空間定義不能標示為 'inline'"
 # 'nested namespace definition is a C++17 extension; define each namespace separately'
 HEFB4B9AD8E01: '巢狀命名空間定義是C++17擴展；請分開定義每個命名空間'
 # 'nested namespace definition is incompatible with C++ standards before C++17'
 H0E35039F1D67: '巢狀命名空間定義與C++17之前的標準不相容'
 # 'nested parentheses not permitted in %0'
-H34953581058C: '在%0中不允許嵌套括號'
+H34953581058C: '在 %0 中不允許嵌套括號'
 # 'nested redefinition of %0'
-H0AC10F45C385: '%0的巢狀重新定義'
+H0AC10F45C385: '%0 的巢狀重新定義'
 # 'nested teams construct here'
 HF6BEE2475F61: '這裡的巢狀團隊構造'
 # 'nested user conditions in OpenMP context selector not supported (yet)'
@@ -24495,7 +24495,7 @@ H60C61DB5DCD2: "未找到期望的指示：考慮使用 '%0-no-diagnostics'"
 # 'no function template matches function template specialization %0'
 H783C344DF4FC: '沒有函數模板與函數模板特化 %0 匹配'
 # 'no getter method %1 for %select{increment|decrement}0 of property'
-H27A03BEFDE9D: '屬性的%select{遞增|遞減}0操作沒有getter方法%1'
+H27A03BEFDE9D: '屬性的%select{遞增|遞減}0操作沒有getter方法 %1'
 # 'no getter method for read from property'
 HC653B7766A2E: '讀取屬性時沒有getter方法'
 # "no handler registered for module format '%0'"
@@ -24509,11 +24509,11 @@ H41C44394DC27: '選擇器 %0 沒有已知的%select{實例|類別}1方法'
 # "no known method %select{%objcinstance1|%objcclass1}0; cast the message send to the method's return type"
 HD141497E30B9: '未找到已知方法 %select{%objcinstance1|%objcclass1}0；將訊息傳遞轉換為方法的返回類型'
 # "no library '%0' found in the default clang lib directory or in LIBRARY_PATH; use '--libomptarget-%1-bc-path' to specify %1 bitcode library"
-H56082C491F7D: '在預設的clang庫目錄或LIBRARY_PATH中未找到庫 "%0"；使用 "--libomptarget-%1-bc-path" 指定%1位元碼庫'
+H56082C491F7D: '在預設的clang庫目錄或LIBRARY_PATH中未找到庫 "%0"；使用 "--libomptarget-%1-bc-path" 指定 %1 位元碼庫'
 # 'no macro named %0'
-HDBF2015FF73B: '沒有名為%0的宏'
+HDBF2015FF73B: '沒有名為 %0 的宏'
 # 'no matching %0 function for non-allocating placement new expression; include <new>'
-H7020E0B0AF12: '對非分配placement new運算式沒有匹配的%0函數；包含<new>'
+H7020E0B0AF12: '對非分配placement new運算式沒有匹配的 %0 函數；包含 <new>'
 # "no matching '#pragma clang module begin' for this '#pragma clang module end'"
 HCC39D351076F: "未找到對應的 '#pragma clang module begin' 來對應此 '#pragma clang module end'"
 # "no matching '#pragma clang module end' for this '#pragma clang module begin'"
@@ -24597,35 +24597,35 @@ H7E37FF613F8F: "找不到包含目錄：'%0'"
 # "no such sysroot directory: '%0'"
 H7EBC246FEEA8: "找不到 sysroot 目錄：'%0'"
 # 'no suitable member %0 in %1'
-H3750344F18EF: '在%1中未找到適合的成員%0'
+H3750344F18EF: '在 %1 中未找到適合的成員 %0'
 # "no suitable precompiled header file found in directory '%0'"
 HC9D05A0684EB: "在目錄 '%0' 中未找到預編譯標頭檔案"
 # 'no target microcontroller specified, please pass -mmcu=<mcu name>'
 H861E68DCEBF9: '未指定目標微控制器，請傳遞 -mmcu=<mcu name>'
 # 'no template named %0'
-HFC0C70B06D89: '找不到名為%0的範本'
+HFC0C70B06D89: '找不到名為 %0 的範本'
 # 'no template named %0 in %1'
-H16DB7E6BC24D: '在%1中未找到名為%0的範本'
+H16DB7E6BC24D: '在 %1 中未找到名為 %0 的範本'
 # 'no template named %0 in %1; did you mean %select{|simply }2%3?'
-HCDFE5581F7D6: '在%1中未找到名為%0的範本; 是否%select{|僅}2指%3?'
+HCDFE5581F7D6: '在 %1 中未找到名為 %0 的範本; 是否%select{|僅}2指 %3?'
 # 'no template named %0; did you mean %1?'
-H32AFF6E21FDC: '未找到名為%0的範本; 是否指%1?'
+H32AFF6E21FDC: '未找到名為 %0 的範本; 是否指 %1?'
 # 'no type named %0 in %1'
-H6E87E8CAFF42: '在%1中未找到名為%0的類型'
+H6E87E8CAFF42: '在 %1 中未找到名為 %0 的類型'
 # 'no type named %0 in %1; did you mean %select{|simply }2%3?'
-H014C7B262D03: '在%1中未找到名為%0的類型; 是否%select{|僅}2指%3?'
+H014C7B262D03: '在 %1 中未找到名為 %0 的類型; 是否%select{|僅}2指 %3?'
 # "no type named 'type' in %0; 'enable_if' cannot be used to disable this declaration"
-H03B3775679FC: "在%0中未找到名為'type'的類型; 'enable_if'無法用來禁用此宣告"
+H03B3775679FC: "在 %0 中未找到名為 'type' 的類型; 'enable_if' 無法用來禁用此宣告"
 # 'no type or protocol named %0'
-HFF0D89AB2752: '未找到名為%0的類型或協定'
+HFF0D89AB2752: '未找到名為 %0 的類型或協定'
 # "no valid clauses specified in OpenACC 'declare' directive"
 H136795D57206: "OpenACC 'declare' 指令中未指定有效的子句"
 # 'no variable template matches specialization; did you mean to use %0 as function template instead?'
-H702E78FBEC31: '未找到匹配的變數範本專門化; 是否應改用%0作為函數範本?'
+H702E78FBEC31: '未找到匹配的變數範本專門化; 是否應改用 %0 作為函數範本?'
 # 'no variable template matches%select{| partial}0 specialization'
 H0903C7695A91: '未找到匹配的%select{|部分}0專門化變數範本'
 # 'no viable candidate for explicit instantiation of %0'
-HAEBC7520AFB0: '無法明確實體化%0的可行候選'
+HAEBC7520AFB0: '無法明確實體化 %0 的可行候選'
 # 'no viable constructor %select{copying variable|copying parameter|initializing template parameter|returning object|initializing statement expression result|throwing object|copying member subobject|copying array element|allocating object|copying temporary|initializing base subobject|initializing vector element|capturing value}0 of type %1'
 HC9B75808C9E9: '無法找到合適的建構函數 %select{複製變數|複製參數|初始化模板參數|返回物件|初始化語句運算式結果|發送物件|複製成員子物件|複製陣列元素|建立物件|複製暫時物件|初始化基底子物件|初始化向量元素|捕捉值}0 的類型 %1'
 # 'no viable constructor %select{copying variable|copying parameter|initializing template parameter|returning object|initializing statement expression result|throwing object|copying member subobject|copying array element|allocating object|copying temporary|initializing base subobject|initializing vector element|capturing value}0 of type %1; C++98 requires a copy constructor when binding a reference to a temporary'
@@ -24743,23 +24743,23 @@ HE77C0A012513: '非常式模板參數值未引用任何物件或函數'
 # 'non-type template argument does not refer to any declaration'
 HB25807F91411: '非常式模板參數值未引用任何宣告'
 # 'non-type template argument for template parameter of pointer type %0 must have its address taken'
-H8D4CDD97C49D: '指標類型%0的模板參數的非常式模板參數值必須取得其位址'
+H8D4CDD97C49D: '指標類型 %0 的模板參數的非常式模板參數值必須取得其位址'
 # 'non-type template argument is not a pointer to member constant'
 HDC21F0C558EB: '非常式模板參數值不是成員常數指標'
 # 'non-type template argument of reference type %0 is not an object'
-H50574CDA0DAD: '類型%0的參考類型非常式模板參數值不是物件'
+H50574CDA0DAD: '類型 %0 的參考類型非常式模板參數值不是物件'
 # 'non-type template argument of type %0 cannot be converted to a value of type %1'
-HDF1742D8033F: '類型%0的非常式模板參數值無法轉換為類型%1的值'
+HDF1742D8033F: '類型 %0 的非常式模板參數值無法轉換為類型 %1 的值'
 # 'non-type template argument of type %0 is not a constant expression'
-H075FB8D7A63A: '類型%0的非常式模板參數值不是常量運算式'
+H075FB8D7A63A: '類型 %0 的非常式模板參數值不是常量運算式'
 # 'non-type template argument of type %0 is not an integral constant expression'
-HE2EA0C6B3858: '類型%0的非常式模板參數值不是整數型別常量運算式'
+HE2EA0C6B3858: '類型 %0 的非常式模板參數值不是整數型別常量運算式'
 # 'non-type template argument of type %0 must have an integral or enumeration type'
-H06D35F5E0195: '非常式模板參數值的類型%0必須是整數或枚舉型別'
+H06D35F5E0195: '非常式模板參數值的類型 %0 必須是整數或枚舉型別'
 # 'non-type template argument referring to %select{function|object}0 %1 with internal linkage is a C++11 extension'
-HEFF3308ED7FE: '引用具有內部連結性%select{函數|物件}0 %1的非常式模板參數值是C++11擴充功能'
+HEFF3308ED7FE: '引用具有內部連結性%select{函數|物件}0 %1 的非常式模板參數值是C++11擴充功能'
 # 'non-type template argument referring to %select{function|object}0 %1 with internal linkage is incompatible with C++98'
-H2F0100862103: '引用具有內部連結性%select{函數|物件}0 %1的非常式模板參數值與C++98不相容'
+H2F0100862103: '引用具有內部連結性%select{函數|物件}0 %1 的非常式模板參數值與C++98不相容'
 # 'non-type template argument refers here'
 HA953EF53E7DD: '非常式模板參數值指向這裡'
 # 'non-type template argument refers to %select{function|object}0 %1 that does not have linkage'
@@ -24767,9 +24767,9 @@ H600BCDFEE43D: '非常式模板參數值引用這裡的%select{函數|物件}0 %
 # 'non-type template argument refers to %select{function|object}0 here'
 H9ED37B3451CC: '非常式模板參數值指向這裡的%select{函數|物件}0'
 # 'non-type template argument refers to non-static data member %0'
-H2465AB2AA5B5: '非常式模板參數值指向非靜態資料成員%0'
+H2465AB2AA5B5: '非常式模板參數值指向非靜態資料成員 %0'
 # 'non-type template argument refers to non-static member function %0'
-H6A037F433017: '非常式模板參數值指向非靜態成員函數%0'
+H6A037F433017: '非常式模板參數值指向非靜態成員函數 %0'
 # "non-type template argument refers to subobject '%0'"
 HD30CEA1C7504: "非常式模板參數值指向子物件'%0'"
 # 'non-type template argument refers to thread-local object'
@@ -24813,11 +24813,11 @@ HCF55E17BA989: '非 void %select{constexpr|consteval}1 函數 %0 應該回傳值
 # 'non-void %select{function|block|lambda|coroutine}0 does not return a value%select{| in all control paths}1'
 H75EE618D1AA4: '非void的%select{函數|區塊|lambda|coroutine}0未回傳值%select{|在所有控制路徑中}1'
 # 'non-void %select{function|method}1 %0 should return a value'
-HEE95067001EB: '非void的%select{函數|方法}1 %0應回傳值'
+HEE95067001EB: '非void的%select{函數|方法}1 %0 應回傳值'
 # 'non-void block should return a value'
 H66594B013217: '非void的區塊應回傳值'
 # "nonnull %select{function call|parameter}0 '%1' will evaluate to 'true' on first encounter"
-H925BCFBBE426: "非空%select{函數呼叫|參數}0 '%1'在首次遇到時將評估為'true'"
+H925BCFBBE426: "非空%select{函數呼叫|參數}0 '%1'在首次遇到時將評估為 'true'"
 # 'not a Doxygen trailing comment'
 HB02E938B9DEC: '不是Doxygen的尾注註解'
 # "not currently inside '#pragma clang arc_cf_code_audited'"
@@ -24827,33 +24827,33 @@ HF77D5E6601B3: "目前不在'#pragma clang assume_nonnull'指令內"
 # "not currently inside '#pragma unsafe_buffer_usage'"
 H658512A345D7: "目前不在'#pragma unsafe_buffer_usage'指令內"
 # 'not enough variable arguments in %0 declaration to fit a sentinel'
-H9930B56495BC: '在%0宣告中可變參數不足以適配哨兵'
+H9930B56495BC: '在 %0 宣告中可變參數不足以適配哨兵'
 # 'not packing field %0 as it is non-POD for the purposes of layout'
-H7FBA81FDAA18: '不打包欄位%0，因為其在布局用途上為非POD類型'
+H7FBA81FDAA18: '不打包欄位 %0，因為其在布局用途上為非POD類型'
 # 'not-yet-instantiated member is declared here'
 HACFD1F41F676: '尚未實例化的成員在此宣告'
 # 'null character ignored'
 H6B4B3A47C8AC: '空值字元被忽略'
 # 'null character(s) preserved in %select{char|string}0 literal'
-H062C86F6116B: '%select{char|string}0字面值中保留空值字元(s)'
+H062C86F6116B: '%select{char|string}0 字面值中保留空值字元(s)'
 # 'null non-type template argument must be cast to template parameter type %0'
-HDDA635486EF3: '空值的非類型模板參數必須轉換為模板參數類型%0'
+HDDA635486EF3: '空值的非類型模板參數必須轉換為模板參數類型 %0'
 # 'null non-type template argument of type %0 does not match template parameter of type %1'
-HCF293B48A07C: '類型%0的空值非類型模板參數與類型%1的模板參數不相符'
+HCF293B48A07C: '類型 %0 的空值非類型模板參數與類型 %1 的模板參數不相符'
 # 'null passed to a callee that requires a non-null argument'
 H5F7D096FCE08: '將空值傳遞給需要非空參數的呼叫目標'
 # 'null returned from %select{function|method}0 that requires a non-null return value'
 HEA9F26CD4560: '從需要非空回傳值的%select{函數|方法}0回傳空值'
 # 'nullability keyword %0 cannot be applied to multi-level pointer type %1'
-H9F63F0EFF7CC: 'nullability關鍵字%0無法應用於多層指標類型%1'
+H9F63F0EFF7CC: 'nullability關鍵字 %0 無法應用於多層指標類型 %1'
 # 'nullability specifier %0 cannot be applied to non-pointer type %1'
-HA1F5D87BE3DF: 'nullability指定詞%0無法應用於非指標類型%1'
+HA1F5D87BE3DF: 'nullability指定詞 %0 無法應用於非指標類型 %1'
 # 'nullability specifier %0 cannot be applied to non-pointer type %1; did you mean to apply the specifier to the %select{pointer|block pointer|member pointer|function pointer|member function pointer}2?'
 H3E269F064E84: '空值規範符 %0 不能應用於非指標類型 %1；您是否想要將規範符應用於 %select{指標|區塊指標|成員指標|函數指標|成員函數指標}2？'
 # 'nullability specifier %0 conflicts with existing specifier %1'
 H4421DC48369F: '空值規範符 %0 與現有規範符 %1 冲突'
 # 'number of elements must be either one or match the size of the vector'
-H2A474F4275FA: '元素數目必須為1或與向量大小一致'
+H2A474F4275FA: '元素數目必須為 1 或與向量大小一致'
 # 'number of entries per line (default 256)'
 H7D63977C73C8: '每行的條目數（預設值 256）'
 # 'number of functions to display when printing the top largest differences in function activity'
@@ -24929,11 +24929,11 @@ H33451023019A: '若要將屬性新增至最近新增的屬性群組，請省略�
 # 'omitting the parameter name in a function definition is a C23 extension'
 H239CD59B1E97: '在函數定義中省略參數名稱是C23擴充功能'
 # 'on M-profile architectures %0 attribute is not supported on targets missing %1; specify an appropriate -march= or -mcpu='
-HF63DAE65A9BA: '在M型態架構上，若目標缺少%1，則%0屬性不受支援；請指定適當的 -march= 或 -mcpu='
+HF63DAE65A9BA: '在M型態架構上，若目標缺少 %1，則 %0 屬性不受支援；請指定適當的 -march= 或 -mcpu='
 # 'one cluster per opcode'
 H571A5AC320D2: '每條機器碼指令對應一個群組'
 # "one of 'for', 'parallel', 'sections' or 'taskgroup' is expected"
-HA318D6E65846: "必須是'for'、'parallel'、'sections'或'taskgroup'其中之一"
+HA318D6E65846: "必須是 'for'、'parallel'、'sections' 或 'taskgroup' 其中之一"
 # 'one possibility'
 HF5AE3D1F7A2D: '一個可能選項'
 # "only %select{'omp_priv' or 'omp_orig'|'omp_in' or 'omp_out'}0 variables are allowed in %select{initializer|combiner}0 expression"
@@ -25065,7 +25065,7 @@ H583C3C9DA6E7: "選項 '%0' 需要與 '%1' 一同指定"
 # "option '%0' requires input to be LLVM bitcode"
 HA5B4E61775E4: "選項 '%0' 需要輸入為LLVM位元碼"
 # "option '%0' was ignored by the %1 toolchain, using '-fPIC'"
-H22B2E1051C0B: "選項 '%0' 被%1工具鏈忽略，改用'-fPIC'"
+H22B2E1051C0B: "選項 '%0' 被 %1 工具鏈忽略，改用'-fPIC'"
 # "option '-MG' requires '-M' or '-MM'"
 HCCC4BA63CA80: "選項 '-MG' 需要搭配 '-M' 或 '-MM'"
 # "option '-ffine-grained-bitfield-accesses' cannot be enabled together with a sanitizer; flag ignored"
@@ -25243,11 +25243,11 @@ H1B5890218438: '填充 %select{結構|介面|類別}0 %1 以 %2 %select{位元�
 # 'padding size of %0 with %1 %select{byte|bit}2%s1 to alignment boundary'
 H5BCCA44B6E5B: '將 %0 的大小以 %1 %select{位元組|位元}2%s1 填充至對齊邊界'
 # 'parameter %0 must have a complete type to use function %1 with the %2 calling convention'
-H35B9EA765265: '參數%0必須具有完整類型，才能在%2調用規約下使用函數%1'
+H35B9EA765265: '參數 %0 必須具有完整類型，才能在 %2 調用規約下使用函數 %1'
 # 'parameter %0 set but not used'
-HB6BB1AF1B37E: '參數%0已設定但未使用'
+HB6BB1AF1B37E: '參數 %0 已設定但未使用'
 # "parameter %0 was not declared, defaults to 'int'; ISO C99 and later do not support implicit int"
-H41790618129F: "參數%0未宣告，預設為'int'；ISO C99及之後版本不支援隱含int類型"
+H41790618129F: "參數 %0 未宣告，預設為 'int'；ISO C99及之後版本不支援隱含int類型"
 # "parameter '%0' is already documented"
 HF9B7DF355428: "參數'%0'已被文檔化"
 # "parameter '%0' not found in the function declaration"
@@ -25265,15 +25265,15 @@ HFB13BD25F7E6: '參數不能使用地址空間修飾'
 # 'parameter name cannot have template arguments'
 H4AE4E444760E: '參數名稱不能包含範型參數'
 # 'parameter named %0 is missing'
-HE41EE5512047: '名為%0的參數缺失'
+HE41EE5512047: '名為 %0 的參數缺失'
 # "parameter of %0 attribute must be 'id' when used on a typedef"
-H95DFECC378EF: "%0屬性在用於typedef時必須為'id'"
+H95DFECC378EF: "%0 屬性在用於typedef時必須為 'id'"
 # 'parameter of %0 attribute must be a single name of an Objective-C %select{class|protocol}1'
-H6E3911EE67CF: '%0屬性必須是Objective-C %select{類|協定}1的單一名稱'
+H6E3911EE67CF: '%0 屬性必須是Objective-C %select{類|協定}1的單一名稱'
 # 'parameter of %0 cannot have a default argument'
-H9997206462BD: '%0的參數不能有預設參數值'
+H9997206462BD: '%0 的參數不能有預設參數值'
 # "parameter of literal operator must have type 'unsigned long long', 'long double', 'char', 'wchar_t', 'char16_t', 'char32_t', or 'const char *'"
-H18EF0BD0BEB6: "字面運算子的參數必須具有類型'unsigned long long'、'long double'、'char'、'wchar_t'、'char16_t'、'char32_t'或'const char *'"
+H18EF0BD0BEB6: "字面運算子的參數必須具有類型'unsigned long long'、'long double'、'char'、'wchar_t'、'char16_t'、'char32_t' 或'const char *'"
 # 'parameter of overloaded %0 cannot have a default argument'
 H31033CF29CE2: '重載的 %0 參數不能有預設參數值'
 # "parameter of overloaded post-%select{increment|decrement}1 operator must have type 'int' (not %0)"
@@ -25303,7 +25303,7 @@ H2F8AAD55F0CC: "'omp %select{取消點|取消}0' 建構式的父區域不能為 
 # "parent umbrella does not match: '%0' (provided) vs '%1' (found)"
 H38C90C7CC02F: "父層傘目錄不匹配：'%0'（提供）與'%1'（找到）"
 # "parent umbrella missing from %0: '%1'"
-HCD77F7184E7F: "父層傘目錄%0中缺少'%1'"
+HCD77F7184E7F: "父層傘目錄 %0 中缺少'%1'"
 # 'parentheses are required around macro argument containing braced initializer list'
 H41A73FF55953: '包含花括號初始化清單的宏參數必須加上括號'
 # 'parentheses are required around this expression in a requires clause'
@@ -25313,11 +25313,11 @@ H55DF42498A9B: '地址非類型模板參數周圍的括號是C++11擴展'
 # 'parentheses around address non-type template argument are incompatible with C++98'
 H8ACABCA7F85D: '地址非類型模板參數周圍的括號與C++98不相容'
 # "parentheses must be omitted if %0 attribute's argument list is empty"
-H90F4FD29334C: '如果%0屬性的參數清單為空，必須省略括號'
+H90F4FD29334C: '如果 %0 屬性的參數清單為空，必須省略括號'
 # 'parentheses were disambiguated as a function declaration'
 H329AE7B68E6C: '括號被解析為函數宣告的消歧'
 # 'parentheses were disambiguated as redundant parentheses around declaration of variable named %0'
-H911B6F6318F6: '括號被解析為%0變數宣告周圍的冗餘括號'
+H911B6F6318F6: '括號被解析為 %0 變數宣告周圍的冗餘括號'
 # 'parenthesize the second argument to silence'
 HB3431A17CC77: '對第二個參數加上括號以消除警告'
 # 'parenthesized initialization of a member array is a GNU extension'
@@ -25325,37 +25325,37 @@ HD07F8AE496CA: '成員陣列的括號初始化是GNU擴展'
 # 'parse the input, create a PFT, dump it, and exit'
 H8632144C8313: '分析輸入、建立PFT、傾印並退出'
 # 'partial ordering for explicit instantiation of %0 is ambiguous'
-HE38D1382AB5B: '%0的明確實體化部分排序存在歧義'
+HE38D1382AB5B: '%0 的明確實體化部分排序存在歧義'
 # 'partial specialization cannot be declared as a friend'
 HA147DDFF5AB9: '無法將部分特化宣告為友元'
 # 'partial specialization matches %0'
-HA30AC1C7D740: '部分特化與%0匹配'
+HA30AC1C7D740: '部分特化與 %0 匹配'
 # 'partial specialization of %0 does not use any of its template parameters'
-H84CBC790F3FB: '%0的部分特化未使用其任何模板參數'
+H84CBC790F3FB: '%0 的部分特化未使用其任何模板參數'
 # 'pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions'
 HB623B7D5D4C9: '傳遞-fsafe-buffer-usage-suggestions以取得程式碼強化建議'
 # 'passing %0-byte aligned argument to %1-byte aligned parameter %2%select{| of %4}3 may result in an unaligned pointer access'
-H8E7373BFAB19: '傳遞%0位元組對齊的引數至%1位元組對齊的參數%2%select{| of %4}3可能导致未對齊的指標存取'
+H8E7373BFAB19: '傳遞 %0 位元組對齊的引數至 %1 位元組對齊的參數 %2%select{| of %4}3可能导致未對齊的指標存取'
 # 'passing %select{address of|reference to}0 local temporary object to musttail function'
 H185CAE78405D: '將本地臨時物件%select{的位址|的參考}0傳遞給musttail函數'
 # "passing %select{an object that undergoes default argument promotion|an object of reference type|a parameter declared with the 'register' keyword}0 to 'va_start' has undefined behavior"
-H71043E0BAFE6: "將%select{經預設參數提升的物件|引用類型的物件|以'register'關鍵字宣告的參數}0傳遞給'va_start'具有未定義行為"
+H71043E0BAFE6: "將%select{經預設參數提升的物件|引用類型的物件|以 'register' 關鍵字宣告的參數}0傳遞給 'va_start' 具有未定義行為"
 # "passing '%0' format string where '%1' format string is expected"
 HB0DCC631BCB0: "傳遞'%0'格式字串，而這裡期望的是'%1'格式字串"
 # "passing a type argument as the first operand to '_Generic' is a C2y extension"
-H9B0C1A1B2AAD: "將類型參數作為'_Generic'的第一個操作數傳遞是C2y的擴充功能"
+H9B0C1A1B2AAD: "將類型參數作為 '_Generic' 的第一個操作數傳遞是C2y的擴充功能"
 # "passing a type argument as the first operand to '_Generic' is incompatible with C standards before C2y"
-H0B03D58A8538: "將類型參數作為'_Generic'的第一個操作數傳遞與C2y之前的所有C標準不相容"
+H0B03D58A8538: "將類型參數作為 '_Generic' 的第一個操作數傳遞與C2y之前的所有C標準不相容"
 # 'passing address of %select{non-local|non-scalar}0 object to __autoreleasing parameter for write-back'
 H8F97A19F11B3: '將%select{非局部|非純量}0物件的位址傳遞給__autoreleasing參數以執行寫回操作'
 # 'passing argument to parameter %0 here'
-H30E4C5FD05FE: '這裡傳遞參數%0的參數值'
+H30E4C5FD05FE: '這裡傳遞參數 %0 的參數值'
 # 'passing argument to parameter here'
 HC7C3DD07B432: '這裡傳遞參數的參數值'
 # 'passing arguments to %select{a function|%1}0 without a prototype is deprecated in all versions of C and is not supported in C23'
 H192BBFFB4918: '將參數傳遞給%select{函數|%1}0而無原型在所有C版本中均已被棄用，且不支援C23'
 # 'passing byval argument %0 with potentially incompatible alignment here'
-H730F797EFCA9: '這裡傳遞具有潛在不相容對齊的byval參數%0'
+H730F797EFCA9: '這裡傳遞具有潛在不相容對齊的byval參數 %0'
 # "passing no argument for the '...' parameter of a variadic macro is a C++20 extension"
 H6D5DB0C5BBB6: "未為可變參數宏的'...'參數傳遞參數是C++20的擴充功能"
 # "passing no argument for the '...' parameter of a variadic macro is a C23 extension"
@@ -25365,23 +25365,23 @@ HCA1A72FB669A: "未為可變參數宏的'...'參數傳遞參數與C23之前的C�
 # "passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20"
 H2B8F35860B3B: "未為可變參數宏的'...'參數傳遞參數與C++20之前的C++標準不相容"
 # 'passing non-generic address space pointer to %0 may cause dynamic conversion affecting performance'
-HAEF068C749A4: '將非通用位址空間指標傳遞給%0可能導致動態轉換而影響效能'
+HAEF068C749A4: '將非通用位址空間指標傳遞給 %0 可能導致動態轉換而影響效能'
 # "passing object of class type %0 through variadic %select{function|block|method|constructor}1%select{|; did you mean to call '%3'?}2"
-H39C1EFFB876B: "將類型%0的物件透過可變參數%select{函數|區塊|方法|建構函數}1傳遞%select{|；您是否想呼叫'%3'？}2"
+H39C1EFFB876B: "將類型 %0 的物件透過可變參數%select{函數|區塊|方法|建構函數}1傳遞%select{|；您是否想呼叫'%3'？}2"
 # 'passing object of trivial but non-POD type %0 through variadic %select{function|block|method|constructor}1 is incompatible with C++98'
-HD5D2FE67C0FC: '將類型%0的物件（其為非POD但具有平凡特性的類型）透過可變參數%select{函數|區塊|方法|建構函數}1傳遞與C++98不相容'
+HD5D2FE67C0FC: '將類型 %0 的物件（其為非POD但具有平凡特性的類型）透過可變參數%select{函數|區塊|方法|建構函數}1傳遞與C++98不相容'
 # "passing only one argument to 'va_start' is incompatible with C standards before C23"
-H0DFF95F6ABB1: "僅傳遞一個參數給'va_start'與C23之前的C標準不相容"
+H0DFF95F6ABB1: "僅傳遞一個參數給 'va_start' 與C23之前的C標準不相容"
 # "passing pointer %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
-H9E268E19A549: "傳遞指標%1需要持有%0 %select{'%2'|'獨佔的%2'}3"
+H9E268E19A549: "傳遞指標 %1 需要持有 %0 %select{'%2'|'獨佔的 %2'}3"
 # "passing pointer to variable %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
-H0E1F82092409: "傳遞變數%1的指標需要持有%0 %select{'%2'|'獨佔的%2'}3"
+H0E1F82092409: "傳遞變數 %1 的指標需要持有 %0 %select{'%2'|'獨佔的 %2'}3"
 # "passing the value that %1 points to by reference requires holding %0 %select{'%2'|'%2' exclusively}3"
-HFB2B4F9A02B6: "以引用方式傳遞%1所指物件的值需要持有%0 %select{'%2'|'獨佔的%2'}3"
+HFB2B4F9A02B6: "以引用方式傳遞 %1 所指物件的值需要持有 %0 %select{'%2'|'獨佔的 %2'}3"
 # 'passing union across security boundary via %select{parameter %1|return value}0 may leak information'
-HA1E50C08E561: '透過%select{參數%1|傳回值}0傳遞聯組跨越安全性邊界可能會洩漏資訊'
+HA1E50C08E561: '透過%select{參數 %1|傳回值}0傳遞聯組跨越安全性邊界可能會洩漏資訊'
 # "passing variable %1 by reference requires holding %0 %select{'%2'|'%2' exclusively}3"
-HB011E968C37B: "以引用方式傳遞變量%1需要持有%0 %select{'%2'|'排他性持有的%2'}3"
+HB011E968C37B: "以引用方式傳遞變量 %1 需要持有 %0 %select{'%2'|'排他性持有的 %2'}3"
 # "pasting formed '%0', an invalid preprocessing token"
 H17B929BA26C6: "拼接形成'%0'，這是無效的預處理符號"
 # "pasting two '/' tokens into a '//' comment is a Microsoft extension"
@@ -25429,7 +25429,7 @@ HB725A707608F: '使用空指標進行指標減法%select{具有|可能具有}0 �
 # 'performs disassembly sequentially'
 HDD6DFBE032D2: '依序執行反組譯'
 # 'permutation index must be at least 1 and at most %0'
-H0297CCE3F38F: '排列索引必須至少為1且至多為%0'
+H0297CCE3F38F: '排列索引必須至少為 1 且至多為 %0'
 # 'pick register allocator based on -O option'
 H46CB03DD1B68: '根據 -O 選項選擇寄存器配置器'
 # 'pipes packet types cannot be of reference type'
@@ -25437,13 +25437,13 @@ H354A6AC50D78: '管道封包類型不能是引用類型'
 # "place '...' %select{immediately before declared identifier|here}0 to declare a function parameter pack"
 HD82CBB258C12: "在%select{宣告的識別符之前立即|這裡}0 放置 '...' 以宣告函數參數包"
 # 'place all array allocations more than <size> elements on the heap'
-H7583F9BA4C9F: '將所有元素數量超過<size>的陣列分配放在堆上'
+H7583F9BA4C9F: '將所有元素數量超過 <size> 的陣列分配放在堆上'
 # 'place all array allocations of dynamic size on the heap'
 H1E67C0E84EC2: '將所有動態大小的陣列分配放在堆上'
 # 'place parentheses around comparison expression to evaluate it first'
 H1021BF49A48F: '在比較運算式外放置括號以優先評估它'
 # 'place parentheses around the %0 expression to evaluate it first'
-HD79F2195D659: '在%0 運算式外放置括號以優先評估它'
+HD79F2195D659: '在 %0 運算式外放置括號以優先評估它'
 # "place parentheses around the '%0' expression to silence this warning"
 H7195F835EC30: "在 '%0' 運算式外放置括號以消除此警告"
 # "place parentheses around the '?:' expression to evaluate it first"
@@ -25501,7 +25501,7 @@ H338B60F2873D: '以指定模式毒化未初始化的堆疊變數'
 # 'poisoning existing macro'
 HDD8F2D4A6FAB: '毒化現有宏'
 # 'position arguments in format strings start counting at 1 (not 0)'
-HC64922328C30: '格式字串中的位置參數從1開始編號（而非0）'
+HC64922328C30: '格式字串中的位置參數從 1 開始編號（而非 0）'
 # "position-independent code requires '-mabicalls'"
 H69FA922C5B49: "位置獨立代碼需要 '-mabicalls'"
 # 'positional arguments are not supported by ISO C'
@@ -25757,7 +25757,7 @@ HC31930E74334: '在未達可程式碼消除後列印函數'
 # 'print functions after veneer elimination pass'
 HD9F864AE57D7: '在veneer消除pass後列印函數'
 # 'print functions of binary 2 that were not matched to any function in binary 1'
-H74494F9D492B: '列印二進位2中未與二進位1的任何函數匹配的函數'
+H74494F9D492B: '列印二進位 2 中未與二進位 1 的任何函數匹配的函數'
 # 'print functions sorted by execution count'
 HB0992E5F3DD7: '按執行次數排序後列印函數'
 # 'print functions sorted by order of dyno stats'
@@ -25767,7 +25767,7 @@ H58EE9BACA77C: '按總分支次數排序後列印函數'
 # 'print functions that could not be overwritten due to excessive size'
 H64A4A3141F70: '列印因大小過大而無法覆寫的函數'
 # 'print functions that have profile in binary 1 but do not in binary 2'
-H8FB878E6408D: '列印在二進位1中有剖析但二進位2中沒有對應的函數'
+H8FB878E6408D: '列印在二進位 1 中有剖析但二進位 2 中沒有對應的函數'
 # 'print global symbols after disassembly'
 H6F71EE919FF4: '在反組譯後列印全域符號'
 # 'print jump tables'
@@ -25855,55 +25855,55 @@ H828E266CB5B1: '傳遞給 __builtin_expect_with_probability 的機率參數必�
 # 'process functions with stack pointer arithmetic'
 H56D80573022C: '處理使用堆疊指標運算的函數'
 # 'profile data may be incomplete: of %0 function%s0, %1 %plural{1:has|:have}1 no data'
-H8ACA9571B75F: '剖析資料可能不完整：在%0個函數中，%1 %plural{1:有|:有}1個函數沒有資料'
+H8ACA9571B75F: '剖析資料可能不完整：在 %0 個函數中，%1 %plural{1:有|:有}1個函數沒有資料'
 # 'profile data may be out of date: of %0 function%s0, %1 %plural{1:has|:have}1 mismatched data that will be ignored'
-HBED3698588C8: '剖析資料可能已過時：在%0個函數中，%1 %plural{1:有|:有}1個不匹配的資料將被忽略'
+HBED3698588C8: '剖析資料可能已過時：在 %0 個函數中，%1 %plural{1:有|:有}1個不匹配的資料將被忽略'
 # 'propagate shadow through ICmpEQ and ICmpNE'
 HB09C108C7674: '通過ICmpEQ和ICmpNE傳播陰影'
 # 'propagating dll attribute to %select{already instantiated|explicitly specialized}0 base class template without dll attribute is not supported'
 H6A4E6175A865: '將dll屬性傳播到%select{已實例化的|明確特殊化的}0基類範本（未指定dll屬性）不受支援'
 # 'property %0 attempting to use instance variable %1 declared in super class %2'
-HDDED40707D8D: '屬性%0嘗試使用在超類%2中宣告的實例變數%1'
+HDDED40707D8D: '屬性 %0 嘗試使用在超類 %2 中宣告的實例變數 %1'
 # 'property %0 cannot be found in forward class object %1'
-H503270AA1975: '在前向類別物件%1中找不到屬性%0'
+H503270AA1975: '在前向類別物件 %1 中找不到屬性 %0'
 # 'property %0 declared with incompatible types in different translation units (%1 vs. %2)'
-H2F559B93D7CB: '屬性%0在不同翻譯單元中宣告為不相容的類型（%1 vs. %2）'
+H2F559B93D7CB: '屬性 %0 在不同翻譯單元中宣告為不相容的類型（%1 vs. %2）'
 # 'property %0 found on object of type %1; did you mean to access it with the "." operator?'
-H0A371D1A94C3: '物件類型%1上找到屬性%0；是否應使用「.」運算子存取？'
+H0A371D1A94C3: '物件類型 %1 上找到屬性 %0；是否應使用「.」運算子存取？'
 # 'property %0 has a variably modified type'
-H81C9932A69B3: '屬性%0具有可變長度類型'
+H81C9932A69B3: '屬性 %0 具有可變長度類型'
 # "property %0 is a class property; did you mean to access it with class '%1'?"
-HFC5FD97AFD4C: '屬性%0是類別屬性；是否意圖使用類別「%1」存取？'
+HFC5FD97AFD4C: '屬性 %0 是類別屬性；是否意圖使用類別「%1」存取？'
 # 'property %0 is already implemented'
-H4ECC248CA95F: '屬性%0已實作'
+H4ECC248CA95F: '屬性 %0 已實作'
 # 'property %0 is declared %select{deprecated|unavailable|partial}1 here'
-HC2D276377832: '屬性%0在此處宣告為%select{已停用|不可用|部分}1'
+HC2D276377832: '屬性 %0 在此處宣告為%select{已停用|不可用|部分}1'
 # 'property %0 is implemented with %select{@synthesize|@dynamic}1 here'
-H43FFE47B4C6F: '屬性%0已使用%select{@synthesize|@dynamic}1實作'
+H43FFE47B4C6F: '屬性 %0 已使用%select{@synthesize|@dynamic}1實作'
 # 'property %0 is implemented with %select{@synthesize|@dynamic}1 in one translation but %select{@dynamic|@synthesize}1 in another translation unit'
-H7C85E91BA02D: '屬性%0在某個翻譯單元使用%select{@synthesize|@dynamic}1實作，但在另一個翻譯單元使用%select{@dynamic|@synthesize}1實作'
+H7C85E91BA02D: '屬性 %0 在某個翻譯單元使用%select{@synthesize|@dynamic}1實作，但在另一個翻譯單元使用%select{@dynamic|@synthesize}1實作'
 # 'property %0 is synthesized to different ivars in different translation units (%1 vs. %2)'
-HE49921A78EC2: '屬性%0在不同翻譯單元合成到不同的實例變數（%1 vs. %2）'
+HE49921A78EC2: '屬性 %0 在不同翻譯單元合成到不同的實例變數（%1 vs. %2）'
 # 'property %0 not found on object of type %1'
-H2822C5946CF1: '物件類型%1上找不到屬性%0'
+H2822C5946CF1: '物件類型 %1 上找不到屬性 %0'
 # 'property %0 not found on object of type %1; did you mean %2?'
-HBDBDE3E27B96: '物件類型%1上找不到屬性%0；是否意圖指%2？'
+HBDBDE3E27B96: '物件類型 %1 上找不到屬性 %0；是否意圖指 %2？'
 # 'property %0 not found on object of type %1; did you mean to access instance variable %2?'
-H8C5C6406F710: '物件類型%1上找不到屬性%0；是否意圖存取實例變數%2？'
+H8C5C6406F710: '物件類型 %1 上找不到屬性 %0；是否意圖存取實例變數 %2？'
 # 'property %0 not found on object of type %1; did you mean to access property %2?'
-H9C85D93EEE02: '屬性%0在類型%1的物件上找不到；您是否想存取屬性%2？'
+H9C85D93EEE02: '屬性 %0 在類型 %1 的物件上找不到；您是否想存取屬性 %2？'
 # 'property %0 refers to an incomplete Objective-C class %1 (with no @interface available)'
-H5BDCDB941EFA: '屬性%0指向不完整的Objective-C類%1（無可用的@interface）'
+H5BDCDB941EFA: '屬性 %0 指向不完整的Objective-C類 %1（無可用的@interface）'
 # 'property %0 requires method %1 to be defined - use @dynamic or provide a method implementation in this category'
-HD9354003F0AB: '屬性%0需要定義方法%1 - 請使用@dynamic或在這個類別延伸中提供方法實作'
+HD9354003F0AB: '屬性 %0 需要定義方法 %1 - 請使用@dynamic或在這個類別延伸中提供方法實作'
 # 'property %0 requires method %1 to be defined - use @synthesize, @dynamic or provide a method implementation in this class implementation'
-HD343415F7FA6: '屬性%0需要定義方法%1 - 請使用@synthesize、@dynamic或在這個類別實作中提供方法實作'
+HD343415F7FA6: '屬性 %0 需要定義方法 %1 - 請使用@synthesize、@dynamic或在這個類別實作中提供方法實作'
 # "property %select{of type %1|with attribute '%1'|without attribute '%1'|with getter %1|with setter %1}0 was selected for synthesis"
-HAD70544BC938: "屬性%select{類型%1|具有屬性'%1'|缺少屬性'%1'|具有getter%1|具有setter%1}0被選取進行合成"
+HAD70544BC938: "屬性%select{類型 %1|具有屬性'%1'|缺少屬性'%1'|具有getter%1|具有setter%1}0被選取進行合成"
 # 'property access is using %0 method which is deprecated'
-HC446F861F2EE: '屬性存取正在使用已棄用的%0方法'
+HC446F861F2EE: '屬性存取正在使用已棄用的 %0 方法'
 # 'property access is using %0 method which is unavailable'
-H61B587B99038: '屬性存取正在使用不可用的%0方法'
+H61B587B99038: '屬性存取正在使用不可用的 %0 方法'
 # 'property access result unused - getters should not be used for side effects'
 H1D3B4CAFB27A: '屬性存取結果未被使用 - getter不應用於副作用'
 # 'property attribute in class extension does not match the primary class'
@@ -25911,7 +25911,7 @@ H928CE0C5C480: '類別延伸中的屬性屬性與主類不符'
 # "property attributes '%0' and '%1' are mutually exclusive"
 H4A7BE0C59F5F: "屬性屬性'%0'和'%1'是互斥的"
 # 'property cannot have array or function type %0'
-HE68B6C09E364: '屬性宣告不能具有陣列或函數類型%0'
+HE68B6C09E364: '屬性宣告不能具有陣列或函數類型 %0'
 # 'property declaration cannot have a default member initializer'
 H5272D8E5D57E: '屬性宣告不能有預設成員初始化器'
 # "property declaration specifies '%0' accessor twice"
@@ -25921,7 +25921,7 @@ H53034807D818: '屬性宣告為傳回非保留物件；getter傳回保留物件'
 # 'property declared here'
 H69D70856EBD1: '屬性在此處宣告'
 # 'property declared in category %0 cannot be implemented in class implementation'
-H04FE1B1065E1: '在類別%0的類別延伸中宣告的屬性無法在類別實作中實作'
+H04FE1B1065E1: '在類別 %0 的類別延伸中宣告的屬性無法在類別實作中實作'
 # 'property does not specify a getter or a putter'
 HD0F5818FB6C8: '屬性未指定getter或setter'
 # "property follows Cocoa naming convention for returning 'owned' objects"
@@ -25933,15 +25933,15 @@ HF42022DEA14A: '在沒有類別宣告的類別中實作屬性'
 # 'property implementation must be in a class or category implementation'
 HD59CD2B75162: '屬性實作必須位於類別或分類的實作中'
 # 'property implementation must have its declaration in interface %0 or one of its extensions'
-HFCF842D4EB86: '屬性實作必須在介面%0或其其中一個擴充中宣告'
+HFCF842D4EB86: '屬性實作必須在介面 %0 或其其中一個擴充中宣告'
 # 'property implementation must have its declaration in the category %0'
-H761B0BB38838: '屬性實作必須在分類%0中宣告'
+H761B0BB38838: '屬性實作必須在分類 %0 中宣告'
 # 'property is assumed atomic by default'
 H2882A0CD4FD8: '屬性預設為原子性'
 # 'property is assumed atomic when auto-synthesizing the property'
 HC5E58A6AB217: '自動合成屬性時預設為原子性'
 # 'property is synthesized to ivar %0 here'
-H7E91E310D399: '此處將屬性合成至實例變數%0'
+H7E91E310D399: '此處將屬性合成至實例變數 %0'
 # 'property name cannot be a bit-field'
 H8E1C0549C2E5: '屬性名稱不能是位段'
 # 'property requires fields to be named'
@@ -25951,21 +25951,21 @@ H32DF2D479322: '此屬性應改為readwrite'
 # 'property synthesized here'
 H0BB379E6C96C: '此處合成屬性'
 # 'property type %0 is incompatible with type %1 inherited from %2'
-HDE3695134102: '屬性類型%0與從%2繼承的類型%1不相容'
+HDE3695134102: '屬性類型 %0 與從 %2 繼承的類型 %1 不相容'
 # "property with '%0' attribute must be of object type"
 H44EF18C35C26: "具有'%0'屬性的屬性必須為物件類型"
 # 'protected %select{constructor|destructor}0 can only be used to %select{construct|destroy}0 a base class subobject'
 H8490EFD629C0: '受保護的%select{建構函數|析構函數}0只能用於%select{建構|销毁}0基類子物件'
 # 'protocol %0 has no definition'
-H3F201B2D647A: '協定%0沒有定義'
+H3F201B2D647A: '協定 %0 沒有定義'
 # 'protocol has circular dependency'
 HBFCB55FB9C5B: '協定存在循環依賴'
 # "protocol has no object type specified; defaults to qualified 'id'"
-H79AE64D3788F: "協定未指定物件類型；預設為已修飾的'id'"
+H79AE64D3788F: "協定未指定物件類型；預設為已修飾的 'id'"
 # 'protocol is declared here'
 H63C66770E070: '協定在此處宣告'
 # 'protocol method is expected to return an instance of the implementing class, but is declared to return %0'
-HCECBCE2ED619: '協定方法期望返回實現類別的實例，但宣告返回%0'
+HCECBCE2ED619: '協定方法期望返回實現類別的實例，但宣告返回 %0'
 # 'protocol method is here'
 H850DBE7D30DB: '協定方法在此處'
 # 'protocol qualifiers must precede type arguments'
@@ -25975,7 +25975,7 @@ H4ECB10C5BABB: "提供的主編譯器IR文件'%0'需要生成OpenMP目標區域�
 # 'pseudo-destructor call is not permitted in constant expressions until C++20'
 HFC660C022DFD: '在C++20之前，常量表達式中不允许使用偽析構函數調用'
 # 'pseudo-destructor destroys object of type %0 with inconsistently-qualified type %1'
-HFC3306882505: '偽析構函數銷毀了類型%0的物件，其修飾類型%1不一致'
+HFC3306882505: '偽析構函數銷毀了類型 %0 的物件，其修飾類型 %1 不一致'
 # 'pseudo-destructors on type void are a Microsoft extension'
 H6C76EC18D3A0: 'void類型的偽析構函數是Microsoft擴充功能'
 # "public framework header includes private framework header '%0'"
@@ -25985,21 +25985,21 @@ H3187DE144A64: '純虛函數%q0被調用'
 # 'put the semicolon on a separate line to silence this warning'
 HD2A85AED0A2F: '在新的一行放置分號以消除此警告'
 # "putter for property must be specified as 'put', not 'set'"
-H65FA70517FA4: "屬性必須指定為'put'，而非'set'"
+H65FA70517FA4: "屬性必須指定為 'put'，而非 'set'"
 # 'qualified call to %0::%1 is treated as a virtual call to %1 due to -fapple-kext'
-HAEBB9D60FCD1: '%0::%1的限定調用被視為對%1的虛調用，這是因-fapple-kext選項'
+HAEBB9D60FCD1: '%0::%1 的限定調用被視為對 %1 的虛調用，這是因-fapple-kext選項'
 # 'qualified destructor name only found in lexical scope; omit the qualifier to find this type name by unqualified lookup'
 H95040EDE1833: '限定的析構函數名稱僅在詞法作用域中找到；省略限定詞以透過非限定搜尋找到此類型名稱'
 # 'qualified member access refers to a member in %0'
-H69C8244E4885: '限定的成員存取引用%0的成員'
+H69C8244E4885: '限定的成員存取引用 %0 的成員'
 # 'qualified module name can only be used to define modules at the top level'
 HCDFABF1A81DD: '限定的模組名稱只能用於頂層定義模組'
 # 'qualified name refers into a specialization of %select{function|variable}0 template %1'
-H4C7D694E4A70: '修飾名稱引用%select{函式|變數}0模板%1的特化'
+H4C7D694E4A70: '修飾名稱引用%select{函式|變數}0模板 %1 的特化'
 # 'qualified reference to %0 is a constructor name rather than a %select{template name|type}1 in this context'
-H08AE31B94F15: '修飾的%0引用在此上下文中是建構函數名稱而非%select{模板名稱|類型}1'
+H08AE31B94F15: '修飾的 %0 引用在此上下文中是建構函數名稱而非%select{模板名稱|類型}1'
 # "qualifier 'const' is needed for variables in address space '%0'"
-HADB69D493623: "在地址空間'%0'中的變數需要'const'修飾"
+HADB69D493623: "在地址空間'%0'中的變數需要 'const' 修飾"
 # 'qualifier in explicit instantiation of %q0 requires a template-id (a typedef is not permitted)'
 HB21409C3C5FB: '%q0的顯式實體化中的修飾需要一個template-id（不允許typedef）'
 # 'qualifiers after comma in declarator list are ignored'
@@ -26053,79 +26053,79 @@ HE2FFC9EC6F02: '重新分配寄存器以避免在熱點代碼中使用REX前綴'
 # 'received warning after diagnostic serialization teardown was underway: %0'
 H60ECB032353D: '在診斷序列化拆卸期間收到警告：%0'
 # 'receiver %0 for class message is a forward declaration'
-HAE87B957CEBD: '類別訊息的接收者%0是.forward declaration/'
+HAE87B957CEBD: '類別訊息的接收者 %0 是.forward declaration/'
 # 'receiver %0 is a forward class and corresponding @interface may not exist'
-H2EFCADD231BF: '接收者%0是.forward class/且對應的@interface可能不存在'
+H2EFCADD231BF: '接收者 %0 是.forward class/且對應的@interface可能不存在'
 # 'receiver expression is here'
 H16AA23E5E187: '接收端表達式在此處'
 # 'receiver is instance of class declared here'
 H063C50E49E8E: '接收者是此處宣告類別的實例'
 # "receiver is treated with 'id' type for purpose of method lookup"
-H23B037191711: "接收者將以'id'類型進行方法查找"
+H23B037191711: "接收者將以 'id' 類型進行方法查找"
 # 'receiver type %0 for instance message is a forward declaration'
-H4107B7B01A42: '實例訊息的接收端類型%0是.forward declaration/'
+H4107B7B01A42: '實例訊息的接收端類型 %0 是.forward declaration/'
 # "receiver type %0 is not 'id' or interface pointer, consider casting it to 'id'"
-HC44380DEE815: "接收端類型%0不是'id'或界面指標，建議轉型為'id'"
+HC44380DEE815: "接收端類型 %0 不是 'id' 或界面指標，建議轉型為 'id'"
 # 'receiver type %0 is not an Objective-C class'
-HDF1E1AF5B7B2: '接收端類型%0不是Objective-C類'
+HDF1E1AF5B7B2: '接收端類型 %0 不是Objective-C類'
 # 'record profile for inter-function control flow activity (default: true)'
 HB3410F96E4B8: '記錄函數間控制流活動的剖析（預設：true）'
 # 'recursive evaluation of default argument'
 H9D22EE24805A: '預設參數的遞迴評估'
 # 'recursive template instantiation exceeded maximum depth of %0'
-H9F7DB4D308D0: '模板實例化超過最大深度%0'
+H9F7DB4D308D0: '模板實例化超過最大深度 %0'
 # "redeclaration cannot add 'loader_uninitialized' attribute"
-H70EFB9FBF448: "重宣告不能添加'loader_uninitialized'屬性"
+H70EFB9FBF448: "重宣告不能添加 'loader_uninitialized' 屬性"
 # 'redeclaration has different alignment requirement (%1 vs %0)'
 H2965974DE860: '重宣告具有不同的對齊要求（%1 vs %0）'
 # "redeclaration of %0 must %select{not |}1have the 'overloadable' attribute"
-H9C609286F3D1: "重宣告%0必須%select{不具有 |}1'overloadable'屬性"
+H9C609286F3D1: "重宣告 %0 必須%select{不具有 |}1'overloadable' 屬性"
 # 'redeclaration of %0 with a different type%diff{: $ vs $|}1,2'
-HEB05B74B4F52: '重宣告%0具有不同的類型%diff{: $ vs $|}1,2'
+HEB05B74B4F52: '重宣告 %0 具有不同的類型%diff{: $ vs $|}1,2'
 # 'redeclaration of %q0 cannot add %q1 attribute'
 H437273BF8230: '重宣告%q0不能添加%q1屬性'
 # 'redeclaration of %q0 should not add %q1 attribute'
 HBC3EEF68F79F: '重宣告%q0不应添加%q1屬性'
 # "redeclaration of C++ built-in type 'bool'"
-H4DE1B64751F8: "重新宣告C++內建類型'bool'"
+H4DE1B64751F8: "重新宣告C++內建類型 'bool'"
 # 'redeclaration of already-defined enum %0 is a GNU extension'
-H3B72AE37DEEE: '已定義的枚舉%0的重新宣告是GNU擴展'
+H3B72AE37DEEE: '已定義的枚舉 %0 的重新宣告是GNU擴展'
 # 'redeclaration of deduction guide'
 H6C137FDA5914: '推導指引的重新宣告'
 # 'redeclaration of method parameter %0'
-H0D9F6CE9B2EA: '方法參數%0的重新宣告'
+H0D9F6CE9B2EA: '方法參數 %0 的重新宣告'
 # 'redeclaration of type parameter %0'
-HC29DAC039CAB: '類型參數%0的重新宣告'
+HC29DAC039CAB: '類型參數 %0 的重新宣告'
 # 'redeclaration of using declaration'
 H96E43918A485: 'using宣告的重新宣告'
 # 'redeclaration of using-enum declaration'
 H7EA3B309B6C8: 'using-enum宣告的重新宣告'
 # 'redeclaring non-static %0 as static is a Microsoft extension'
-H853738CC6C0D: '將非靜態%0重新宣告為靜態是Microsoft擴展'
+H853738CC6C0D: '將非靜態 %0 重新宣告為靜態是Microsoft擴展'
 # 'redefining builtin macro'
 H6021415EA4BB: '重新定義內建宏'
 # 'redefinition of %0'
-HB70C986DD184: '%0的重新定義'
+HB70C986DD184: '%0 的重新定義'
 # 'redefinition of %0 as an alias for a different namespace'
-H97345A757B2F: '將%0重新定義為不同命名空間的別名'
+H97345A757B2F: '將 %0 重新定義為不同命名空間的別名'
 # 'redefinition of %0 as different kind of symbol'
-H9380CBD04275: '將%0重新定義為不同類型的符號'
+H9380CBD04275: '將 %0 重新定義為不同類型的符號'
 # 'redefinition of %0 will not be visible outside of this function'
-H6605A7137B7E: '%0的重新定義在這個函數之外不可見'
+H6605A7137B7E: '%0 的重新定義在這個函數之外不可見'
 # 'redefinition of %0 with a different type%diff{: $ vs $|}1,2'
-HB1C0A119B95E: '%0的重新定義，類型不同%diff{：%$ vs $|}1,2'
+HB1C0A119B95E: '%0 的重新定義，類型不同%diff{：%$ vs $|}1,2'
 # 'redefinition of %select{typedef|type alias}0 for variably-modified type %1'
-HB599B51A5F4D: '可變長度修飾類型%1的%select{typedef|類型別名}0的重新定義'
+HB599B51A5F4D: '可變長度修飾類型 %1 的%select{typedef|類型別名}0的重新定義'
 # "redefinition of a 'extern inline' function %0 is not supported in %select{C99 mode|C++}1"
-HF158368144B8: '在%select{C99模式|C++}1中不支援重新定義extern inline函數%0'
+HF158368144B8: '在%select{C99模式|C++}1中不支援重新定義extern inline函數 %0'
 # 'redefinition of concept %0 with different template parameters or requirements'
-H4C4283523181: '%0概念的重新定義，其模板參數或需求不同'
+H4C4283523181: '%0 概念的重新定義，其模板參數或需求不同'
 # 'redefinition of default argument'
 H6507C3F7227D: '預設參數的重新定義'
 # 'redefinition of enumerator %0'
-H1EE462BB5E46: '枚舉值%0的重新定義'
+H1EE462BB5E46: '枚舉值 %0 的重新定義'
 # 'redefinition of forward class %0 of a typedef name of an object type is ignored'
-H06040CF8C316: '物件類型的typedef名稱%0的前向宣告類重新定義被忽略'
+H06040CF8C316: '物件類型的typedef名稱 %0 的前向宣告類重新定義被忽略'
 # 'redefinition of inferred submodule'
 H43BB40E423BF: '推論子模組的重新定義'
 # 'redefinition of label %0'
@@ -26213,25 +26213,25 @@ HCCFE4F550EEB: '在asm的%select{輸入|輸出}1中引用具有記憶體約束�
 # "reference to enumeration must use 'enum' not 'enum %select{struct|class}0'"
 HDC33545DFD9E: "引用枚舉時必須使用 'enum' 而不是 'enum %select{struct|class}0'"
 # 'reference to local %select{variable|binding}1 %0 declared in enclosing %select{%3|block literal|lambda expression|context}2'
-H9B72122A433C: '在封閉的%select{%3|區塊字面量|lambda expression|上下文}2中宣告的局部%select{變數|綁定}1 %0被引用'
+H9B72122A433C: '在封閉的%select{%3|區塊字面量|lambda expression|上下文}2中宣告的局部%select{變數|綁定}1 %0 被引用'
 # "reference to marker '%0' is ambiguous"
 HD452BD6D3FB0: '引用標記‘%0’是模稜兩可的'
 # 'reference to non-static member function must be called%select{|; did you mean to call it with no arguments?}0'
 H472EE5EB17CD: '引用非靜態成員函數必須被呼叫%select{|; 您是否想要呼叫時不帶參數？}0'
 # 'reference to type %0 cannot bind to an initializer list'
-H9194F3CD2BD5: '類型%0的引用無法綁定到初始值列表'
+H9194F3CD2BD5: '類型 %0 的引用無法綁定到初始值列表'
 # 'reference to type %0 requires an initializer'
-HD97076E9024C: '類型%0的引用需要初始值設定項'
+HD97076E9024C: '類型 %0 的引用需要初始值設定項'
 # 'reference to unresolved using declaration'
 H4256A6DE4B09: '引用未解決的using宣告'
 # 'referenced %0 is declared here'
-HE1EBB7B8DBAD: '被引用的%0在此宣告'
+HE1EBB7B8DBAD: '被引用的 %0 在此宣告'
 # 'referenced member %0 is declared here'
-H8DB9210452D3: '被引用的成員%0在此宣告'
+H8DB9210452D3: '被引用的成員 %0 在此宣告'
 # "referring to 'main' within an expression is a Clang extension"
-H5EC3F4017EE7: "在運算式中引用'main'是Clang的擴充功能"
+H5EC3F4017EE7: "在運算式中引用 'main' 是Clang的擴充功能"
 # "region cannot be%select{| closely}0 nested inside '%1' region%select{|; perhaps you forget to enclose 'omp %3' directive into a parallel region?|; perhaps you forget to enclose 'omp %3' directive into a for or a parallel for region with 'ordered' clause?|; perhaps you forget to enclose 'omp %3' directive into a target region?|; perhaps you forget to enclose 'omp %3' directive into a teams region?|; perhaps you forget to enclose 'omp %3' directive into a for, simd, for simd, parallel for, or parallel for simd region?}2"
-H9F4A9870BA07: "%select{|緊密}0嵌套在 '%1' 區域內%select{|; 可能您忘記將'omp %3'指令包圍在平行區域中？|; 可能您忘記將'omp %3'指令包圍在帶有'ordered'子句的for或parallel for區域中？|; 可能您忘記將'omp %3'指令包圍在target區域中？|; 可能您忘記將'omp %3'指令包圍在teams區域中？|; 可能您忘記將'omp %3'指令包圍在for、simd、for simd、parallel for或parallel for simd區域中？}2"
+H9F4A9870BA07: "%select{|緊密}0嵌套在 '%1' 區域內%select{|; 可能您忘記將'omp %3'指令包圍在平行區域中？|; 可能您忘記將'omp %3'指令包圍在帶有 'ordered' 子句的for或parallel for區域中？|; 可能您忘記將'omp %3'指令包圍在target區域中？|; 可能您忘記將'omp %3'指令包圍在teams區域中？|; 可能您忘記將'omp %3'指令包圍在for、simd、for simd、parallel for或parallel for simd區域中？}2"
 # "register '%0' unsuitable for global register variables on this target"
 HAC3AEFE8413B: '此目標上寄存器‘%0’不適合用於全域寄存器變數'
 # 'register number should be an integer'
@@ -26241,25 +26241,25 @@ H44776CA40899: '轉換的寄存器壓力因素。'
 # 'register space cannot be specified on global constants'
 H7D24E3150A81: '無法在全域常數上指定寄存器空間'
 # 'reimplementation of category %1 for class %0'
-H30BD90819E63: '為類別%0重新實作類別%1'
+H30BD90819E63: '為類別 %0 重新實作類別 %1'
 # 'reimplementation of class %0'
-HD4142B86FCD9: '類別%0的重新實作'
+HD4142B86FCD9: '類別 %0 的重新實作'
 # 'reinterpret_cast cannot resolve overloaded function %0 to type %1'
-H60D5F589023C: 'reinterpret_cast無法將重載函數%0解析為類型%1'
+H60D5F589023C: 'reinterpret_cast無法將重載函數 %0 解析為類型 %1'
 # 'reinterpret_cast from %0 to %1 has undefined behavior'
-H1A1328A6B1E4: '從%0到%1的reinterpret_cast行為未定義'
+H1A1328A6B1E4: '從 %0 到 %1 的reinterpret_cast行為未定義'
 # 'reinterpret_cast of a %0 to %1 needs its address, which is not allowed'
-H8633F993884D: '將%0重新詮釋為%1的reinterpret_cast需要其地址，但這並未被允許'
+H8633F993884D: '將 %0 重新詮釋為 %1 的reinterpret_cast需要其地址，但這並未被允許'
 # "releasing %0 '%1' that was not held"
-HD16686A7FEA7: "釋放未持有的%0 '%1'"
+HD16686A7FEA7: "釋放未持有的 %0 '%1'"
 # "releasing %0 '%1' using %select{shared|exclusive}2 access, expected %select{shared|exclusive}3 access"
-H2106963D41B0: "使用%select{共享|獨佔}2存取方式釋放%0 '%1'，期望%select{共享|獨佔}3存取方式"
+H2106963D41B0: "使用%select{共享|獨佔}2存取方式釋放 %0 '%1'，期望%select{共享|獨佔}3存取方式"
 # 'remainder by zero in preprocessor expression'
 HE098B5222CAD: '在預處理表達式中除以零'
 # 'remaining %0 candidate%s0 omitted; pass -fshow-overloads=all to show them'
-HD0784BB8E50F: '省略%0個候選項；使用-fshow-overloads=all參數顯示所有候選項'
+HD0784BB8E50F: '省略 %0 個候選項；使用-fshow-overloads=all參數顯示所有候選項'
 # 'remap file source paths <old> to <new> in coverage mapping. If there are multiple options, prefix replacement is applied in reverse order starting from the last one'
-HD493DCAA04BC: '在覆蓋率映射中將來源路徑<old>重映射為<new>。若有多個選項，則按反向順序從最後一個開始套用前綴替換'
+HD493DCAA04BC: '在覆蓋率映射中將來源路徑 <old> 重映射為 <new>。若有多個選項，則按反向順序從最後一個開始套用前綴替換'
 # 'remap file source paths in debug info, coverage mapping, predefined preprocessor macros and __builtin_FILE(). Implies -ffile-reproducible.'
 HD15C7DEA6A6F: '在除錯資訊、覆蓋率映射、預定義預處理宏和__builtin_FILE()中重映射來源路徑。隱含-ffile-reproducible參數。'
 # 'remap file source paths in predefined preprocessor macros and __builtin_FILE(). Implies -ffile-reproducible.'
@@ -26269,7 +26269,7 @@ H1F5563CE509E: 'remarks_a'
 # 'remarks_b'
 H40EB09D856D2: 'remarks_b'
 # "remove '_Noreturn'"
-H4CD6C2426BE8: "移除'_Noreturn'"
+H4CD6C2426BE8: "移除 '_Noreturn'"
 # "remove 'enum%select{| struct| class}0' to befriend an enum"
 H9CF5F9198489: "移除'enum%select{| struct| class}0'以與枚舉建立友元關係"
 # "remove 'u8' prefix to avoid a change of behavior; Clang encodes unprefixed narrow string literals as UTF-8"
@@ -26289,7 +26289,7 @@ HBB1C1AF59745: '移除括號以消除此警告'
 # 'remove std::move call here'
 H87B3A4171A2A: '在此處移除std::move調用'
 # "remove the %select{'%1' if its condition|condition if it}0 is always %select{false|true}2"
-HE5C66C3841AD: "移除%select{'%1' 如果其條件|條件如果它}0始終為%select{false|true}2"
+HE5C66C3841AD: "移除%select{'%1' 如果其條件|條件如果它}0始終為 %select{false|true}2"
 # "remove the call to '%0' since unsigned values cannot be negative"
 H3BE7257796E7: "移除對 '%0' 的呼叫，因為無符號值不能為負數"
 # 'remove the kernel-info pass at the end of the full LTO pipeline'
@@ -26315,13 +26315,13 @@ H2C65B1A1835B: "重複的RISC-V 'interrupt' 屬性在此處"
 # 'repeated evaluation of the same literal expression can produce different objects'
 H816EF14DCA64: '對同一字面運算式的重複評估可能產生不同的物件'
 # "replace 'default' with 'delete'"
-H6143A5F8A323: "將'default'替換為'delete'"
+H6143A5F8A323: "將 'default' 替換為 'delete'"
 # "replace expression with '%0' %select{|or use 'xor' instead of '^' }1to silence this warning"
-H8BD6D24EAB4A: "將運算式替換為'%0' %select{|或改用'xor'代替'^' }1以消除此警告"
+H8BD6D24EAB4A: "將運算式替換為'%0' %select{|或改用 'xor' 代替'^' }1以消除此警告"
 # 'replace parentheses with an initializer to declare a variable'
 H1CB1AEAC6164: '使用初始化器替換括號以宣告變數'
 # "replacement function %0 cannot be declared 'inline'"
-H8E774898376D: "替代函數%0不能被宣告為'inline'"
+H8E774898376D: "替代函數 %0 不能被宣告為 'inline'"
 # 'report accesses through a pointer which has poisoned shadow'
 HDB29EEB5BF15: '報告通過具有被污染影子的指標進行的存取'
 # 'report stats in csv'
@@ -26371,7 +26371,7 @@ H044B0871CB3F: 'restrict 需要指標或參考'
 # 'restrict requires a pointer or reference (%0 is invalid)'
 HB4AA3977DC42: 'restrict 需要指標或引用（%0 無效）'
 # "result argument to %select{overflow builtin|checked integer operation}0 must be a pointer to a non-const integer type %select{|other than plain 'char', 'bool', bit-precise, or an enumeration }0(%1 invalid)"
-HD81ECBB4661A: "%select{溢位內建函數|已檢查整數運算}0的結果參數必須是對非const整數類型的指標%select{|（不包括普通'char'、'bool'、精確位元或列舉類型）}0（%1無效）"
+HD81ECBB4661A: "%select{溢位內建函數|已檢查整數運算}0的結果參數必須是對非const整數類型的指標%select{|（不包括普通 'char'、'bool'、精確位元或列舉類型）}0（%1 無效）"
 # "result of '%0' is %1; did you mean '%2' (%3)?"
 H369683737B3D: "'%0' 的結果是 %1；您是否是指 '%2'（%3）？"
 # "result of '%0' is %1; did you mean '%2'?"
@@ -26389,11 +26389,11 @@ H86DA5A0E3154: '比較 %select{%3|無符號列舉運算式}0 %2 %select{無符�
 # 'result of comparison of %select{%3|unsigned expression}0 %2 %select{unsigned expression|%3}0 is always %4'
 HABA37A2C23DF: '比較 %select{%3|無符號運算式}0 %2 %select{無符號運算式|%3}0 的結果始終為 %4'
 # 'result of comparison of %select{%4|%1-bit %select{signed|unsigned}2 value}0 %3 %select{%1-bit %select{signed|unsigned}2 value|%4}0 is always %5'
-H3E54DBA92461: '%select{%4|%1位 %select{有符號|無符號}2 數值}0 %3 %select{%1位 %select{有符號|無符號}2 數值|%4}0 的比較結果始終為 %5'
+H3E54DBA92461: '%select{%4|%1 位 %select{有符號|無符號}2 數值}0 %3 %select{%1 位 %select{有符號|無符號}2 數值|%4}0 的比較結果始終為 %5'
 # 'result of comparison of %select{constant %0|true|false}1 with %select{expression of type %2|boolean expression}3 is always %4'
 H0604EEA5685E: '%select{常量 %0|true|false}1 與 %select{類型 %2 的運算式|布林運算式}3 的比較結果始終為 %4'
 # "result of comparison of constant %0 with expression of type 'BOOL' is always %1, as the only well defined values for 'BOOL' are YES and NO"
-H641A75823917: "與'BOOL'類型的運算式進行常數%0比較，結果始終為%1，因'BOOL'的明確定義值僅有YES和NO"
+H641A75823917: "與 'BOOL' 類型的運算式進行常數 %0 比較，結果始終為 %1，因 'BOOL' 的明確定義值僅有YES和NO"
 # "retain'ed block property does not copy the block - use copy attribute instead"
 HD7F1D5C5B0F0: '建構函數嘗試區塊的 catch 區塊中傳回為非法操作'
 # 'return in the catch of a function try block of a constructor is illegal'
@@ -26425,19 +26425,19 @@ H0105A22E2A8D: "預設 'operator<=>' 的返回類型無法推導，因 %select{|
 # 'return type of out-of-line definition of %q0 differs from that in the declaration'
 H469315680A98: '%q0 的實作定義與宣告的返回類型不符'
 # 'return type of virtual function %0 is not covariant with the return type of the function it overrides (%1 has different qualifiers than %2)'
-H00BA4129869D: '虛函數%0的返回類型與它覆寫的函數返回類型不協變（%1的修飾符與%2不同）'
+H00BA4129869D: '虛函數 %0 的返回類型與它覆寫的函數返回類型不協變（%1 的修飾符與 %2 不同）'
 # 'return type of virtual function %0 is not covariant with the return type of the function it overrides (%1 is incomplete)'
 HE8582E3BF357: '虛函數 %0 的返回類型與其覆寫函數的返回類型無協變關係（%1 為未完整類型）'
 # 'return type of virtual function %0 is not covariant with the return type of the function it overrides (%1 is not derived from %2)'
 H5A21B37900C4: '虛函數 %0 的返回類型與其覆寫函數的返回類型無協變關係（%1 非 %2 的派生類）'
 # 'return type of virtual function %0 is not covariant with the return type of the function it overrides (class type %1 does not have the same cv-qualification as or less cv-qualification than class type %2)'
-H2AB9EE663373: '虛函數%0的返回類型與它覆寫的函數返回類型不協變（類型%1的cv修飾符與類型%2不同或更少）'
+H2AB9EE663373: '虛函數 %0 的返回類型與它覆寫的函數返回類型不協變（類型 %1 的cv修飾符與類型 %2 不同或更少）'
 # 'return type of virtual function %3 is not covariant with the return type of the function it overrides (ambiguous conversion from derived class %0 to base class %1:%2)'
-H94F1AF985110: '虛函數%3的返回類型與它覆寫的函數返回類型不協變（派生類%0到基類%1的轉換存在歧義：%2）'
+H94F1AF985110: '虛函數 %3 的返回類型與它覆寫的函數返回類型不協變（派生類 %0 到基類 %1 的轉換存在歧義：%2）'
 # "return value not in expected state; expected '%0', observed '%1'"
 H8EF54209E2EA: "返回值不在期望狀態；期望'%0'，觀察到'%1'"
 # 'return value of %0 is a large (%1 bytes) pass-by-value object; pass it by reference instead ?'
-HA1B074D05D38: '%0的返回值是大型（%1位元組）傳遞值參數的物件；建議改用傳參考方式傳遞？'
+HA1B074D05D38: '%0 的返回值是大型（%1 位元組）傳遞值參數的物件；建議改用傳參考方式傳遞？'
 # 'returning %select{address of|reference to}0 local temporary object'
 H0D9CD7C30605: '%select{取址|引用}0局部暫時物件作為返回值'
 # 'returning address of label, which is local'
@@ -26445,15 +26445,15 @@ H7C6FDC7A79CE: '返回存活於局部堆疊的區塊'
 # 'returning block that lives on the local stack'
 HFB5C6DCAD180: '返回局部堆疊上的區塊指標'
 # "returning pointer %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
-H524B3D4E5221: "返回指標%1需要持有%0 %select{'%2'|'%2'獨佔}3"
+H524B3D4E5221: "返回指標 %1 需要持有 %0 %select{'%2'|'%2'獨佔}3"
 # "returning pointer to variable %1 requires holding %0 %select{'%2'|'%2' exclusively}3"
-HC47B423E80E3: "返回%1變數的指標需要持有%0 %select{'%2'|'%2'獨佔}3"
+HC47B423E80E3: "返回 %1 變數的指標需要持有 %0 %select{'%2'|'%2'獨佔}3"
 # 'returning reference to local temporary object'
 H3C7B38DADD40: '返回局部暫時物件的引用'
 # "returning the value that %1 points to by reference requires holding %0 %select{'%2'|'%2' exclusively}3"
-HDFB7294684C5: "以引用返回%1所指的值需要持有%0 %select{'%2'|'%2'獨佔}3"
+HDFB7294684C5: "以引用返回 %1 所指的值需要持有 %0 %select{'%2'|'%2'獨佔}3"
 # "returning variable %1 by reference requires holding %0 %select{'%2'|'%2' exclusively}3"
-H5E5D0E85F387: "以引用返回%1變數需要持有%0 %select{'%2'|'%2'獨佔}3"
+H5E5D0E85F387: "以引用返回 %1 變數需要持有 %0 %select{'%2'|'%2'獨佔}3"
 # "rewriter doesn't support user-specified control flow semantics for @try/@finally (code may not execute properly)"
 H9C522D3EEF6D: '重寫器不支援使用者指定的@try/@finally控制流程語法（程式碼可能無法正確執行）'
 # 'rewriting block literal declared in global scope is not implemented'
@@ -26461,9 +26461,9 @@ HC8DC37202696: '重寫在全域作用域中宣告的區塊字面量尚未實作'
 # 'rewriting sub-expression within a macro (may not be correct)'
 H72B7281F7712: '重寫宏內的子運算式（結果可能不正確）'
 # 'right hand operand to %0 has non-pointer-to-member type %1'
-H53A963FA3084: '%0的右操作元具有非成員指標類型%1'
+H53A963FA3084: '%0 的右操作元具有非成員指標類型 %1'
 # "right shifting a 'bool' implicitly converts it to 'int'"
-HEDBEE20D2831: "對'bool'進行右位移隱式轉換為'int'"
+HEDBEE20D2831: "對 'bool' 進行右位移隱式轉換為 'int'"
 # 'rocPrim path, required by the HIP Standard Parallel Algorithm Acceleration library, used to implicitly include the rocPrim library'
 HD40BA7FFEFEE: 'rocPrim 路徑，rocPrim 庫加速 HIP 標準平行演算法的必要元件，用於隱含包含 rocPrim 庫'
 # 'rocThrust path, required by the HIP Standard Parallel Algorithm Acceleration library, used to implicitly include the rocThrust library'
@@ -26515,9 +26515,9 @@ HD3067EEE76AC: '純量初始化式不能為空'
 # 'scalar operand type has greater rank than the type of the vector element. (%0 and %1)'
 H2C50DCFF8689: '純量運算元類型的階級高於向量元素的類型. (%0 和 %1)'
 # 'scale argument must be 1, 2, 4, or 8'
-H325DB8FF3A78: 'scale參數必須為1、2、4或8'
+H325DB8FF3A78: 'scale參數必須為 1、2、4或 8'
 # 'scale factor for the latch probability. Value should be greater than 1. Lower values are ignored'
-HAACE1BBE5003: 'latch機率的scale因子。值必須大於1，較小的值將被忽略'
+HAACE1BBE5003: 'latch機率的scale因子。值必須大於 1，較小的值將被忽略'
 # 'scale of asan shadow mapping'
 H538257B2498C: 'asan陰影映射的scale因子'
 # 'scale of memprof shadow mapping'
@@ -26545,7 +26545,7 @@ HBAB6DD203AC7: "'va_arg' 的第二個參數為不完整類型 %0"
 # "second argument to 'va_arg' is of non-POD type %0"
 H6E23523199DB: "'va_arg' 的第二個參數為非POD類型 %0"
 # "second argument to 'va_arg' is of promotable type %0; this va_arg has undefined behavior because arguments will be promoted to %1"
-HD77AAC429CAF: 'va_arg的第二個參數是可提升的類型%0；此va_arg具有未定義行為，因為參數將被提升為%1'
+HD77AAC429CAF: 'va_arg的第二個參數是可提升的類型 %0；此va_arg具有未定義行為，因為參數將被提升為 %1'
 # "second argument to 'va_start' is not the last non-variadic parameter"
 H37CA82AB0144: 'va_start的第二個參數不是最後一個非可變參數'
 # 'second argument to __builtin_alloca_with_align is supposed to be in bits'
@@ -26557,29 +26557,29 @@ H9D3B291ADD1F: '__builtin_call_with_static_chain的第二個參數必須是指�
 # 'section attribute is specified on redeclared variable'
 H4BE9B9505588: 'section屬性指定在重新宣告的變數上'
 # 'section length is evaluated to a negative value %0'
-HDAA24A68E89D: 'section長度被評估為負值%0'
+HDAA24A68E89D: 'section長度被評估為負值 %0'
 # 'section length is unspecified and cannot be inferred because subscripted value is %select{not an array|an array of unknown bound}0'
 HD324F8149A40: 'section長度未指定且無法推導，因為下標值是%select{非陣列|未知維度的陣列}0'
 # 'section of pointer to function type %0'
-HDFC73840E7DC: 'section的指標指向函數類型%0'
+HDFC73840E7DC: 'section的指標指向函數類型 %0'
 # 'section of pointer to incomplete type %0'
-HFA4996C0EBB1: 'section的指標指向不完整類型%0'
+HFA4996C0EBB1: 'section的指標指向不完整類型 %0'
 # 'section stride is evaluated to a non-positive value %0'
-H2C7B2A05B911: 'section的間隔被評估為非正數%0'
+H2C7B2A05B911: 'section的間隔被評估為非正數 %0'
 # 'see attribute on parameter here'
 HDD0675B1BF06: '參見此處參數上的屬性'
 # 'seed for randomization'
 HD63DCBC599F4: '隨機化種子'
 # "selected '%select{begin|end}0' %select{function|template }1%2 with iterator type %3"
-H752B6650220E: "選擇 '%select{begin|end}0' %select{函數|範本 }1%2，其迭代器類型為%3"
+H752B6650220E: "選擇 '%select{begin|end}0' %select{函數|範本 }1%2，其迭代器類型為 %3"
 # "selected 'operator<=>' for %select{|member|base class}0 %1 declared here"
 H810A0D73AD55: "選擇 'operator<=>' 給%select{|成員|基類}0 %1，該處宣告"
 # 'selector element is not a valid lvalue'
 H0BFE26B0616A: '選擇器元素不是有效的左值'
 # 'selector element of type %0 cannot be a constant lvalue expression'
-H9F3EFE55FA69: '類型%0的選擇器元素不能是常量左值表達式'
+H9F3EFE55FA69: '類型 %0 的選擇器元素不能是常量左值表達式'
 # 'selector element type %0 is not a valid object'
-HED5168FB3348: '選擇器元素類型%0不是有效的物件'
+HED5168FB3348: '選擇器元素類型 %0 不是有效的物件'
 # 'semantic annotations must be present for all parameters of an entry function or patch constant function'
 H8F1EA44B7AC0: '入口函數或修補常數函數的所有參數都必須有語義註解'
 # 'semicolon before method body is ignored'
@@ -26603,11 +26603,11 @@ H0B75386E5DBF: '不能為readonly屬性指定setter'
 # 'setting the floating point evaluation method to `source` on a target without SSE is not supported'
 H3CBE26190DE7: '在無SSE的目標上將浮點數評估方法設定為`source`不受支援'
 # 'several methods with selector %0 of mismatched types are found for the @selector expression'
-H992F0A773FBB: '在@selector運算式中找到具有選擇子%0但類型不匹配的多個方法'
+H992F0A773FBB: '在@selector運算式中找到具有選擇子 %0 但類型不匹配的多個方法'
 # 'share stubs across functions'
 H4D76BB47577B: '在函數間共用存根'
 # 'shift count %0 >= width of type %1 (%2 bit%s2)'
-HF6F9C4B1183E: '位移次數%0 >= 類型%1的位元數（%2 bit%s2）'
+HF6F9C4B1183E: '位移次數 %0 >= 類型 %1 的位元數（%2 bit%s2）'
 # 'shift count >= width of type'
 H64BC6739BC0B: '位移次數 >= 類型的位元數'
 # 'shift count is negative'
@@ -26619,7 +26619,7 @@ H31FAC4015C01: '簡化指令'
 # 'show a graph.'
 HDBFEE5F65752: '顯示圖形。'
 # 'show execution count of functions in binary 2 as a ratio of the total samples in binary 1 - make sure both profiles have equal collection time and sampling rate for this to make sense'
-H7302A3496B1D: '以二進位1的總取樣數為基準，顯示二進位2中函數的執行次數比率 - 確保兩個配置文件具有相同的收集時間和取樣率，才能讓此顯示有意義'
+H7302A3496B1D: '以二進位 1 的總取樣數為基準，顯示二進位 2 中函數的執行次數比率 - 確保兩個配置文件具有相同的收集時間和取樣率，才能讓此顯示有意義'
 # 'show in text.'
 H8201270E0209: '以文字顯示。'
 # 'show profile density details'
@@ -26701,7 +26701,7 @@ H3988159D97D2: '跳過傳回類型'
 # 'skip variable types'
 H1C4CB11B7B2B: '跳過變數類型'
 # "skipping '%0' because module declaration of '%1' lacks the 'framework' qualifier"
-H07A078D1E04E: "跳過'%0'，因為模組宣告'%1'缺少'framework'修飾符"
+H07A078D1E04E: "跳過'%0'，因為模組宣告'%1'缺少 'framework' 修飾符"
 # 'skipping stray token'
 HF5D19BFCA4A8: '跳過孤立的記號'
 # 'sort hot data by hot function usage and count'
@@ -26723,7 +26723,7 @@ H7D02F3625956: '來源管理器位置位址空間使用情形：'
 # 'specialization of member %q0 does not specialize an instantiated member'
 H7EB7CDEAD3CD: '成員%q0的特化未特化已實例化的成員'
 # 'specified %0 type tag requires a null pointer'
-HEFCCEFE3C17F: '指定的%0類型標籤需要空指標'
+HEFCCEFE3C17F: '指定的 %0 類型標籤需要空指標'
 # 'specifies thread count for the multithreading for updating DWO debug info'
 H230218760941: '指定多執行緒更新DWO除錯資訊的執行緒數量'
 # 'specify a target CPU'
@@ -26823,31 +26823,31 @@ H4F7EABF6B0DD: '靜態斷言失敗%select{：%1|}0'
 # 'static const volatile data member must be initialized out of line'
 H407C919E04E8: 'static const volatile 成員變數必須在外部初始化'
 # 'static data member %0 already has an initializer'
-H6ACB0F956377: '靜態資料成員%0已經有初始值設定'
+H6ACB0F956377: '靜態資料成員 %0 已經有初始值設定'
 # 'static data member %0 in union is a C++11 extension'
-HA330F37BE63B: '聯結體中的靜態資料成員%0是C++11擴充功能'
+HA330F37BE63B: '聯結體中的靜態資料成員 %0 是C++11擴充功能'
 # 'static data member %0 in union is incompatible with C++98'
-HEBF9EACD8366: '聯結體中的靜態資料成員%0與C++98不相容'
+HEBF9EACD8366: '聯結體中的靜態資料成員 %0 與C++98不相容'
 # 'static data member %0 not allowed in anonymous %select{struct|interface|union|class|enum}1'
-HC964FFEFDD87: '在匿名%select{結構|介面|聯結體|類別|列舉}1中不允许有靜態資料成員%0'
+HC964FFEFDD87: '在匿名%select{結構|介面|聯結體|類別|列舉}1中不允许有靜態資料成員 %0'
 # 'static data member %0 not allowed in local %select{struct|interface|union|class|enum}2 %1'
-HA56CE2DF143E: '在區域%select{結構|介面|聯結體|類別|列舉}2 %1中不允许有靜態資料成員%0'
+HA56CE2DF143E: '在區域%select{結構|介面|聯結體|類別|列舉}2 %1 中不允许有靜態資料成員 %0'
 # 'static data member definition cannot specify a storage class'
 HF3222609AACF: '靜態資料成員的定義不能指定儲存類別'
 # 'static data member of type %0 must be initialized out of line'
-H4598A36D5110: '類型為%0的靜態資料成員必須在外部初始化'
+H4598A36D5110: '類型為 %0 的靜態資料成員必須在外部初始化'
 # 'static declaration of %0 follows non-static declaration'
-H2C721D0B8C3C: '對%0的靜態宣告跟在非靜態宣告之後'
+H2C721D0B8C3C: '對 %0 的靜態宣告跟在非靜態宣告之後'
 # 'static lambdas are a C++23 extension'
 H0728106ADDA2: '靜態lambda表達式是C++23的擴充功能'
 # 'static lambdas are incompatible with C++ standards before C++23'
 H81C85F6C724E: '靜態lambda表達式與C++23之前的標準不相容'
 # 'static member %0 cannot be a bit-field'
-HDFCBA261B7FE: '靜態成員%0不能是位段'
+HDFCBA261B7FE: '靜態成員 %0 不能是位段'
 # 'static members cannot be declared in an anonymous %select{struct|union}0'
 HF2CC0A1A3C82: '無法在匿名%select{結構|聯結體}0中宣告靜態成員'
 # 'static variable %0 is suspiciously used within its own initialization'
-H1CCD7A0167D8: '在自身初始化時使用靜態變數%0可能有問題'
+H1CCD7A0167D8: '在自身初始化時使用靜態變數 %0 可能有問題'
 # 'static_cast between pointer-to-function and pointer-to-object is a Microsoft extension'
 H747267A37B70: '將函式指標轉換為物件指標的static_cast是Microsoft的擴充功能'
 # "std::coroutine_handle isn't a class template"
@@ -26861,7 +26861,7 @@ H57E56532E11C: 'std::initializer_list必須是帶有一個型別參數的類模�
 # 'std::nothrow must be a valid variable declaration'
 H81985EEDEA6B: 'std::nothrow 必須是有效的變數宣告'
 # 'std::nothrow was not found; include <new> before defining a coroutine which uses get_return_object_on_allocation_failure()'
-H553185766FEB: '未找到std::nothrow；在定義使用get_return_object_on_allocation_failure()的協程前，請包含<new>頭檔'
+H553185766FEB: '未找到std::nothrow；在定義使用get_return_object_on_allocation_failure()的協程前，請包含 <new> 頭檔'
 # "step simple modifier is exclusive and cannot be use with 'val', 'uval' or 'ref' modifier"
 H61FE9B0F27A0: 'step 簡單修飾符是專屬的，不能與val、uval或ref修飾符併用'
 # 'still within definition of %q0 here'
@@ -26879,17 +26879,17 @@ H892362B1790A: '用以將區塊分割為碎片的策略'
 # 'stress rotate selection in aggressive ppc isel for bit permutations'
 HAC5B66207D31: '在積極的ppc指令選擇中對位元排列進行壓力旋轉選擇'
 # 'strftime format attribute requires 3rd parameter to be 0'
-H48F53118805C: 'strftime 格式特性需要第三個參數為0'
+H48F53118805C: 'strftime 格式特性需要第三個參數為 0'
 # 'stride must be greater or equal to the number of rows'
 H8F8F20EB9F60: '間隔值必須大於或等於列數'
 # 'string is ill-formed as UTF-8 and will become a null %0 when boxed'
-H978281414E51: '此UTF-8格式有誤的字串在封裝後將成為空值%0'
+H978281414E51: '此UTF-8格式有誤的字串在封裝後將成為空值 %0'
 # "string literal after 'operator' cannot have an encoding prefix"
 HE2D46EB90348: '操作符後面的字串字面量不能有編碼前綴'
 # 'string literal after \'operator\' must be \'""\''
 HB2C541BB7B81: '操作符後面的字串字面量必須為空字串""'
 # 'string literal of length %0 exceeds maximum length %1 that %select{C90|ISO C99|C++}2 compilers are required to support'
-H446F1FE51F67: '長度為%0 的字串字面量超過%select{C90|ISO C99|C++}2 編譯器必須支援的最大長度%1'
+H446F1FE51F67: '長度為 %0 的字串字面量超過%select{C90|ISO C99|C++}2 編譯器必須支援的最大長度 %1'
 # 'string literal operator templates are a GNU extension'
 HC7C4AAEBD81D: '字串字面量操作符範本是GNU擴充語法'
 # 'string literal with user-defined suffix cannot be used here'
@@ -27049,9 +27049,9 @@ H9354CE031F68: "目標不支援 'protected' 可見性；使用 'default'"
 # 'target exception specification is not superset of source'
 H14AD31786EFD: '目標例外規格不是來源的超集'
 # 'target function %select{is a member of different class%diff{ (expected $ but has $)|}1,2|has different number of parameters (expected %1 but has %2)|has type mismatch at %ordinal3 parameter%diff{ (expected $ but has $)|}1,2|has different return type%diff{ ($ expected but has $)|}1,2}0'
-HFEFD6F95E799: '目標函數%select{是不同類別的成員%diff{（期望$但有$）|}1,2|參數數量不一致（期望%1 但有%2 個）|第%ordinal3 個參數類型不符%diff{（期望$但有$）|}1,2|回傳類型不同%diff{（期望$但有$）|}1,2}0'
+HFEFD6F95E799: '目標函數%select{是不同類別的成員%diff{（期望$但有$）|}1,2|參數數量不一致（期望 %1 但有 %2 個）|第%ordinal3 個參數類型不符%diff{（期望$但有$）|}1,2|回傳類型不同%diff{（期望$但有$）|}1,2}0'
 # 'target function has calling convention %1 (expected %0)'
-HE7D037C49FE5: '目標函數的呼叫約定為%1（期望%0）'
+HE7D037C49FE5: '目標函數的呼叫約定為 %1（期望 %0）'
 # 'target of using declaration'
 HCB1C9C62D72D: 'using宣告的目標'
 # 'target of using declaration conflicts with declaration already in scope'
@@ -27063,13 +27063,13 @@ H48B3A7876AE7: '基於目標屬性的函數多載不受NVCC支援，將視為函
 # 'tbd'
 H1D9C8AC0B205: 'tbd'
 # 'template %0 has no definition and no %select{|viable }1deduction guides for deduction of template arguments'
-H39A2D17F6485: '模板%0 沒有定義，也%select{找不到|找不到可行的 }1模板參數推導指引'
+H39A2D17F6485: '模板 %0 沒有定義，也%select{找不到|找不到可行的 }1模板參數推導指引'
 # 'template argument / label address difference / what did you expect?'
 H4022196FB5B0: '模板參數/標籤位址差異/你期望的是什麼？'
 # 'template argument does not refer to a class or alias template, or template template parameter'
 H10B27B45B43C: '模板參數未指向類別或別名模板，或模板模板參數'
 # 'template argument for non-type template parameter is treated as function type %0'
-HF7C463216541: '非類型模板參數的模板參數被視為函數類型%0'
+HF7C463216541: '非類型模板參數的模板參數被視為函數類型 %0'
 # 'template argument for non-type template parameter must be an expression'
 HA6F518CB9F6F: '非類型模板參數的模板參數必須是運算式'
 # 'template argument for template template parameter must be a class template%select{| or type alias template}0'
@@ -27077,15 +27077,15 @@ H4605CB1853A3: '模板模板參數的模板參數必須是類別模板%select{|�
 # 'template argument for template type parameter must be a type'
 H9FFBB255FD4F: '模板類型參數的模板參數必須是類型'
 # "template argument for template type parameter must be a type; did you forget 'typename'?"
-H477EE50BCF4B: "模板類型參數的模板參數必須是類型；是否遺忘了'typename'？"
+H477EE50BCF4B: "模板類型參數的模板參數必須是類型；是否遺忘了 'typename'？"
 # "template argument for template type parameter must be a type; omitted 'typename' is a Microsoft extension"
-H0CC2569F4810: "模板類型參數的模板參數必須是類型；遺漏'typename'是Microsoft擴充"
+H0CC2569F4810: "模板類型參數的模板參數必須是類型；遺漏 'typename' 是Microsoft擴充"
 # 'template argument is the type of an unresolved overloaded function'
 H1DDFBAF8CEBB: '模板參數是未解析的多載函數類型'
 # 'template argument refers to function template %0, here'
-H59E0A4B6EEC0: '模板參數引用函數模板%0，位置在此'
+H59E0A4B6EEC0: '模板參數引用函數模板 %0，位置在此'
 # 'template argument uses local type %0'
-H8CFAA5F55F9C: '模板參數使用局部類型%0'
+H8CFAA5F55F9C: '模板參數使用局部類型 %0'
 # 'template argument uses unnamed type'
 H1A9FF29A8094: '模板參數使用未命名類型'
 # 'template declaration from hidden source: %0'
@@ -27129,7 +27129,7 @@ HB5785F1417CF: '模板參數清單的參數數量不同（%0 vs %1）'
 # 'template parameter missing a default argument'
 H5BFE290A5AC0: '模板參數缺少預設參數'
 # "template parameter of a function template with the 'sycl_kernel' attribute cannot be a non-type template parameter"
-H7625BE567F07: "具有'sycl_kernel'屬性之函數模板的模板參數不能是非類型模板參數"
+H7625BE567F07: "具有 'sycl_kernel' 屬性之函數模板的模板參數不能是非類型模板參數"
 # 'template parameter pack cannot have a default argument'
 HD1F9E9063EB7: '模板參數包不能有預設參數'
 # 'template parameter pack must be the last template parameter'
@@ -27139,21 +27139,21 @@ H8C66CF577C62: '模板參數重新定義預設參數'
 # 'template specialization declaration cannot be a friend'
 HA8ECAC04AF8C: '模板特化宣告不能是友元'
 # 'template specialization or definition requires a template parameter list corresponding to the nested type %0'
-HC868EA3957FF: '模板特化或定義需要對應至嵌套類型%0的模板參數清單'
+HC868EA3957FF: '模板特化或定義需要對應至嵌套類型 %0 的模板參數清單'
 # "template specialization requires 'template<>'"
 H1ADEE7A736DF: "模板特化需要使用'template<>'"
 # 'template template argument %0 is more constrained than template template parameter %1'
-HE3F8D9BFA908: '模板模板參數%0比模板模板參數%1更受限'
+HE3F8D9BFA908: '模板模板參數 %0 比模板模板參數 %1 更受限'
 # 'template template argument has different template parameters than its corresponding template template parameter'
 HB7542BD3C1FF: '模板模板參數與其對應的模板模板參數具有不同的模板參數'
 # 'template template parameter must have its own template parameters'
 H2E8B286B021F: '模板模板參數必須有自己的模板參數'
 # "template template parameter requires 'class'%select{| or 'typename'}0 after the parameter list"
-HC7B5002008B5: "模板模板參數需要在參數清單後使用'class'%select{|或'typename'}0"
+HC7B5002008B5: "模板模板參數需要在參數清單後使用 'class'%select{|或 'typename'}0"
 # "template template parameter using 'typename' is a C++17 extension"
-HD13D228AA386: "使用'typename'的模板模板參數是C++17擴充"
+HD13D228AA386: "使用 'typename' 的模板模板參數是C++17擴充"
 # "template template parameter using 'typename' is incompatible with C++ standards before C++17"
-H2724DAD0662B: "使用'typename'的模板模板參數與C++17之前的標準不相容"
+H2724DAD0662B: "使用 'typename' 的模板模板參數與C++17之前的標準不相容"
 # 'templates can only be declared in namespace or class scope'
 H549BBF1A776B: '模板只能在命名空間或類別作用域中宣告'
 # 'templates cannot be declared inside of a local class'
@@ -27165,13 +27165,13 @@ H013054578BC3: '綁定至已分配物件之成員引用的臨時物件將在完�
 # 'temporary created here'
 H6CF924D32FF7: '臨時物件在此處建立'
 # 'temporary of type %0 has %select{private|protected}1 destructor'
-HA776568AF253: '類型為%0的臨時物件具有%select{private|protected}1析構函數'
+HA776568AF253: '類型為 %0 的臨時物件具有 %select{private|protected}1 析構函數'
 # 'tentative array definition assumed to have one element'
 H1578DBDB8944: '假設未定義的陣列定義有單一元素'
 # 'tentative definition has type %0 that is never completed'
-H2533423DBC92: '未定義的定義具有從未完成的類型%0'
+H2533423DBC92: '未定義的定義具有從未完成的類型 %0'
 # 'tentative definition of variable with internal linkage has incomplete non-array type %0'
-H137EE1AFC5D6: '具有內部綁定的變數的未定義定義具有不完整的非陣列類型%0'
+H137EE1AFC5D6: '具有內部綁定的變數的未定義定義具有不完整的非陣列類型 %0'
 # 'tenths of percents of main entry frequency to use as a threshold when evaluating whether a basic block is cold (0 means it is only considered cold if the block has zero samples). Default: 0 '
 HB4A505AFFDA6: '在評估基本區塊是否為冷區塊時，用作閾值的主入口頻率的十分之一百分比（0表示僅當區塊的樣本為零時才視為冷區塊）。預設值：0 '
 # "test module file extension '%0' has different version (%1.%2) than expected (%3.%4)"
@@ -27179,13 +27179,13 @@ HD419260C8BE7: "測試模組檔案擴充名 '%0' 的版本 (%1.%2) 與期望的 
 # 'the #__include_macros directive is only for internal use by -imacros'
 H1FBDC6FD510E: '#__include_macros 指令僅供 -imacros 內部使用'
 # 'the %0 sub-architecture does not support unaligned accesses'
-H8EEF78B6F581: '子架構%0不支援未對齊的存取'
+H8EEF78B6F581: '子架構 %0 不支援未對齊的存取'
 # 'the %0 type cannot be used to declare a program scope variable'
-HCC2A02E45E01: '類型%0無法用於宣告程式的全域變數'
+HCC2A02E45E01: '類型 %0 無法用於宣告程式的全域變數'
 # 'the %0 type cannot be used to declare a structure or union field'
-H3AA824360E4A: '類型%0無法用於宣告結構或共用體的成員'
+H3AA824360E4A: '類型 %0 無法用於宣告結構或共用體的成員'
 # 'the %select{1st|2nd|3rd}1 template parameter of %0 needs to be %select{a type|an integer or enum value}2'
-HC15D25E5BA46: '模板%0的%select{第1個|第2個|第3個}1參數需要是%select{類型|整數或枚舉值}2'
+HC15D25E5BA46: '模板 %0 的%select{第 1 個|第 2 個|第 3 個}1參數需要是%select{類型|整數或枚舉值}2'
 # 'the %select{function or variable|function}0 specified in an %select{alias|ifunc}1 must refer to its mangled name'
 H2A963C3F164E: '在%select{別名|ifunc}1中指定的%select{函數或變數|函數}0必須引用其裝飾名稱'
 # "the %select{message|string}0 object in %select{this static assertion|this asm operand}0 is missing %select{a 'size()' member function|a 'data()' member function|'data()' and 'size()' member functions}1"
@@ -27197,9 +27197,9 @@ H831B25ED6E8C: "在HLSL中不支援'%select{&|*|->}0'運算子"
 # "the '[[_Noreturn]]' attribute spelling is deprecated in C23; use '[[noreturn]]' instead"
 H584C1C164ECE: "在C23中，'[[_Noreturn]]'屬性拼寫已棄用；請改用'[[noreturn]]'"
 # "the 'copyprivate' clause must not be used with the 'nowait' clause"
-H026F61D558F6: "不能將'copyprivate'子句與'nowait'子句一起使用"
+H026F61D558F6: "不能將 'copyprivate' 子句與 'nowait' 子句一起使用"
 # "the 'static' modifier for the array size is not legal in new expressions"
-H285525BB6E11: "在new運算式中，陣列大小的'static'修飾符不合法"
+H285525BB6E11: "在new運算式中，陣列大小的 'static' 修飾符不合法"
 # "the ApplicationExtensionSafe flag does not match: '%0' (provided) vs '%1' (found)"
 H74ECAC68920E: "ApplicationExtensionSafe旗標不相符：提供的'%0'對比找到的'%1'"
 # 'the GNU address of label extension is not allowed in coroutines'
@@ -27287,7 +27287,7 @@ H1067F4A3FF41: '執行的模式'
 # 'the name of the PDB file to write'
 H3B634F1D4C6F: '要寫入的PDB檔名稱'
 # "the name of the construct must be specified in presence of 'hint' clause"
-HF664729B6FC3: "存在'hint'子句時，該結構的名稱必須指定"
+HF664729B6FC3: "存在 'hint' 子句時，該結構的名稱必須指定"
 # 'the number of preprocessor source tokens (%0) exceeds this token limit (%1)'
 H205DE1F2F79F: '預處理器源代碼標記 (%0) 的數量超過此標記限制 (%1)'
 # 'the object size sanitizer has no effect at -O0, but is explicitly enabled: %0'
@@ -27321,7 +27321,7 @@ H10756E8D2178: '提供的選擇與感興趣的AST節點無交集'
 # 'the referenced item is not found in any private clause on the same directive'
 HBDA357C86E91: '在相同的指令中未找到任何私有子句中的所引用項目'
 # "the result of a delegate init call must be immediately returned or assigned to 'self'"
-HA6A6824B2746: "代理初始化調用的結果必須立即返回或賦值給'self'"
+HA6A6824B2746: "代理初始化調用的結果必須立即返回或賦值給 'self'"
 # 'the resulting value is always non-negative after implicit conversion'
 H9908ECBF3885: '隱式轉換後的結果值始終為非負數'
 # "the second argument of '-fpatchable-function-entry' must be smaller than the first argument"
@@ -27335,7 +27335,7 @@ HEFB1186DBBA0: '所選的表示式過於簡單而無法提取'
 # 'the semantics of this intrinsic changed with GCC version 4.4 - the newer semantics are provided here'
 H1D55F6813757: '此內建函數的語意自GCC 4.4版本起有所改變，這裡提供的是較新的語意'
 # 'the sign of a  flushed-to-zero number is preserved in the sign of 0'
-HE7436E3F21CE: '被沖刷至零的數值的符號會在0的符號中保留'
+HE7436E3F21CE: '被沖刷至零的數值的符號會在 0 的符號中保留'
 # 'the specified comparator type does not provide a viable const call operator'
 H327A107A2A90: '指定的比較器類型未提供有效的const呼叫運算子'
 # 'the specified hash functor does not provide a viable const call operator'
@@ -27347,9 +27347,9 @@ H0E1E5BD56218: "'atomic capture'的語句必須是符合以下形式的複合語
 # "the statement for 'atomic capture' must be an expression statement of form 'v = ++x;', 'v = --x;', 'v = x++;', 'v = x--;', 'v = x binop= expr;', 'v = x = x binop expr' or 'v = x = expr binop x', where x and v are both lvalue expressions with scalar type"
 H47D428195CE9: "'atomic capture'的語句必須是符合以下形式的表示式語句：'v = ++x;'、'v = --x;'、'v = x++;'、'v = x--;'、'v = x binop= expr;'、'v = x = x binop expr' 或 'v = x = expr binop x'，其中x和v都是具有純量類型的左值運算式"
 # "the statement for 'atomic compare capture' must be a compound statement of form '{v = x; cond-up-stmt}', ''{cond-up-stmt v = x;}', '{if(x == e) {x = d;} else {v = x;}}', '{r = x == e; if(r) {x = d;}}', or '{r = x == e; if(r) {x = d;} else {v = x;}}', where 'cond-update-stmt' can have one of the following forms: 'if(expr ordop x) {x = expr;}', 'if(x ordop expr) {x = expr;}', 'if(x == e) {x = d;}', or 'if(e == x) {x = d;}' where 'x', 'r', and 'v' are lvalue expressions with scalar type, 'expr', 'e', and 'd' are expressions with scalar type, and 'ordop' is one of '<' or '>'"
-H09C6A6DB560B: "'atomic compare capture'的語句必須是符合以下形式的複合語句：'{v = x; cond-up-stmt}'、''{cond-up-stmt v = x;}'、'{if(x == e) {x = d;} else {v = x;}}'、'{r = x == e; if(r) {x = d;}}' 或 '{r = x == e; if(r) {x = d;} else {v = x;}}'，其中'cond-update-stmt'可以是以下其中一種形式：'if(expr ordop x) {x = expr;}'、'if(x ordop expr) {x = expr;}'、'if(x == e) {x = d;}' 或 'if(e == x) {x = d;}'，其中'x'、'r'、'v'是具有純量類型的左值運算式，'expr'、'e'、'd'是具有純量類型的運算式，且'ordop'是'<'或'>'中的一種"
+H09C6A6DB560B: "'atomic compare capture'的語句必須是符合以下形式的複合語句：'{v = x; cond-up-stmt}'、''{cond-up-stmt v = x;}'、'{if(x == e) {x = d;} else {v = x;}}'、'{r = x == e; if(r) {x = d;}}' 或 '{r = x == e; if(r) {x = d;} else {v = x;}}'，其中'cond-update-stmt'可以是以下其中一種形式：'if(expr ordop x) {x = expr;}'、'if(x ordop expr) {x = expr;}'、'if(x == e) {x = d;}' 或 'if(e == x) {x = d;}'，其中 'x'、'r'、'v' 是具有純量類型的左值運算式，'expr'、'e'、'd' 是具有純量類型的運算式，且 'ordop' 是'<'或'>'中的一種"
 # "the statement for 'atomic compare' must be a compound statement of form '{x = expr ordop x ? expr : x;}', '{x = x ordop expr? expr : x;}', '{x = x == e ? d : x;}', '{x = e == x ? d : x;}', or 'if(expr ordop x) {x = expr;}', 'if(x ordop expr) {x = expr;}', 'if(x == e) {x = d;}', 'if(e == x) {x = d;}' where 'x' is an lvalue expression with scalar type, 'expr', 'e', and 'd' are expressions with scalar type, and 'ordop' is one of '<' or '>'"
-H4091D9BED6D2: "'atomic compare'的語句必須是符合以下形式的複合語句：'{x = expr ordop x ? expr : x;}'、'{x = x ordop expr? expr : x;}'、'{x = x == e ? d : x;}'、'{x = e == x ? d : x;}'、'if(expr ordop x) {x = expr;}'、'if(x ordop expr) {x = expr;}'、'if(x == e) {x = d;}' 或 'if(e == x) {x = d;}'，其中'x'是具有純量類型的左值運算式，'expr'、'e'、'd'是具有純量類型的運算式，且'ordop'是'<'或'>'中的一種"
+H4091D9BED6D2: "'atomic compare'的語句必須是符合以下形式的複合語句：'{x = expr ordop x ? expr : x;}'、'{x = x ordop expr? expr : x;}'、'{x = x == e ? d : x;}'、'{x = e == x ? d : x;}'、'if(expr ordop x) {x = expr;}'、'if(x ordop expr) {x = expr;}'、'if(x == e) {x = d;}' 或 'if(e == x) {x = d;}'，其中 'x' 是具有純量類型的左值運算式，'expr'、'e'、'd' 是具有純量類型的運算式，且 'ordop' 是'<'或'>'中的一種"
 # "the statement for 'atomic read' must be an expression statement of form 'v = x;', where v and x are both lvalue expressions with scalar type"
 HDAD21CA5AD66: "'atomic read'的語句必須是符合以下形式的表示式語句：'v = x;'，其中v和x都是具有純量類型的左值運算式"
 # "the statement for 'atomic update' must be an expression statement of form '++x;', '--x;', 'x++;', 'x--;', 'x binop= expr;', 'x = x binop expr' or 'x = expr binop x', where x is an lvalue expression with scalar type"
@@ -27593,11 +27593,11 @@ H22C1DF007CBE: '遞迴使用 %0 當作 %1 的超類別'
 # 'turn on the stoke analysis'
 H0C2490B9B2A0: '啟用 stoke 分析'
 # 'type %0 can only be used as a function parameter in OpenCL'
-H43CCACC05DF1: '無法分解類型%0'
+H43CCACC05DF1: '無法分解類型 %0'
 # 'type %0 cannot be decomposed'
 HAD575CEF4CDD: '類型 %0 無法分解'
 # 'type %0 cannot be narrowed to %1 in initializer list'
-HA66630D471E5: 'C++11的初始化清單中無法將類型%0窄化為%1'
+HA66630D471E5: 'C++11的初始化清單中無法將類型 %0 窄化為 %1'
 # 'type %0 cannot be narrowed to %1 in initializer list in C++11'
 H121C0CF66257: '類型 %0 無法在初始化清單中窄化為 %1（C++11）'
 # "type %0 cannot be used prior to '::' because it has no members"
@@ -27717,7 +27717,7 @@ HFF5B8C2A68FC: '在此處宣告的類型參數 %0'
 # "type specifier missing, defaults to 'int'"
 H4B268E82A57A: "類型指定項遺失，預設為 'int'"
 # "type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int"
-H8CEE1B0F6CB9: "類型指定者遺失，預設為'int'; ISO C99 及更新版本不支援隱式 int"
+H8CEE1B0F6CB9: "類型指定者遺失，預設為 'int'; ISO C99 及更新版本不支援隱式 int"
 # 'type trait requires %0%select{| or more}1 argument%select{|s}2; have %3 argument%s3'
 H5F2DEBC2DD6F: '類型特性需要 %0%select{|或更多}1 個參數%select{|s}2; 獲得 %3 個參數'
 # 'type was declared read-only here'
@@ -27849,7 +27849,7 @@ H85486A35A143: "未具體說明的 friend 宣告是 C++11 的擴充功能；請�
 # 'unexpected %0 in function call; perhaps remove the %0?'
 HF91D5DDAC941: '函數呼叫中出現意外的 %0；或許移除 %0？'
 # "unexpected %0, expected to see one of %select{|'best_case', 'full_generality', }1'single_inheritance', 'multiple_inheritance', or 'virtual_inheritance'"
-H715E4C7A8362: "意外的%0，期望下列其中一個：%select{|'best_case', 'full_generality', }1'single_inheritance', 'multiple_inheritance'或'virtual_inheritance'"
+H715E4C7A8362: "意外的 %0，期望下列其中一個：%select{|'best_case', 'full_generality', }1'single_inheritance', 'multiple_inheritance' 或 'virtual_inheritance'"
 # "unexpected '#pragma acc ...' in program"
 H1E1E01704393: "程式中出現意外的 '#pragma acc ...'"
 # "unexpected '#pragma omp ...' in program"
@@ -27911,9 +27911,9 @@ HD169A0238D64: "#pragma clang optimize 意外多出參數 '%0'"
 # 'unexpected extra tokens at end of @import declaration'
 HC94D2D8555A6: '@import 宣告結尾處有多餘的語法單元'
 # 'unexpected interface name %0: expected expression'
-HD34771026F11: '意外的介面名稱%0：期望運算式'
+HD34771026F11: '意外的介面名稱 %0：期望運算式'
 # 'unexpected namespace name %0: expected expression'
-HD2F7F8269F1D: '意外的命名空間名稱%0：期望運算式'
+HD2F7F8269F1D: '意外的命名空間名稱 %0：期望運算式'
 # 'unexpected namespace scope prior to decltype'
 H276642EE3F52: 'decltype 之前的命名空間作用域不合法'
 # "unexpected operation specified in 'append_args' clause, expected 'interop'"
@@ -27927,9 +27927,9 @@ H279452517A7B: 'Objective-C 字串後出現 unexpected token'
 # 'unexpected token in pragma diagnostic'
 HF7F8BD94B55D: 'pragma diagnostic 中出現 unexpected token'
 # 'unexpected type name %0: expected expression'
-H5096D6005D2D: '意外的類型名稱%0：期望運算式'
+H5096D6005D2D: '意外的類型名稱 %0：期望運算式'
 # 'unexpected type name %0: expected identifier'
-HECE4BA85049C: '意外的類型名稱%0：期望識別符'
+HECE4BA85049C: '意外的類型名稱 %0：期望識別符'
 # "unexpected value; use 'true' or 'false'"
 HBC54A5A54D19: "unexpected 值；請使用 'true' 或 'false'"
 # 'unguarded header; consider using #ifdef guards or #pragma once'
@@ -28491,33 +28491,33 @@ HD69F3507E82F: '使用嚴格的DWARF'
 # 'use stricter verifier for HLFIR intrinsic operations'
 H7296989D6AE9: '對HLFIR內建運算使用更嚴格的驗證器'
 # "use the GNU '__attribute__' syntax"
-H7DBF5BB23C34: '使用GNU "__attribute__"語法'
+H7DBF5BB23C34: '使用GNU "__attribute__" 語法'
 # 'used here'
 H1359FF249380: '在此處使用'
 # 'used in initialization here'
 H9614905D4DE2: '在此處初始化時使用'
 # 'used type %0 where __hlsl_resource_t is required'
-HB0299AD4C891: '在需要__hlsl_resource_t的地方使用了類型%0'
+HB0299AD4C891: '在需要__hlsl_resource_t的地方使用了類型 %0'
 # 'used type %0 where arithmetic or pointer type is required'
-HEF054774D419: '在需要算術或指針類型的地方使用了類型%0'
+HEF054774D419: '在需要算術或指針類型的地方使用了類型 %0'
 # 'used type %0 where floating point type is not allowed'
-HF095E0FB08EE: '在不允許浮點類型的地方使用了類型%0'
+HF095E0FB08EE: '在不允許浮點類型的地方使用了類型 %0'
 # 'used type %0 where integer is required'
-HCD053F3A5F86: '在需要整數類型的地方使用了類型%0'
+HCD053F3A5F86: '在需要整數類型的地方使用了類型 %0'
 # 'used type %0 where integer or floating point type is required'
-H46DF1623ED73: '在需要整數或浮點類型的地方使用了類型%0'
+H46DF1623ED73: '在需要整數或浮點類型的地方使用了類型 %0'
 # 'used%select{| in pointer arithmetic| in buffer access}0 here'
 H2D0FA9F859F9: '在此處%select{|在指標運算|在緩衝區存取}0使用'
 # "user-defined literal suffixes %select{<ERROR>|not starting with '_'|containing '__'}0 are reserved%select{; no literal will invoke this operator|}1"
-H414028466FC2: '用戶定義的字面量後綴%select{<ERROR>|未以"_"開頭|包含"__"}0被保留%select{；沒有字面量會調用此運算符|}1'
+H414028466FC2: '用戶定義的字面量後綴%select{<ERROR>|未以 "_" 開頭|包含 "__"}0被保留%select{；沒有字面量會調用此運算符|}1'
 # 'using'
 H92BD75EBD8FD: '使用'
 # 'using %0 directive in %select{NSString|CFString}1 which is being passed as a formatting argument to the formatting %select{method|CFfunction}2'
-HFA21A8452E12: '在%select{NSString|CFString}1中使用%0指令，該指令被用作格式化%select{方法|CF函數}2的格式化參數'
+HFA21A8452E12: '在 %select{NSString|CFString}1 中使用 %0 指令，該指令被用作格式化%select{方法|CF函數}2的格式化參數'
 # 'using %0 with a literal is redundant'
-HA26F40AA0176: '與字面量一起使用%0是冗餘的'
+HA26F40AA0176: '與字面量一起使用 %0 是冗餘的'
 # 'using %select{integer|floating point|complex}1 absolute value function %0 when argument is of %select{integer|floating point|complex}2 type'
-H2A1C61EF88A1: '當參數為%select{整數|浮點|複數}2類型時，使用%select{整數|浮點|複數}1絕對值函數%0'
+H2A1C61EF88A1: '當參數為%select{整數|浮點|複數}2類型時，使用%select{整數|浮點|複數}1絕對值函數 %0'
 # "using '%%P' format specifier with an Objective-C pointer results in dumping runtime object structure, not object value"
 H513C1ECC12E7: "在Objective-C指針中使用'%%P'格式說明符將會傾印執行階段物件結構，而不是物件值"
 # "using '%%P' format specifier without precision"
@@ -28573,9 +28573,9 @@ H23CBFE9436FA: "正在使用'%0'的sysroot，但目標為'%1'"
 # 'using the result of an assignment as a condition without parentheses'
 HD808A1E3A9FB: '在條件中使用賦值運算的結果但未使用括號'
 # 'using the undeclared type %0 as a default template argument is a Microsoft extension'
-H9BAAEE7535FA: '將未宣告的類型%0用作預設模板參數是Microsoft擴充功能'
+H9BAAEE7535FA: '將未宣告的類型 %0 用作預設模板參數是Microsoft擴充功能'
 # 'using unversioned Android target directory %0 for target %1; unversioned directories will not be used in Clang 19 -- provide a versioned directory for the target version or lower instead'
-H120D3110B47A: '為目標%1使用未指定版本的Android目標目錄%0；Clang 19將不再使用未指定版本的目錄——請為目標版本提供已指定版本的目錄或使用較低版本'
+H120D3110B47A: '為目標 %1 使用未指定版本的Android目標目錄 %0；Clang 19將不再使用未指定版本的目錄——請為目標版本提供已指定版本的目錄或使用較低版本'
 # 'using-enum cannot name a dependent type'
 H3DC57F2168E8: 'using-enum不能命名依賴類型'
 # 'usual LSP protocol'
@@ -28585,19 +28585,19 @@ H1FAF5254B686: 'UUID屬性包含格式錯誤的GUID'
 # 'uuid does not match previous declaration'
 H1E8E115FA4D8: 'UUID與之前的宣告不相符'
 # 'valid %0 clauses start with %1; %select{token|tokens}2 will be ignored'
-HA977999237FF: '有效的%0子句以%1開頭；%select{詞彙|詞彙們}2將被忽略'
+HA977999237FF: '有效的 %0 子句以 %1 開頭；%select{詞彙|詞彙們}2將被忽略'
 # 'valid target CPU values are: %0'
 HB573A028A656: '有效的目標CPU值為：%0'
 # 'value %0 is outside the range of representable values of type %1'
-H76B206381D68: '值%0超出類型%1可表示的範圍'
+H76B206381D68: '值 %0 超出類型 %1 可表示的範圍'
 # 'value %1 cannot be represented in type %0'
-H0FCCEC09B538: '值%1無法以類型%0表示'
+H0FCCEC09B538: '值 %1 無法以類型 %0 表示'
 # "value '%0' out of range for constraint '%1'"
 H2964C78586A1: "值'%0'超出約束'%1'的範圍"
 # 'value is not an integer: %0'
 HDF6724275715: '值不是整數：%0'
 # 'value of #pragma pack(show) == %0'
-H78F0B6172824: '#pragma pack(show)的值等於%0'
+H78F0B6172824: '#pragma pack(show)的值等於 %0'
 # 'value of the aligned pointer (%0) is not a multiple of the asserted %1 %plural{1:byte|:bytes}1'
 HCBC69FE1B218: '對齊指標 (%0) 的值不是聲稱的 %1 %plural{1:位元組|:位元組}1 的倍數'
 # "value of type %0 is not contextually convertible to 'bool'"
@@ -28775,7 +28775,7 @@ H82A01F59E7E3: "在 '#pragma omp declare variant' 中宣告的變體函數本身
 # "variant in '#pragma omp declare variant' is the same as the base function"
 HEC73C56687BA: "在 '#pragma omp declare variant' 中的變體與基底函數相同"
 # "variant in '#pragma omp declare variant' with type %0 is incompatible with type %1%select{| with appended arguments}2"
-H443E0ACFD62A: '#pragma omp declare variant中類型為%0的變體與%1%select{|加上附加參數}2的類型不相容'
+H443E0ACFD62A: '#pragma omp declare variant中類型為 %0 的變體與 %1%select{|加上附加參數}2的類型不相容'
 # 'vector component access exceeds type %0'
 HA6E77B2F0A3C: '向量元件存取超出類型 %0 的範圍'
 # 'vector component access has invalid length %0; supported lengths are: 1,2,3,4,8,16'
@@ -28799,7 +28799,7 @@ HBD47DE4A7313: '向量條件運算子的向量操作數必須為相同類型 %di
 # 'vector size not an integral multiple of component size'
 H77E12186A8E0: '向量大小不是元件大小的整數倍數'
 # "vectorize_width loop hint malformed; use vectorize_width(X, fixed) or vectorize_width(X, scalable) where X is an integer, or vectorize_width('fixed' or 'scalable')"
-H52976DB4C3C0: "vectorize_width循環提示格式錯誤；請使用vectorize_width(X, fixed)或vectorize_width(X, scalable)，其中X為整數，或vectorize_width('fixed'或'scalable')"
+H52976DB4C3C0: "vectorize_width循環提示格式錯誤；請使用vectorize_width(X, fixed)或vectorize_width(X, scalable)，其中X為整數，或vectorize_width('fixed' 或 'scalable')"
 # "vendor '%0' is not supported: '%1'"
 HEF7F8EFDE1D2: "供應商'%0'不受支援：%1"
 # 'verbose'
@@ -28829,7 +28829,7 @@ H346B24B0B01F: '版本列表包含對程式碼生成無影響的條目'
 # 'version number must have non-zero major, minor, or sub-minor version'
 H32D5C8ECFF2D: '版本號必須有非零的主要、次要或次次要版本'
 # 'violations found for %0'
-HC357EBB7E4D0: '在%0中發現違規項目'
+HC357EBB7E4D0: '在 %0 中發現違規項目'
 # 'virtual base class declared here'
 H2738AB0FED80: '在此處宣告虛基類'
 # 'virtual constexpr functions are incompatible with C++ standards before C++20'
@@ -28893,13 +28893,13 @@ H22A978739C8D: '弱識別符 %0 永未宣告'
 # 'weakref declaration must have internal linkage'
 H8016E3683340: 'weakref宣告必須具有內部連結性'
 # 'weakref declaration of %0 must also have an alias attribute'
-H101799E65B31: '%0的weakref宣告還必須具有別名屬性'
+H101799E65B31: '%0 的weakref宣告還必須具有別名屬性'
 # 'weakref declaration of %0 must be in a global context'
-HDA1EB6DAD24A: '%0的weakref宣告必須在全域環境中'
+HDA1EB6DAD24A: '%0 的weakref宣告必須在全域環境中'
 # 'webassembly: disables the fix  irreducible control flow optimization pass'
 HA0B81E145B1D: 'webassembly：禁用修正不可簡化控制流優化pass'
 # 'when a function is considered for merging into a partition that already contains some of its callees, do the merge if at least n% of the code it can reach is already present inside the partition; e.g. 0.7 means only merge >70%'
-HB679EAE1AA06: '當一個函數被考慮合併到已經包含其部分被呼叫函數的區塊時，如果至少有n%的可達代碼已經存在於該區塊中，則進行合併；例如0.7表示僅合併>70%'
+HB679EAE1AA06: '當一個函數被考慮合併到已經包含其部分被呼叫函數的區塊時，如果至少有n%的可達代碼已經存在於該區塊中，則進行合併；例如 0.7表示僅合併>70%'
 # 'when applied to this declaration'
 HA6DB04448955: '當應用於此宣告時'
 # 'when deciding to split a function, apply this alignment while doing the size comparison (see -split-threshold). Default value: 2.'
@@ -28911,7 +28911,7 @@ H9F7ED2DB900A: '當由類別 %0 實作時'
 # "when looking up '%select{begin|end}0' function for range expression of type %1"
 HC4C870329421: '在為類型 %1 的區間運算式尋找 %select{begin|end}0 函數時'
 # 'when max depth is reached and we can no longer branch out, this value determines if a function is worth merging into an already existing partition to reduce code duplication. This is a factor of the ideal partition size, e.g. 2.0 means we consider the function for merging if its cost (including its callees) is 2x the size of an ideal partition.'
-HC50D6FBB78F2: '當最大深度達到且我們無法再分支時，此值決定了函數是否值得合併到已存在的區塊以減少代碼重複。這是理想區塊大小的因子，例如2.0表示如果函數的代價（包括其被呼叫函數）是理想區塊大小的2倍，則考慮進行合併。'
+HC50D6FBB78F2: '當最大深度達到且我們無法再分支時，此值決定了函數是否值得合併到已存在的區塊以減少代碼重複。這是理想區塊大小的因子，例如 2.0表示如果函數的代價（包括其被呼叫函數）是理想區塊大小的 2 倍，則考慮進行合併。'
 # 'when possible, poison scoped variables at the beginning of the scope (slower, but more precise)'
 H00AA44541919: '在可能的情況下，從作用域的開頭毒化作用域變數（較慢，但更精確）'
 # 'when repeating the instruction snippet by looping over it, duplicate the snippet until the loop body contains at least this many instruction'
@@ -28925,27 +28925,27 @@ HF9F26A96F310: '要執行的gadget掃描器'
 # 'while building implicit deduction guide first needed here'
 HD4658CE20D59: '在建立隱含的推導指引時，首先需要在此處'
 # 'while calculating associated constraint of template %0 here'
-HD4CBA036E98A: '在計算模板%0的相關約束時'
+HD4CBA036E98A: '在計算模板 %0 的相關約束時'
 # 'while checking a default template argument used here'
 H7E4F64D4A848: '在檢查在此處使用的預設模板參數時'
 # "while checking constraint satisfaction for class template partial specialization '%0' required here"
-H190F26B4DB43: '在檢查類模板部分特化%0的約束滿足情況時，需要在此處'
+H190F26B4DB43: '在檢查類模板部分特化 %0 的約束滿足情況時，需要在此處'
 # "while checking constraint satisfaction for function '%0' required here"
-H1A3A707B1D73: '在檢查函數%0的約束滿足情況時，需要在此處'
+H1A3A707B1D73: '在檢查函數 %0 的約束滿足情況時，需要在此處'
 # "while checking constraint satisfaction for template '%0' required here"
-H19BE8EB0741D: '在檢查模板%0的約束滿足情況時，需要在此處'
+H19BE8EB0741D: '在檢查模板 %0 的約束滿足情況時，需要在此處'
 # "while checking constraint satisfaction for variable template partial specialization '%0' required here"
-HD73CEE0E62DB: '在檢查變數模板部分特化%0的約束滿足情況時，需要在此處'
+HD73CEE0E62DB: '在檢查變數模板部分特化 %0 的約束滿足情況時，需要在此處'
 # "while checking implicit 'delete this' for virtual destructor"
 H738DE49AA679: "在檢查虛函數析構函數的隱含'delete this'時"
 # "while checking the satisfaction of concept '%0' requested here"
-HE2FF74B26A28: '在檢查在此處請求的概念%0的滿足情況時'
+HE2FF74B26A28: '在檢查在此處請求的概念 %0 的滿足情況時'
 # 'while checking the satisfaction of nested requirement requested here'
 HE3D634694184: '在檢查在此處請求的嵌套需求的滿足情況時'
 # "while declaring the corresponding implicit 'operator==' for this defaulted 'operator<=>'"
 H332A7297AC58: "在為此預設的'operator<=>'宣告對應的隱含'operator=='時"
 # 'while declaring the implicit %select{default constructor|copy constructor|move constructor|copy assignment operator|move assignment operator|destructor}1 for %0'
-HAC5877F575DC: '在為%0宣告隱含的%select{預設建構函數|複製建構函數|移動建構函數|複製指定運算子|移動指定運算子|析構函數}1時'
+HAC5877F575DC: '在為 %0 宣告隱含的%select{預設建構函數|複製建構函數|移動建構函數|複製指定運算子|移動指定運算子|析構函數}1時'
 # 'while loop has empty body'
 H374FEF617D4F: 'while迴圈的身體為空'
 # 'while loop outside of a function'
@@ -28963,7 +28963,7 @@ H154EA9F3EDC1: '在這裡替換 lambda 表達式時'
 # 'while substituting into concept arguments here; substitution failures not allowed in concept arguments'
 HAC706623FF86: '在此處替換概念參數時；概念參數不允許替換失敗'
 # 'while substituting prior template arguments into %select{non-type|template}0 template parameter%1 %2'
-HF0EDCF82D09D: '在將先前模板參數替換到 %select{非類型|模板}0 模板參數%1 %2 時'
+HF0EDCF82D09D: '在將先前模板參數替換到 %select{非類型|模板}0 模板參數 %1 %2 時'
 # 'while substituting template arguments into constraint expression here'
 H19C71987DC07: '在將模板參數替換到約束表達式時'
 # 'whitespace is not allowed in parameter passing direction'

--- a/scripts/zh_formatter.py
+++ b/scripts/zh_formatter.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: MIT License
+# Copyright (c) 2025 Yingwei Zheng
+# This file is licensed under the MIT License.
+# See the LICENSE file for more information.
+
+import re
+import argparse
+import os
+import shutil
+from pathlib import Path
+
+CHINESE_CHAR = r"[\u4e00-\u9fa5]"
+ASCII_CHAR = r"[\x20-\x7E]"
+NON_SPACE_ASCII_CHAR = r"[\x00-\x1F\x21-\x7F]"
+ALPHA_DIGIT = r"[_a-zA-Z0-9]"
+ADD_SPACE_BETWEEN_TWO_GROUPS = r"\1 \2"
+
+"""
+SPACE_MUST_BETWEEN = [ (ptn1, ptn2), ...]
+records the list of (ptn1, ptn2) that must have a space between them.
+"""
+SPACE_MUST_BETWEEN = [
+    (CHINESE_CHAR, r"%\d+"),
+    (CHINESE_CHAR, rf"\'{ASCII_CHAR}+\'"),
+    (CHINESE_CHAR, rf"\"{ASCII_CHAR}+\""),
+    (CHINESE_CHAR, rf"<{ASCII_CHAR}+>"),
+]
+
+"""
+RULES = [(<regex_pattern>, <replacement_pattern>), ...]
+"""
+RULES = (
+    [
+        # %select{...} and %diff{...} with leading ASCII letters
+        (rf"({CHINESE_CHAR})(%\w+?\{{{NON_SPACE_ASCII_CHAR})", ADD_SPACE_BETWEEN_TWO_GROUPS),
+        # %select{...ascii}0汉字
+        (rf"(%select\{{.*?{NON_SPACE_ASCII_CHAR}\}}\d+)({CHINESE_CHAR})", ADD_SPACE_BETWEEN_TWO_GROUPS),
+        # %diff{...ascii}0,1汉字
+        (rf"(%diff\{{.*?{NON_SPACE_ASCII_CHAR}\}}\d+,\d+)({CHINESE_CHAR})", ADD_SPACE_BETWEEN_TWO_GROUPS),
+        # 汉字123
+        (rf"({CHINESE_CHAR})(\d+)", ADD_SPACE_BETWEEN_TWO_GROUPS),
+        # 123汉字 ()
+        (rf"( \d+)({CHINESE_CHAR})", ADD_SPACE_BETWEEN_TWO_GROUPS),
+        (rf"({CHINESE_CHAR}\d+)({CHINESE_CHAR})", ADD_SPACE_BETWEEN_TWO_GROUPS),
+    ]
+    + [
+        (rf"({ptn1})({ptn2})", ADD_SPACE_BETWEEN_TWO_GROUPS)
+        for ptn1, ptn2 in SPACE_MUST_BETWEEN
+    ]
+    + [
+        (rf"({ptn2})({ptn1})", ADD_SPACE_BETWEEN_TWO_GROUPS)
+        for ptn1, ptn2 in SPACE_MUST_BETWEEN
+    ]
+)
+
+
+def format_text(text: str, verbose=False):
+    """Apply Chinese text formatting rules using regex substitutions."""
+    for pattern, replacement in RULES:
+        # re.ASCII flag let {ASCII_CHAR} does not match non-ASCII characters
+        new_text = re.sub(pattern, replacement, text, flags=re.ASCII)
+        if new_text != text and verbose:
+            print(f"Applied rule: {pattern} -> {replacement}")
+            print(f"\tOriginal : {text}")
+            print(f"\tNew      : {new_text}")
+        text = new_text
+    return text
+
+
+def process_input(content: str, args: argparse.ArgumentParser):
+    """Process input content with formatting and optional verbose output."""
+    formatted = format_text(content, args.verbose)
+    return formatted
+
+
+def main():
+    """Main function with argument parsing and processing logic."""
+    parser = argparse.ArgumentParser(
+        description="Chinese Text Formatting Tool",
+        formatter_class=argparse.RawTextHelpFormatter,
+        epilog="Usage Examples:\n"
+        "  Process file:   %this_script -i input.txt -o output.txt\n"
+        "  In-place edit:  %this_script -i input.txt --inplace\n"
+        '  Process string: %this_script -s "%select{abc}2中文"\n'
+        "  Print to stdout:   %this_script -i input.txt -v\n"
+        "  Verbose mode:   %this_script -i input.txt -v",
+    )
+
+    # Input group (mutually exclusive)
+    input_group = parser.add_mutually_exclusive_group(required=True)
+    input_group.add_argument("-i", "--input", help="Input file path")
+    input_group.add_argument("-s", "--string", help="Process string directly")
+
+    # Output options
+    output_group = parser.add_argument_group("Output Options")
+    output_group.add_argument("-o", "--output", help="Output file path")
+    output_group.add_argument(
+        "--inplace",
+        action="store_true",
+        help="Modify input file in-place (with backup)",
+    )
+
+    # Additional options
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show verbose processing information",
+    )
+    parser.add_argument(
+        "--backup-ext", default=".bak", help="Backup file extension (default: .bak)"
+    )
+
+    args = parser.parse_args()
+
+    # Argument validation
+    if args.inplace and not args.input:
+        parser.error("--inplace requires -i/--input")
+    if args.output and args.inplace:
+        parser.error("Cannot use both --output and --inplace")
+
+    # Process content
+    try:
+        # Handle string input
+        if args.string:
+            result = process_input(args.string, args)
+            print("Formatted Result:".ljust(20, "="))
+            print(result)
+            return
+
+        # Handle file input
+        in_file = Path(args.input)
+        if not in_file.exists():
+            raise FileNotFoundError(f"Input file not found: {args.input}")
+
+        content = in_file.read_text(encoding="utf-8")
+
+        formatted = process_input(content, args)
+
+        # Handle output destination
+        if args.inplace:
+            backup_file = args.input + args.backup_ext
+            shutil.copy2(args.input, backup_file)
+            if args.verbose:
+                print(f"Created backup file: {backup_file}")
+            in_file.write_text(formatted, encoding="utf-8")
+            print(f"Successfully modified: {args.input}")
+
+        elif args.output:
+            out_file = Path(args.output)
+            out_file.parent.mkdir(parents=True, exist_ok=True)
+            out_file.write_text(formatted, encoding="utf-8")
+            if args.verbose:
+                print(f"Output saved to: {args.output}")
+
+        else:
+            print("Formatted Result:".ljust(20, "="))
+            print(formatted)
+
+    except Exception as e:
+        print(f"Processing error: {str(e)}")
+        if args.verbose:
+            raise e
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Change some Chinese translation items to better match Chinese language habits and technical requirements. 

1. Insert space adhering to the matches and replacement of the following regex :
    > For the sake of brevity, only the patterns of increasing the right space are listed here.
    ```
    (%select\{[a-zA-Z0-9].*[a-zA-Z0-9]\}\d)([\u4e00-\u9fa5])
    // 不能为1或... -->  不能为 1 或...
    ([\u4e00-\u9fa5])(\d+)([\u4e00-\u9fa5]|")
    ([\u4e00-\u9fa5])(\d+)
    // %1子句 --> %1 子句
    (%\d)([\u4e00-\u9fa5])
    ("\w+")([\u4e00-\u9fa5])
    ('\w+')([\u4e00-\u9fa5])
    (<\w+>)([\u4e00-\u9fa5])
    ```
    
    Perform replacement via `$1 $2`

2. Change word order. e.g., "期望%select{.后的标识符|}0模块名称" --> "期望模块名称%select{中 '.' 后应为标识符|}0"