### PR TITLE
Fix: handle common lang setting "C"

### DIFF
--- a/clang-i18n.cpp
+++ b/clang-i18n.cpp
@@ -88,7 +88,7 @@ public:
   TranslationTable() {
     using namespace llvm;
     auto Lang = getLang();
-    if (Lang.empty() || Lang == "en_US" || Lang == "en_UK")
+    if (Lang.empty() || Lang == "en_US" || Lang == "en_UK" || Lang == "C")
       return;
     auto TranslationDir = getTranslationDir();
     auto Path = TranslationDir.str() + "/" + Lang.str() + ".yml";


### PR DESCRIPTION
`LANG=C` is the default language setting in POSIX, meaning there is **no locale** support. 
In this situation, we should do nothing instead of attempting to search C.yml.